### PR TITLE
#132: Document Expo local dev auth troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,15 +238,16 @@ npm run android
 Then keep Metro running (`npm start`). If you installed an old **EAS dev-client** or **preview** APK by mistake, uninstall it and use a fresh local build or the PR **Install Fluent** link — see [docs/guides/qa-preview-testing.md](docs/guides/qa-preview-testing.md).
 
 **Dev client won't load / `UnexpectedServerData` / Expo code-signing errors on launch**
-Local development needs **no Expo account** — clone and run anonymously. This error appears when you are logged into an Expo account that lacks access to this EAS project: the CLI tries to fetch a development code-signing certificate for the committed `projectId` and fails. Log out (or run offline):
+Local development needs **no Expo account** — clone and run anonymously. The Expo CLI signs the dev manifest with your user credentials, so if you are logged into an Expo account that lacks access to this EAS project, it fails fetching a development code-signing certificate for the committed `projectId`. Check and clear your CLI session:
 
 ```bash
-npx expo logout
-# or, per run, skip all Expo network calls:
+npx expo whoami     # shows the logged-in account, or "Not logged in"
+npx expo logout     # run anonymously (recommended for local dev)
+# or, per run, skip all Expo network requests:
 npx expo start --offline
 ```
 
-The Expo session is global, not in the repo — it lives in `~/.expo/state.json`, so it persists across clones and machines (re-cloning the repo does not clear it). Expo/EAS login is only required for maintainer tasks (`eas build`, `eas update`, `eas submit`), never for local dev.
+The CLI session is stored globally on your machine, not in the repo, so it persists across clones (re-cloning does not clear it — use `expo logout`). Expo/EAS login is only required for maintainer tasks (`eas build`, `eas update`, `eas submit`), never for local dev.
 
 **`adb: command not found`**
 Your environment variables aren't set. Complete Step 4 and reload your shell (`source ~/.zshrc`, `source ~/.bashrc`, or restart the terminal).

--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ npm run android
 
 Then keep Metro running (`npm start`). If you installed an old **EAS dev-client** or **preview** APK by mistake, uninstall it and use a fresh local build or the PR **Install Fluent** link — see [docs/guides/qa-preview-testing.md](docs/guides/qa-preview-testing.md).
 
+**Dev client won't load / `UnexpectedServerData` / Expo code-signing errors on launch**
+Local development needs **no Expo account** — clone and run anonymously. This error appears when you are logged into an Expo account that lacks access to this EAS project: the CLI tries to fetch a development code-signing certificate for the committed `projectId` and fails. Log out (or run offline):
+
+```bash
+npx expo logout
+# or, per run, skip all Expo network calls:
+npx expo start --offline
+```
+
+The Expo session is global, not in the repo — it lives in `~/.expo/state.json`, so it persists across clones and machines (re-cloning the repo does not clear it). Expo/EAS login is only required for maintainer tasks (`eas build`, `eas update`, `eas submit`), never for local dev.
+
 **`adb: command not found`**
 Your environment variables aren't set. Complete Step 4 and reload your shell (`source ~/.zshrc`, `source ~/.bashrc`, or restart the terminal).
 


### PR DESCRIPTION
## 🔥 TLDR
Add README troubleshooting for Expo dev-client launch failures caused by a mismatched global Expo CLI session — local dev needs no Expo account; use `expo whoami` / `expo logout` or `--offline`.

## 📋 Summary
- **Issue**: Contributors logged into an Expo account without access to this EAS project hit `UnexpectedServerData` / code-signing errors when starting the dev client, even though local development should not require Expo auth.
- **Root Cause**: Expo CLI signs dev manifests with user credentials when online; a foreign global session triggers EAS project/certificate fetches that fail for this repo's `projectId`.
- **Solution**: Document the anonymous local-dev path and the documented CLI fixes (`whoami`, `logout`, `--offline`), plus clarify that login is only needed for maintainer EAS tasks.
- **Impact**: Unblocks onboarding without requiring Expo org membership for day-to-day development.

**Related Issue:** https://github.com/eten-tech-foundation/fluent-mobile/issues/132

Refs #132

**Type of Change:**
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Maintenance/refactor (no functional changes)

---

## 🔧 Technical Changes

### Key Files Modified

**`README.md`**
- Added troubleshooting entry under **Dev client won't load / UnexpectedServerData / Expo code-signing errors**
- Documents `npx expo whoami`, `npx expo logout`, and `npx expo start --offline`
- Clarifies session is global to the machine (persists across clones), not stored in the repo
- States Expo/EAS login is only required for `eas build`, `eas update`, `eas submit`

**Lines changed**: ~11 lines added | **Files modified**: 1

### Dependencies & Configuration
- [x] No new dependencies
- [ ] New dependencies:
- [x] No config changes
- [ ] Environment/build config changes:
- [x] No database changes
- [ ] Database/storage changes:

---

## ✅ Testing & Quality Checklist

### Testing Completed
- [ ] ✅ Android device/emulator tested
- [ ] ✅ Unit tests added/updated and passing
- [x] ✅ Edge cases considered and tested

### Code Quality (fluent-mobile gates)
- [x] ✅ `npm run lint`
- [x] ✅ `npm run format:check`
- [x] ✅ `npm run typecheck`
- [x] ✅ `npm test -- --ci`
- [x] ✅ Self-reviewed the code changes

---

## 📸 Screenshots/Recordings
N/A — documentation-only change.

---

## 🎯 Why This Solution?
1. **Documented CLI interface**: Uses official `whoami` / `logout` / `--offline` commands rather than internal file paths that may change.
2. **Sets correct expectations**: Open-source contributors should not need Expo org access to run locally.
3. **Complements existing OTA troubleshooting**: Separate failure mode from the disabled-updates-on-local-dev fix already on main.

## 📱 Before/After
- **Before**: Contributors hit cryptic launch errors with no repo guidance on global Expo session mismatch.
- **After**: README explains cause and fix in one troubleshooting block.

---

## ⚠️ Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes documented below:

---

## 📊 Performance Impact

**Bundle Size:**
- [x] No significant impact (< 1MB)

**Runtime Performance:**
- [x] No performance impact

**Battery/Memory:**
- [x] No impact on battery or memory usage

---

## 🧪 How to Test

**Prerequisites:** Node 24+, machine logged into an Expo account **without** access to this EAS project (optional but best repro)

**Steps:**
1. Checkout branch and read README Troubleshooting section
2. Run `npx expo whoami` — note logged-in account
3. If launch fails with code-signing/UnexpectedServerData, run `npx expo logout`
4. Start dev client again: `npm run android` / `npm start`
5. Alternatively verify `npx expo start --offline` skips Expo network calls

**Expected:** After logout or offline mode, local dev works without Expo org membership. README steps match observed behavior.

---

## 🔗 Additional Context
Confirmed against Expo CLI docs: CLI signs manifests with user credentials when online; `--offline` prevents network requests. Project `.expo/` holds local device/settings only — auth session is global per machine.

**Deployment Notes:** None.

**Follow-up Tasks:**
- [ ] Consider linking from onboarding docs if contributors still miss this step

---

### 🎬 Find Yourself a Solid Gif
https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif