### PR TITLE
#133: Clean up .gitignore for Android-only Expo project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,26 +2,6 @@
 #
 .DS_Store
 
-# Xcode
-#
-build/
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-xcuserdata
-*.xccheckout
-*.moved-aside
-DerivedData
-*.hmap
-*.ipa
-*.xcuserstate
-**/.xcode.env.local
-
 # Android/IntelliJ
 #
 build/
@@ -40,24 +20,8 @@ node_modules/
 npm-debug.log
 yarn-error.log
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/
-
-**/fastlane/report.xml
-**/fastlane/Preview.html
-**/fastlane/screenshots
-**/fastlane/test_output
-
 # Bundle artifact
 *.jsbundle
-
-# Ruby / CocoaPods
-**/Pods/
-/vendor/bundle/
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ yarn-error.log
 # Environment files
 .env
 .env.*
+!.env.example
 
 # Expo CNG — native projects are generated locally and in CI
 .expo/


### PR DESCRIPTION
## 🔥 TLDR
Harden `.gitignore` for Android-only Expo CNG: protect `.env.example` from the broad `.env.*` rule and remove unused iOS/Xcode/CocoaPods/fastlane boilerplate.

## 📋 Summary
- **Issue**: `.env.*` accidentally matched the committed `.env.example` template, and the gitignore still carried iOS/fastlane/CocoaPods sections from the RN template despite the project being Android-only.
- **Root Cause**: Default React Native template gitignore plus an overly broad env glob without a negation rule.
- **Solution**: Add `!.env.example` and delete dead iOS-related ignore sections while keeping Android, Expo CNG, and EAS signing rules.
- **Impact**: Safer env template handling and a leaner, accurate gitignore for contributors.

**Related Issue:** https://github.com/eten-tech-foundation/fluent-mobile/issues/133

Refs #133

**Type of Change:**
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Maintenance/refactor (no functional changes)

---

## 🔧 Technical Changes

### Key Files Modified

**`.gitignore`**
- Added `!.env.example` negation under env rules
- Removed `# Xcode`, `# fastlane`, and `# Ruby / CocoaPods` sections
- Kept Android `build/`, Expo CNG (`/android`, `/ios`, `.expo/`), EAS signing artifacts, Metro, Yarn, TypeScript entries

**Lines changed**: ~37 lines modified | **Files modified**: 1

### Dependencies & Configuration
- [x] No new dependencies
- [ ] New dependencies:
- [x] No config changes
- [ ] Environment/build config changes:
- [x] No database changes
- [ ] Database/storage changes:

---

## ✅ Testing & Quality Checklist

### Testing Completed
- [ ] ✅ Android device/emulator tested
- [ ] ✅ Unit tests added/updated and passing
- [x] ✅ Edge cases considered and tested

### Code Quality (fluent-mobile gates)
- [x] ✅ `npm run lint`
- [x] ✅ `npm run format:check`
- [x] ✅ `npm run typecheck`
- [x] ✅ `npm test -- --ci`
- [x] ✅ Self-reviewed the code changes

---

## 📸 Screenshots/Recordings
N/A — gitignore-only change.

---

## 🎯 Why This Solution?
1. **Negation over narrowing the glob**: Keeps `.env.local` / `.env.production` ignored while explicitly allowing the committed template.
2. **Remove dead sections**: Android-only project does not need iOS/Xcode/CocoaPods/fastlane ignores; reduces noise and confusion.
3. **Keep CNG safety net**: `/ios` remains ignored so a mistaken prebuild cannot commit an iOS tree.

## 📱 Before/After
- **Before**: `.env.example` matched `.env.*`; gitignore included unused iOS template sections.
- **After**: `.env.example` explicitly tracked; gitignore reflects Android-only + Expo CNG reality.

---

## ⚠️ Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes documented below:

---

## 📊 Performance Impact

**Bundle Size:**
- [x] No significant impact (< 1MB)

**Runtime Performance:**
- [x] No performance impact

**Battery/Memory:**
- [x] No impact on battery or memory usage

---

## 🧪 How to Test

**Prerequisites:** Node 24+, repo checkout on `chore/gitignore-cleanup`

**Steps:**
1. Run `git check-ignore -v .env.example` — should print nothing (not ignored)
2. Run `git check-ignore -v .env.local` — should match `.env.*`
3. Run `git check-ignore -v android/app/build` — should match `build/`
4. Confirm `.env.example` still appears in `git ls-files`

**Expected:** Env template stays committable; secrets/local env files remain ignored; Android build artifacts still ignored.

---

## 🔗 Additional Context
Verified against Expo CNG docs: `/android` and `/ios` gitignore entries are recommended for prebuild workflows.

**Deployment Notes:** None.

**Follow-up Tasks:**
- [ ] None

### 🎬 Find Yourself a Solid Gif
https://media.giphy.com/media/l0MYC0LajboPezWs0/giphy.gif