### PR TITLE
  [#40]: Add Settings screen with preferences and generic PageHeader

### DIFF
--- a/src/app/screens/HomeScreen.tsx
+++ b/src/app/screens/HomeScreen.tsx
@@ -4,27 +4,22 @@ import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { theme } from '../../theme';
 import { PageHeader } from '../../components/layout/PageHeader';
+import { SettingsButton } from '../../components/ui/SettingsButton';
+import { PageHeaderSyncButton } from '../../components/ui/PageHeaderSyncButton';
 import { TabBar, HomeTab } from '../../components/layout/TabBar';
 import { ScreenContainer } from '../../components/layout/ScreenContainer';
 import { MyWorkTab } from '../tabs/MyWorkTab';
 import { ProjectsTab } from '../tabs/ProjectsTab';
 import { useSync } from '../../hooks/useSync';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
-import { UserSettingsMenu } from '../../components/ui/UserSettingsMenu';
 import { RootStackParamList } from '../../types/navigation/types';
 import { onSyncComplete, onSyncStart } from '../../services/syncEvents';
 
-interface HomeScreenProps {
-  onSignOut?: () => void;
-}
-
-export default function HomeScreen({ onSignOut }: HomeScreenProps) {
+export default function HomeScreen() {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const route = useRoute<RouteProp<RootStackParamList, 'Home'>>();
   const [activeTab, setActiveTab] = useState<HomeTab>('myWork');
   const [refreshKey, setRefreshKey] = useState(0);
-  const [settingsVisible, setSettingsVisible] = useState(false);
-  const [settingsAnchor, setSettingsAnchor] = useState({ top: 0, left: 16 });
   const [isNewUserLoading, setIsNewUserLoading] = useState(
     () => route.params?.newUserLoading === true,
   );
@@ -58,13 +53,12 @@ export default function HomeScreen({ onSignOut }: HomeScreenProps) {
   }, []);
 
   const handleSettingsPress = () => {
-    setSettingsAnchor({ top: 56, left: 16 });
-    setSettingsVisible(true);
+    navigation.push('Settings');
   };
 
-  const handleUserSwitched = () => {
-    setRefreshKey(key => key + 1);
-  };
+  // const handleUserSwitched = () => {
+  //   setRefreshKey(key => key + 1);
+  // };
 
   const handleSyncPress = useCallback(() => {
     navigation.navigate('Sync');
@@ -86,16 +80,13 @@ export default function HomeScreen({ onSignOut }: HomeScreenProps) {
   return (
     <ScreenContainer edges={['top']}>
       <PageHeader
-        onSettingsPress={handleSettingsPress}
-        syncStatus={syncStatus}
-        onSyncPress={handleSyncPress}
-      />
-      <UserSettingsMenu
-        visible={settingsVisible}
-        onClose={() => setSettingsVisible(false)}
-        anchor={settingsAnchor}
-        onSignOut={onSignOut}
-        onUserSwitched={handleUserSwitched}
+        leftIcon={<SettingsButton onPress={handleSettingsPress} />}
+        rightIcon={
+          <PageHeaderSyncButton
+            syncStatus={syncStatus}
+            onPress={handleSyncPress}
+          />
+        }
       />
       <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
       <View style={styles.content}>

--- a/src/app/screens/HomeScreen.tsx
+++ b/src/app/screens/HomeScreen.tsx
@@ -6,6 +6,7 @@ import { theme } from '../../theme';
 import { PageHeader } from '../../components/layout/PageHeader';
 import { SettingsButton } from '../../components/ui/SettingsButton';
 import { PageHeaderSyncButton } from '../../components/ui/PageHeaderSyncButton';
+import { UserSettingsMenu } from '../../components/ui/UserSettingsMenu';
 import { TabBar, HomeTab } from '../../components/layout/TabBar';
 import { ScreenContainer } from '../../components/layout/ScreenContainer';
 import { MyWorkTab } from '../tabs/MyWorkTab';
@@ -15,11 +16,17 @@ import { useSyncStatus } from '../../hooks/useSyncStatus';
 import { RootStackParamList } from '../../types/navigation/types';
 import { onSyncComplete, onSyncStart } from '../../services/syncEvents';
 
-export default function HomeScreen() {
+interface HomeScreenProps {
+  onSignOut?: () => void;
+}
+
+export default function HomeScreen({ onSignOut }: HomeScreenProps) {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const route = useRoute<RouteProp<RootStackParamList, 'Home'>>();
   const [activeTab, setActiveTab] = useState<HomeTab>('myWork');
   const [refreshKey, setRefreshKey] = useState(0);
+  const [settingsVisible, setSettingsVisible] = useState(false);
+  const [settingsAnchor, setSettingsAnchor] = useState({ top: 56, left: 16 });
   const [isNewUserLoading, setIsNewUserLoading] = useState(
     () => route.params?.newUserLoading === true,
   );
@@ -53,12 +60,13 @@ export default function HomeScreen() {
   }, []);
 
   const handleSettingsPress = () => {
-    navigation.push('Settings');
+    setSettingsAnchor({ top: 56, left: 16 });
+    setSettingsVisible(true);
   };
 
-  // const handleUserSwitched = () => {
-  //   setRefreshKey(key => key + 1);
-  // };
+  const handleUserSwitched = useCallback(() => {
+    setRefreshKey(key => key + 1);
+  }, []);
 
   const handleSyncPress = useCallback(() => {
     navigation.navigate('Sync');
@@ -96,6 +104,13 @@ export default function HomeScreen() {
           <ProjectsTab refreshKey={refreshKey} />
         )}
       </View>
+      <UserSettingsMenu
+        visible={settingsVisible}
+        onClose={() => setSettingsVisible(false)}
+        anchor={settingsAnchor}
+        onSignOut={onSignOut}
+        onUserSwitched={handleUserSwitched}
+      />
     </ScreenContainer>
   );
 }

--- a/src/app/screens/PrepareForOfflineScreen.tsx
+++ b/src/app/screens/PrepareForOfflineScreen.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { PageHeader } from '../../components/layout/PageHeader';
+import { PageHeaderBackButton } from '../../components/ui/PageHeaderBackButton';
+import { ScreenContainer } from '../../components/layout/ScreenContainer';
+import { RootStackParamList } from '../../types/navigation/types';
+import { theme } from '../../theme';
+
+type Nav = StackNavigationProp<RootStackParamList, 'PrepareForOffline'>;
+
+export default function PrepareForOfflineScreen() {
+  const navigation = useNavigation<Nav>();
+  const goBack = useCallback(() => navigation.goBack(), [navigation]);
+
+  return (
+    <ScreenContainer edges={['top']}>
+      <View style={styles.screen}>
+        <PageHeader
+          title="Prepare for Offline"
+          leftIcon={<PageHeaderBackButton onPress={goBack} />}
+        />
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text style={styles.body}>
+            Download resources and manage device storage so you can keep working
+            without a network connection.
+          </Text>
+        </ScrollView>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    padding: theme.spacing.lg,
+  },
+  body: {
+    fontSize: theme.typography.sizes.md,
+    color: theme.colors.mutedForeground,
+    lineHeight: 22,
+  },
+});

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -1,0 +1,208 @@
+import React, { useCallback } from 'react';
+import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { CloudUpload, HardDrive, LogOut, UserPlus } from 'lucide-react-native';
+import { PageHeader } from '../../components/layout/PageHeader';
+import { PageHeaderBackButton } from '../../components/ui/PageHeaderBackButton';
+import { ScreenContainer } from '../../components/layout/ScreenContainer';
+import {
+  SettingsDestructiveRow,
+  SettingsNavigationRow,
+  SettingsToggleRow,
+} from '../../components/ui/SettingsListRow';
+import {
+  LOGOUT_UNSYNCED_CANCEL,
+  LOGOUT_UNSYNCED_CONFIRM,
+  LOGOUT_UNSYNCED_MESSAGE,
+  LOGOUT_UNSYNCED_TITLE,
+} from '../../constants/messages';
+import { getPendingUploadCount } from '../../db/queries';
+import { FluentAPI, setActiveToken } from '../../services/api';
+import { clearCredentials } from '../../services/keychain';
+import {
+  getActiveUserId,
+  getKnownUserIds,
+  kvStorage,
+  KV_KEYS,
+} from '../../services/storage';
+import { usePreferences } from '../../hooks/usePreferences';
+import { RootStackParamList } from '../../types/navigation/types';
+import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
+import { logger } from '../../utils/logger';
+
+const log = logger.create('SettingsScreen');
+
+type Nav = StackNavigationProp<RootStackParamList, 'Settings'>;
+
+interface SettingsScreenProps {
+  onSignOut?: () => void;
+}
+
+function SettingsSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionLabel}>{label}</Text>
+      <View style={styles.sectionCard}>{children}</View>
+    </View>
+  );
+}
+
+export default function SettingsScreen({ onSignOut }: SettingsScreenProps) {
+  const navigation = useNavigation<Nav>();
+  const { uploadOverCellular, setUploadOverCellular } = usePreferences();
+
+  const goBack = useCallback(() => navigation.goBack(), [navigation]);
+
+  const handleAddUser = useCallback(() => {
+    navigation.navigate('AddUser');
+  }, [navigation]);
+
+  const performLogOut = async () => {
+    const currentUserId = getActiveUserId();
+
+    try {
+      await FluentAPI.signOut();
+    } catch (e) {
+      log.error('Server sign out failed', { error: e });
+    }
+
+    await clearCredentials(currentUserId);
+
+    const remaining = getKnownUserIds().filter(id => id !== currentUserId);
+    kvStorage.setItemSync(KV_KEYS.KNOWN_USER_IDS, remaining.join(','));
+    log.info('User signed out', { userId: currentUserId });
+
+    setActiveToken(null);
+    kvStorage.removeItemSync(KV_KEYS.ACTIVE_USER_ID);
+    kvStorage.removeItemSync(KV_KEYS.USER_ID);
+    kvStorage.removeItemSync(KV_KEYS.USER_EMAIL);
+    onSignOut?.();
+  };
+
+  const handleLogOut = async () => {
+    const pendingCount = await getPendingUploadCount();
+
+    if (pendingCount > 0) {
+      Alert.alert(LOGOUT_UNSYNCED_TITLE, LOGOUT_UNSYNCED_MESSAGE, [
+        { text: LOGOUT_UNSYNCED_CANCEL, style: 'cancel' },
+        {
+          text: LOGOUT_UNSYNCED_CONFIRM,
+          style: 'destructive',
+          onPress: () => {
+            void performLogOut();
+          },
+        },
+      ]);
+      return;
+    }
+
+    await performLogOut();
+  };
+
+  const iconColor = theme.colors.foreground;
+
+  return (
+    <ScreenContainer edges={['top']}>
+      <View style={styles.screen}>
+        <PageHeader
+          title="Settings"
+          leftIcon={<PageHeaderBackButton onPress={goBack} />}
+        />
+        <ScrollView contentContainerStyle={styles.content}>
+          <SettingsSection label="Offline">
+            <SettingsNavigationRow
+              title="Prepare for Offline"
+              subtitle="Download resources and manage device storage"
+              icon={
+                <HardDrive
+                  size={iconSizes.headerTab}
+                  color={iconColor}
+                  strokeWidth={listIconStrokeWidth}
+                />
+              }
+              onPress={() => navigation.navigate('PrepareForOffline')}
+            />
+          </SettingsSection>
+
+          <SettingsSection label="Sync">
+            <SettingsToggleRow
+              title="Upload over cellular"
+              subtitle="When off, uploads only happen on WiFi"
+              icon={
+                <CloudUpload
+                  size={iconSizes.headerTab}
+                  color={iconColor}
+                  strokeWidth={listIconStrokeWidth}
+                />
+              }
+              value={uploadOverCellular}
+              onValueChange={setUploadOverCellular}
+            />
+          </SettingsSection>
+
+          <SettingsSection label="Account">
+            <SettingsNavigationRow
+              title="Add user"
+              subtitle="Sign in with another account on this device"
+              icon={
+                <UserPlus
+                  size={iconSizes.headerTab}
+                  color={iconColor}
+                  strokeWidth={listIconStrokeWidth}
+                />
+              }
+              onPress={handleAddUser}
+            />
+            <SettingsDestructiveRow
+              title="Log out"
+              icon={
+                <LogOut
+                  size={iconSizes.headerTab}
+                  color={theme.colors.destructive}
+                  strokeWidth={listIconStrokeWidth}
+                />
+              }
+              onPress={() => {
+                void handleLogOut();
+              }}
+            />
+          </SettingsSection>
+        </ScrollView>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    padding: theme.spacing.lg,
+    gap: theme.spacing.lg,
+  },
+  section: {
+    gap: theme.spacing.xs,
+  },
+  sectionLabel: {
+    fontSize: theme.typography.sizes.xs,
+    fontWeight: theme.typography.weights.medium,
+    color: theme.colors.mutedForeground,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginLeft: theme.spacing.xs,
+  },
+  sectionCard: {
+    backgroundColor: theme.colors.cardBackground,
+    borderRadius: theme.radius.lg,
+    overflow: 'hidden',
+  },
+});

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -19,12 +19,13 @@ import {
 } from '../../constants/messages';
 import { getPendingUploadCount } from '../../db/queries';
 import { FluentAPI, setActiveToken } from '../../services/api';
-import { clearCredentials } from '../../services/keychain';
+import { clearCredentials, getCredentials } from '../../services/keychain';
 import {
   getActiveUserId,
   getKnownUserIds,
   kvStorage,
   KV_KEYS,
+  switchActiveUser,
 } from '../../services/storage';
 import { usePreferences } from '../../hooks/usePreferences';
 import { RootStackParamList } from '../../types/navigation/types';
@@ -79,11 +80,19 @@ export default function SettingsScreen({ onSignOut }: SettingsScreenProps) {
     kvStorage.setItemSync(KV_KEYS.KNOWN_USER_IDS, remaining.join(','));
     log.info('User signed out', { userId: currentUserId });
 
-    setActiveToken(null);
-    kvStorage.removeItemSync(KV_KEYS.ACTIVE_USER_ID);
-    kvStorage.removeItemSync(KV_KEYS.USER_ID);
-    kvStorage.removeItemSync(KV_KEYS.USER_EMAIL);
-    onSignOut?.();
+    if (remaining.length > 0) {
+      const nextUserId = remaining[0];
+      const creds = await getCredentials(nextUserId);
+      setActiveToken(creds?.token ?? null);
+      switchActiveUser(nextUserId);
+      navigation.goBack();
+    } else {
+      setActiveToken(null);
+      kvStorage.removeItemSync(KV_KEYS.ACTIVE_USER_ID);
+      kvStorage.removeItemSync(KV_KEYS.USER_ID);
+      kvStorage.removeItemSync(KV_KEYS.USER_EMAIL);
+      onSignOut?.();
+    }
   };
 
   const handleLogOut = async () => {

--- a/src/components/layout/PageHeader.test.tsx
+++ b/src/components/layout/PageHeader.test.tsx
@@ -1,44 +1,38 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
 import { PageHeader } from './PageHeader';
-
-jest.mock('lucide-react-native', () => {
-  const MockReact = require('react');
-  const { View } = require('react-native');
-  const MockIcon = () => MockReact.createElement(View);
-  return {
-    Settings: MockIcon,
-    ArrowUp: MockIcon,
-    Check: MockIcon,
-    Cloud: MockIcon,
-    CloudOff: MockIcon,
-    RefreshCw: MockIcon,
-  };
-});
-
-jest.mock('../ui/CloudSyncStatusIcon', () => ({
-  CloudSyncStatusIcon: () => {
-    const MockReact = require('react');
-    const { View } = require('react-native');
-    return MockReact.createElement(View);
-  },
-}));
 
 jest.mock('../../assets/icons/fluent-logo-white.svg', () => {
   const MockReact = require('react');
   const { View } = require('react-native');
-  return () => MockReact.createElement(View);
+  return () => MockReact.createElement(View, { testID: 'fluent-logo' });
 });
 
 describe('PageHeader', () => {
-  it('renders sync status icon and navigates on press', () => {
-    const onSyncPress = jest.fn();
+  it('renders the Fluent logo when no title is provided', () => {
+    render(<PageHeader />);
 
-    render(<PageHeader syncStatus="online_synced" onSyncPress={onSyncPress} />);
+    expect(screen.getByTestId('fluent-logo')).toBeTruthy();
+  });
 
-    expect(screen.getByLabelText('Synced. Open Sync page.')).toBeTruthy();
+  it('renders a centered title when provided', () => {
+    render(<PageHeader title="Settings" />);
 
-    fireEvent.press(screen.getByLabelText('Synced. Open Sync page.'));
-    expect(onSyncPress).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Settings')).toBeTruthy();
+  });
+
+  it('renders left and right icon slots', () => {
+    render(
+      <PageHeader
+        title="Settings"
+        leftIcon={<Text testID="left-icon">Left</Text>}
+        rightIcon={<Text testID="right-icon">Right</Text>}
+      />,
+    );
+
+    expect(screen.getByTestId('left-icon')).toBeTruthy();
+    expect(screen.getByTestId('right-icon')).toBeTruthy();
+    expect(screen.getByText('Settings')).toBeTruthy();
   });
 });

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -1,63 +1,36 @@
 import React from 'react';
-import { View, TouchableOpacity, StyleSheet } from 'react-native';
-import { Settings } from 'lucide-react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import FluentLogoWhite from '../../assets/icons/fluent-logo-white.svg';
-import { CloudSyncStatusIcon } from '../ui/CloudSyncStatusIcon';
-import {
-  theme,
-  iconSizes,
-  logoSize,
-  headerLayout,
-  listIconStrokeWidth,
-  touchHitSlop,
-} from '../../theme';
-import { SyncStatus, SYNC_STATUS_LABELS } from '../../utils/syncStatusState';
+import { theme, logoSize, headerLayout } from '../../theme';
 
 interface PageHeaderProps {
-  onSettingsPress?: () => void;
-  onSyncPress?: () => void;
-  syncStatus: SyncStatus;
+  title?: string;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
 }
 
-export function PageHeader({
-  onSettingsPress,
-  onSyncPress,
-  syncStatus,
-}: PageHeaderProps) {
-  const iconColor = theme.colors.primaryForeground;
-
+export function PageHeader({ title, leftIcon, rightIcon }: PageHeaderProps) {
   return (
     <View style={styles.container}>
-      <TouchableOpacity
-        onPress={onSettingsPress}
-        style={styles.settingsSlot}
-        accessibilityLabel="Settings"
-        hitSlop={touchHitSlop}
-      >
-        <Settings
-          size={iconSizes.header}
-          color={iconColor}
-          strokeWidth={listIconStrokeWidth}
-        />
-      </TouchableOpacity>
+      <View style={styles.leftSlot}>{leftIcon}</View>
 
-      <TouchableOpacity
-        onPress={onSyncPress}
-        style={styles.syncSlot}
-        accessibilityLabel={SYNC_STATUS_LABELS[syncStatus]}
-        accessibilityRole="button"
-        hitSlop={touchHitSlop}
-      >
-        <CloudSyncStatusIcon status={syncStatus} decorative />
-      </TouchableOpacity>
+      <View style={styles.rightSlot}>{rightIcon}</View>
 
-      <View style={styles.logoOverlay} pointerEvents="none">
-        <FluentLogoWhite
-          width={logoSize.width}
-          height={logoSize.height}
-          style={styles.logo}
-        />
-      </View>
+      {title ? (
+        <View style={styles.centerOverlay} pointerEvents="none">
+          <Text style={styles.title} numberOfLines={1}>
+            {title}
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.centerOverlay} pointerEvents="none">
+          <FluentLogoWhite
+            width={logoSize.width}
+            height={logoSize.height}
+            style={styles.logo}
+          />
+        </View>
+      )}
     </View>
   );
 }
@@ -73,7 +46,7 @@ const styles = StyleSheet.create({
     paddingVertical: headerLayout.paddingVertical,
     minHeight: headerLayout.minHeight,
   },
-  settingsSlot: {
+  leftSlot: {
     width: headerLayout.sideSlot,
     height: headerLayout.sideSlot,
     alignItems: 'center',
@@ -81,21 +54,24 @@ const styles = StyleSheet.create({
     marginLeft: -theme.spacing.sm,
     zIndex: 1,
   },
-  syncSlot: {
+  rightSlot: {
     width: headerLayout.sideSlot,
     height: headerLayout.sideSlot,
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: theme.radius.full,
-    padding: 6,
     zIndex: 1,
   },
-  logoOverlay: {
+  centerOverlay: {
     ...StyleSheet.absoluteFillObject,
     alignItems: 'center',
     justifyContent: 'center',
   },
   logo: {
     marginVertical: logoSize.marginVertical,
+  },
+  title: {
+    fontSize: theme.typography.sizes.lg,
+    fontWeight: theme.typography.weights.bold,
+    color: theme.colors.primaryForeground,
   },
 });

--- a/src/components/ui/PageHeaderBackButton.test.tsx
+++ b/src/components/ui/PageHeaderBackButton.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { PageHeaderBackButton } from './PageHeaderBackButton';
+
+jest.mock('lucide-react-native', () => {
+  const MockReact = require('react');
+  const { View } = require('react-native');
+  const MockIcon = () => MockReact.createElement(View);
+  return { ChevronLeft: MockIcon };
+});
+
+describe('PageHeaderBackButton', () => {
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+
+    render(<PageHeaderBackButton onPress={onPress} />);
+
+    fireEvent.press(screen.getByLabelText('Go back'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/PageHeaderBackButton.tsx
+++ b/src/components/ui/PageHeaderBackButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { ChevronLeft } from 'lucide-react-native';
+import {
+  theme,
+  iconSizes,
+  listIconStrokeWidth,
+  touchHitSlop,
+} from '../../theme';
+
+interface PageHeaderBackButtonProps {
+  onPress: () => void;
+}
+
+export function PageHeaderBackButton({ onPress }: PageHeaderBackButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="Go back"
+      hitSlop={touchHitSlop}
+    >
+      <ChevronLeft
+        size={iconSizes.header}
+        color={theme.colors.primaryForeground}
+        strokeWidth={listIconStrokeWidth}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/src/components/ui/PageHeaderSyncButton.test.tsx
+++ b/src/components/ui/PageHeaderSyncButton.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { PageHeaderSyncButton } from './PageHeaderSyncButton';
+
+jest.mock('lucide-react-native', () => {
+  const MockReact = require('react');
+  const { View } = require('react-native');
+  const MockIcon = () => MockReact.createElement(View);
+  return {
+    ArrowUp: MockIcon,
+    Check: MockIcon,
+    Cloud: MockIcon,
+    CloudOff: MockIcon,
+    RefreshCw: MockIcon,
+  };
+});
+
+jest.mock('./CloudSyncStatusIcon', () => ({
+  CloudSyncStatusIcon: () => {
+    const MockReact = require('react');
+    const { View } = require('react-native');
+    return MockReact.createElement(View);
+  },
+}));
+
+describe('PageHeaderSyncButton', () => {
+  it('renders sync status label and calls onPress when pressed', () => {
+    const onPress = jest.fn();
+
+    render(
+      <PageHeaderSyncButton syncStatus="online_synced" onPress={onPress} />,
+    );
+
+    expect(screen.getByLabelText('Synced. Open Sync page.')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Synced. Open Sync page.'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/PageHeaderSyncButton.tsx
+++ b/src/components/ui/PageHeaderSyncButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { CloudSyncStatusIcon } from './CloudSyncStatusIcon';
+import { theme, headerLayout, touchHitSlop } from '../../theme';
+import { SyncStatus, SYNC_STATUS_LABELS } from '../../utils/syncStatusState';
+
+interface PageHeaderSyncButtonProps {
+  syncStatus: SyncStatus;
+  onPress: () => void;
+}
+
+export function PageHeaderSyncButton({
+  syncStatus,
+  onPress,
+}: PageHeaderSyncButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={styles.syncSlot}
+      accessibilityLabel={SYNC_STATUS_LABELS[syncStatus]}
+      accessibilityRole="button"
+      hitSlop={touchHitSlop}
+    >
+      <CloudSyncStatusIcon status={syncStatus} decorative />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  syncSlot: {
+    width: headerLayout.sideSlot,
+    height: headerLayout.sideSlot,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: theme.radius.full,
+    padding: 6,
+  },
+});

--- a/src/components/ui/SettingsButton.test.tsx
+++ b/src/components/ui/SettingsButton.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { SettingsButton } from './SettingsButton';
+
+jest.mock('lucide-react-native', () => {
+  const MockReact = require('react');
+  const { View } = require('react-native');
+  const MockIcon = () => MockReact.createElement(View);
+  return { Settings: MockIcon };
+});
+
+describe('SettingsButton', () => {
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+
+    render(<SettingsButton onPress={onPress} />);
+
+    fireEvent.press(screen.getByLabelText('Settings'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/SettingsButton.tsx
+++ b/src/components/ui/SettingsButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { Settings } from 'lucide-react-native';
+import {
+  theme,
+  iconSizes,
+  listIconStrokeWidth,
+  touchHitSlop,
+} from '../../theme';
+
+interface SettingsButtonProps {
+  onPress: () => void;
+}
+
+export function SettingsButton({ onPress }: SettingsButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      accessibilityLabel="Settings"
+      accessibilityRole="button"
+      hitSlop={touchHitSlop}
+    >
+      <Settings
+        size={iconSizes.header}
+        color={theme.colors.primaryForeground}
+        strokeWidth={listIconStrokeWidth}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/src/components/ui/SettingsListRow.tsx
+++ b/src/components/ui/SettingsListRow.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { ChevronRight } from 'lucide-react-native';
+import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
+
+interface SettingsNavigationRowProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  onPress: () => void;
+}
+
+export function SettingsNavigationRow({
+  icon,
+  title,
+  subtitle,
+  onPress,
+}: SettingsNavigationRowProps) {
+  return (
+    <TouchableOpacity
+      style={styles.row}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+    >
+      <View style={styles.iconSlot}>{icon}</View>
+      <View style={styles.textBlock}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.subtitle}>{subtitle}</Text>
+      </View>
+      <ChevronRight
+        size={iconSizes.headerTab}
+        color={theme.colors.mutedForeground}
+        strokeWidth={listIconStrokeWidth}
+      />
+    </TouchableOpacity>
+  );
+}
+
+interface SettingsToggleRowProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+}
+
+export function SettingsToggleRow({
+  icon,
+  title,
+  subtitle,
+  value,
+  onValueChange,
+}: SettingsToggleRowProps) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.iconSlot}>{icon}</View>
+      <View style={styles.textBlock}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.subtitle}>{subtitle}</Text>
+      </View>
+      <Switch
+        value={value}
+        onValueChange={onValueChange}
+        trackColor={{
+          false: theme.colors.border,
+          true: theme.colors.primary,
+        }}
+        thumbColor={theme.colors.primaryForeground}
+        accessibilityLabel={title}
+      />
+    </View>
+  );
+}
+
+interface SettingsDestructiveRowProps {
+  icon: React.ReactNode;
+  title: string;
+  onPress: () => void;
+}
+
+export function SettingsDestructiveRow({
+  icon,
+  title,
+  onPress,
+}: SettingsDestructiveRowProps) {
+  return (
+    <TouchableOpacity
+      style={styles.row}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+    >
+      <View style={styles.iconSlot}>{icon}</View>
+      <Text style={styles.destructiveTitle}>{title}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.md,
+  },
+  iconSlot: {
+    width: iconSizes.headerTab,
+    alignItems: 'center',
+  },
+  textBlock: {
+    flex: 1,
+    gap: 2,
+  },
+  title: {
+    fontSize: theme.typography.sizes.md,
+    color: theme.colors.foreground,
+  },
+  subtitle: {
+    fontSize: theme.typography.sizes.sm,
+    color: theme.colors.mutedForeground,
+  },
+  destructiveTitle: {
+    flex: 1,
+    fontSize: theme.typography.sizes.md,
+    color: theme.colors.destructive,
+  },
+});

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -19,7 +19,7 @@ import { logger } from '../../utils/logger';
 
 const log = logger.create('UserSettingsMenu');
 
-type Nav = StackNavigationProp<RootStackParamList, 'Home'>;
+type Nav = StackNavigationProp<RootStackParamList>;
 
 interface UserSettingsMenuProps {
   visible: boolean;
@@ -48,6 +48,11 @@ export function UserSettingsMenu({
 
   const handleOpen = () => {
     loadKnownUsers();
+  };
+
+  const handleOpenSettings = () => {
+    onClose();
+    navigation.navigate('Settings');
   };
 
   const handleAddUser = () => {
@@ -112,8 +117,20 @@ export function UserSettingsMenu({
         >
           <TouchableOpacity
             style={appStyles.menuItem}
+            onPress={handleOpenSettings}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+          >
+            <Ionicons name="settings-outline" size={18} color="#333" />
+            <Text style={appStyles.menuItemText}>Settings</Text>
+          </TouchableOpacity>
+
+          <View style={appStyles.menuDivider} />
+          <TouchableOpacity
+            style={appStyles.menuItem}
             onPress={handleAddUser}
             activeOpacity={0.7}
+            accessibilityRole="button"
           >
             <Ionicons name="person-add-outline" size={18} color="#333" />
             <Text style={appStyles.menuItemText}>Add User</Text>
@@ -129,6 +146,7 @@ export function UserSettingsMenu({
                   style={appStyles.menuItem}
                   onPress={() => handleSwitchUser(user.id)}
                   activeOpacity={0.7}
+                  accessibilityRole="button"
                 >
                   <Ionicons
                     name={
@@ -158,6 +176,7 @@ export function UserSettingsMenu({
             style={appStyles.menuItem}
             onPress={handleSignOut}
             activeOpacity={0.7}
+            accessibilityRole="button"
           >
             <Ionicons name="log-out-outline" size={18} color="#d32f2f" />
             <Text style={[appStyles.menuItemText, appStyles.menuItemDanger]}>

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -122,7 +122,7 @@ export function UserSettingsMenu({
             accessibilityRole="button"
           >
             <Ionicons name="settings-outline" size={18} color="#333" />
-            <Text style={appStyles.menuItemText}>Settings</Text>
+            <Text style={appStyles.menuItemText}>More Settings</Text>
           </TouchableOpacity>
 
           <View style={appStyles.menuDivider} />

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -6,3 +6,9 @@ export const MY_WORK_EMPTY_MESSAGE =
 
 export const PROJECT_CHAPTERS_EMPTY_MESSAGE =
   'No chapters are available in this project yet.';
+
+export const LOGOUT_UNSYNCED_TITLE = 'Unsynced work on device';
+export const LOGOUT_UNSYNCED_MESSAGE =
+  'You have recordings that have not been uploaded. Log out anyway?';
+export const LOGOUT_UNSYNCED_CONFIRM = 'Log out';
+export const LOGOUT_UNSYNCED_CANCEL = 'Cancel';

--- a/src/hooks/usePreferences.test.ts
+++ b/src/hooks/usePreferences.test.ts
@@ -1,0 +1,113 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { usePreference, usePreferences } from './usePreferences';
+import {
+  notifyUserPreferencesChanged,
+  setUserPreferences,
+} from '../services/userPreferences';
+import { kvStorage } from '../services/storage';
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock('../services/storage', () => ({
+  kvStorage: {
+    getItemSync: jest.fn(),
+    setItemSync: jest.fn(),
+  },
+}));
+
+const mockGetItemSync = kvStorage.getItemSync as jest.Mock;
+const mockSetItemSync = kvStorage.setItemSync as jest.Mock;
+
+describe('usePreferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItemSync.mockReturnValue(null);
+    mockSetItemSync.mockImplementation((_key, value) => {
+      mockGetItemSync.mockReturnValue(value);
+    });
+  });
+
+  it('returns preferences from storage', () => {
+    mockGetItemSync.mockReturnValue('true');
+
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.uploadOverCellular).toBe(true);
+    expect(result.current.preferences).toEqual({ uploadOverCellular: true });
+  });
+
+  it('persists and updates upload over cellular', () => {
+    const { result } = renderHook(() => usePreferences());
+
+    act(() => {
+      result.current.setUploadOverCellular(true);
+    });
+
+    expect(mockSetItemSync).toHaveBeenCalledWith(
+      'pref_upload_over_cellular',
+      'true',
+    );
+    expect(result.current.uploadOverCellular).toBe(true);
+  });
+
+  it('reload refreshes preferences from storage', () => {
+    const { result } = renderHook(() => usePreferences());
+
+    mockGetItemSync.mockReturnValue('true');
+
+    act(() => {
+      result.current.reload();
+    });
+
+    expect(result.current.uploadOverCellular).toBe(true);
+  });
+});
+
+describe('usePreference', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItemSync.mockReturnValue(null);
+    mockSetItemSync.mockImplementation((_key, value) => {
+      mockGetItemSync.mockReturnValue(value);
+    });
+  });
+
+  it('returns a single preference value', () => {
+    mockGetItemSync.mockReturnValue('true');
+
+    const { result } = renderHook(() => usePreference('uploadOverCellular'));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when the preference changes in storage', () => {
+    const { result } = renderHook(() => usePreference('uploadOverCellular'));
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setUserPreferences({ uploadOverCellular: true });
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('does not update when storage is unchanged', () => {
+    let latestValue = false;
+
+    const { rerender } = renderHook(() => {
+      latestValue = usePreference('uploadOverCellular');
+    });
+
+    expect(latestValue).toBe(false);
+
+    act(() => {
+      notifyUserPreferencesChanged();
+    });
+
+    rerender({});
+    expect(latestValue).toBe(false);
+  });
+});

--- a/src/hooks/usePreferences.ts
+++ b/src/hooks/usePreferences.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import {
+  getUserPreferenceValue,
+  notifyUserPreferencesChanged,
+  setUserPreferences,
+  subscribeToUserPreferences,
+  type UserPreferences,
+} from '../services/userPreferences';
+
+export function usePreference<K extends keyof UserPreferences>(
+  key: K,
+): UserPreferences[K] {
+  return useSyncExternalStore(
+    subscribeToUserPreferences,
+    () => getUserPreferenceValue(key),
+    () => getUserPreferenceValue(key),
+  );
+}
+
+export function usePreferences() {
+  const uploadOverCellular = usePreference('uploadOverCellular');
+
+  const preferences = useMemo(
+    (): UserPreferences => ({ uploadOverCellular }),
+    [uploadOverCellular],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      notifyUserPreferencesChanged();
+    }, []),
+  );
+
+  const setPreferences = useCallback((updates: Partial<UserPreferences>) => {
+    setUserPreferences(updates);
+  }, []);
+
+  const setUploadOverCellular = useCallback(
+    (enabled: boolean) => {
+      setPreferences({ uploadOverCellular: enabled });
+    },
+    [setPreferences],
+  );
+
+  return {
+    preferences,
+    uploadOverCellular,
+    setPreferences,
+    setUploadOverCellular,
+    reload: notifyUserPreferencesChanged,
+  };
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -36,7 +36,9 @@ export default function AppNavigator({
         </>
       ) : (
         <>
-          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Home">
+            {() => <HomeScreen onSignOut={onSignOut} />}
+          </Stack.Screen>
           <Stack.Screen name="Settings">
             {() => <SettingsScreen onSignOut={onSignOut} />}
           </Stack.Screen>

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import { RootStackParamList } from '../types/navigation/types';
 import HomeScreen from '../app/screens/HomeScreen';
+import SettingsScreen from '../app/screens/SettingsScreen';
+import PrepareForOfflineScreen from '../app/screens/PrepareForOfflineScreen';
 import ViewProject from '../app/tabs/ViewProject';
 import ViewChapter from '../app/tabs/ViewChapter';
 import LoginScreen from '../app/tabs/LoginScreen';
@@ -34,9 +36,14 @@ export default function AppNavigator({
         </>
       ) : (
         <>
-          <Stack.Screen name="Home">
-            {() => <HomeScreen onSignOut={onSignOut} />}
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Settings">
+            {() => <SettingsScreen onSignOut={onSignOut} />}
           </Stack.Screen>
+          <Stack.Screen
+            name="PrepareForOffline"
+            component={PrepareForOfflineScreen}
+          />
           <Stack.Screen name="Chapters" component={ViewProject} />
           <Stack.Screen name="VerseDetail" component={ViewChapter} />
           <Stack.Screen name="AddUser">

--- a/src/services/userPreferences.test.ts
+++ b/src/services/userPreferences.test.ts
@@ -1,0 +1,73 @@
+import {
+  getUploadOverCellular,
+  getUserPreferences,
+  setUploadOverCellular,
+  setUserPreferences,
+  subscribeToPreference,
+} from './userPreferences';
+import { kvStorage } from './storage';
+
+jest.mock('./storage', () => ({
+  kvStorage: {
+    getItemSync: jest.fn(),
+    setItemSync: jest.fn(),
+  },
+}));
+
+const mockGetItemSync = kvStorage.getItemSync as jest.Mock;
+const mockSetItemSync = kvStorage.setItemSync as jest.Mock;
+
+describe('userPreferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItemSync.mockReturnValue(null);
+    mockSetItemSync.mockImplementation((_key, value) => {
+      mockGetItemSync.mockReturnValue(value);
+    });
+  });
+
+  it('returns default preferences when nothing is stored', () => {
+    expect(getUserPreferences()).toEqual({ uploadOverCellular: false });
+  });
+
+  it('reads upload over cellular from storage', () => {
+    mockGetItemSync.mockReturnValue('true');
+    expect(getUserPreferences()).toEqual({ uploadOverCellular: true });
+    expect(getUploadOverCellular()).toBe(true);
+  });
+
+  it('persists upload over cellular via setUserPreferences', () => {
+    setUserPreferences({ uploadOverCellular: true });
+    expect(mockSetItemSync).toHaveBeenCalledWith(
+      'pref_upload_over_cellular',
+      'true',
+    );
+
+    setUserPreferences({ uploadOverCellular: false });
+    expect(mockSetItemSync).toHaveBeenCalledWith(
+      'pref_upload_over_cellular',
+      'false',
+    );
+  });
+
+  it('persists upload over cellular via setUploadOverCellular', () => {
+    setUploadOverCellular(true);
+    expect(mockSetItemSync).toHaveBeenCalledWith(
+      'pref_upload_over_cellular',
+      'true',
+    );
+  });
+
+  it('notifies key-specific subscribers when a value changes', () => {
+    const listener = jest.fn();
+
+    subscribeToPreference('uploadOverCellular', listener);
+    setUserPreferences({ uploadOverCellular: true });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(true);
+
+    setUserPreferences({ uploadOverCellular: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/userPreferences.ts
+++ b/src/services/userPreferences.ts
@@ -1,0 +1,95 @@
+import { kvStorage } from './storage';
+
+const PREFERENCE_KEYS = {
+  UPLOAD_OVER_CELLULAR: 'pref_upload_over_cellular',
+} as const;
+
+export type UserPreferences = {
+  uploadOverCellular: boolean;
+};
+
+const DEFAULT_USER_PREFERENCES: UserPreferences = {
+  uploadOverCellular: false,
+};
+
+type PreferencesListener = () => void;
+
+const listeners: PreferencesListener[] = [];
+
+let cachedPreferences: UserPreferences = DEFAULT_USER_PREFERENCES;
+
+function readUploadOverCellularFromStorage(): boolean {
+  return kvStorage.getItemSync(PREFERENCE_KEYS.UPLOAD_OVER_CELLULAR) === 'true';
+}
+
+function refreshCachedPreferences(): UserPreferences {
+  const uploadOverCellular = readUploadOverCellularFromStorage();
+
+  if (cachedPreferences.uploadOverCellular === uploadOverCellular) {
+    return cachedPreferences;
+  }
+
+  cachedPreferences = { uploadOverCellular };
+  return cachedPreferences;
+}
+
+export function subscribeToUserPreferences(
+  onStoreChange: PreferencesListener,
+): () => void {
+  listeners.push(onStoreChange);
+  return () => {
+    const index = listeners.indexOf(onStoreChange);
+    if (index > -1) {
+      listeners.splice(index, 1);
+    }
+  };
+}
+
+export function subscribeToPreference<K extends keyof UserPreferences>(
+  key: K,
+  listener: (value: UserPreferences[K]) => void,
+): () => void {
+  let lastValue = getUserPreferenceValue(key);
+
+  return subscribeToUserPreferences(() => {
+    const nextValue = getUserPreferenceValue(key);
+    if (nextValue !== lastValue) {
+      lastValue = nextValue;
+      listener(nextValue);
+    }
+  });
+}
+
+export function notifyUserPreferencesChanged(): void {
+  refreshCachedPreferences();
+  listeners.forEach(listener => listener());
+}
+
+export function getUserPreferenceValue<K extends keyof UserPreferences>(
+  key: K,
+): UserPreferences[K] {
+  return refreshCachedPreferences()[key];
+}
+
+export function getUserPreferences(): UserPreferences {
+  return refreshCachedPreferences();
+}
+
+export function setUserPreferences(updates: Partial<UserPreferences>): void {
+  if (updates.uploadOverCellular !== undefined) {
+    kvStorage.setItemSync(
+      PREFERENCE_KEYS.UPLOAD_OVER_CELLULAR,
+      updates.uploadOverCellular ? 'true' : 'false',
+    );
+  }
+
+  notifyUserPreferencesChanged();
+}
+
+export function getUploadOverCellular(): boolean {
+  return getUserPreferenceValue('uploadOverCellular');
+}
+
+export function setUploadOverCellular(enabled: boolean): void {
+  setUserPreferences({ uploadOverCellular: enabled });
+}

--- a/src/types/navigation/types.ts
+++ b/src/types/navigation/types.ts
@@ -2,6 +2,8 @@ export type RootStackParamList = {
   Login: undefined;
   AddUser: undefined;
   Home: { newUserLoading?: boolean } | undefined;
+  Settings: undefined;
+  PrepareForOffline: undefined;
   Sync: undefined;
   Chapters: {
     projectId: number;


### PR DESCRIPTION

https://github.com/eten-tech-foundation/fluent-mobile/issues/40

https://github.com/user-attachments/assets/091198d1-0455-491c-a6dd-b9bb44573a3a


### 👉 TLDR

Adds a dedicated **Settings** screen reachable from Home (gear → **More Settings**), reuses the shared **`PageHeader`** with slot-based icons, and introduces **`userPreferences` + `usePreferences`** for persisted settings. The screen includes Prepare for Offline navigation, an Upload over cellular toggle (stored locally, not wired to upload logic yet), Add user, and Log out with a confirmation when unsynced recordings exist.

---

### Next changes

Follow-ups for separate PRs: wire the gear icon to navigate directly to Settings (and retire the anchored menu once account actions move fully onto the Settings screen), implement the **Prepare for Offline** flow ([#39](https://linear.app)), enforce **Upload over cellular** in upload/connectivity logic, and add the **Sync** screen the header already navigates to. Remove multi-user dropdown behavior from `UserSettingsMenu` if Settings becomes the single account entry point.