### PR TITLE
[#108]: Document local development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Custom dev client — not Expo Go.** This app uses native modules (`expo-dev-client`, `op-sqlite`, keychain, etc.) and must run in a **development build** you compile locally (`npm run android`) or install from EAS. It will **not** work in the Expo Go app from the Play Store.
 
-**For AI agents / contributors:** see [docs/AGENT_ONBOARDING.md](docs/AGENT_ONBOARDING.md) for repo layout, architecture, commands, and Cursor rules.
+**For AI agents / contributors:** see [docs/AGENT_ONBOARDING.md](docs/AGENT_ONBOARDING.md) for repo layout, architecture, commands, and Cursor rules. For **hosted dev vs local Docker API** setup, see [docs/guides/local-development-workflow.md](docs/guides/local-development-workflow.md).
 
 ## Prerequisites
 
@@ -189,7 +189,10 @@ Copy environment variables:
 cp .env.example .env
 ```
 
-Edit `.env` and set `EXPO_PUBLIC_API_BASE_URL` (use `http://10.0.2.2:9999` for the Android emulator).
+Edit `.env` and set `EXPO_PUBLIC_API_BASE_URL`:
+
+- **Hosted dev:** `https://dev.api.fluent.bible` (shared remote data; ask team for login credentials)
+- **Local Docker API:** `http://10.0.2.2:9999` (see [docs/guides/local-development-workflow.md](docs/guides/local-development-workflow.md))
 
 ---
 

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -48,12 +48,13 @@ Quick map for Cursor agents and new contributors. Verified against Expo SDK 56 +
 | [`.github/dependabot.yml`](../.github/dependabot.yml) | Weekly dependency PRs (npm + GitHub Actions) |
 | [`.cursor/rules/`](../.cursor/rules/) | Cursor agent rules |
 | [`docs/guides/dependabot-process.md`](guides/dependabot-process.md) | Safe Dependabot merge process |
+| [`docs/guides/local-development-workflow.md`](guides/local-development-workflow.md) | Hosted dev + local Docker API paths |
 | [`.cursor/commands/`](../.cursor/commands/) | Slash commands (`/create-pr`, etc.) |
 
 ## Setup
 
 1. Node 24: `nvm use 24` (or match `engines` in `package.json`).
-2. Copy env: `cp .env.example .env` — set `EXPO_PUBLIC_API_BASE_URL`.
+2. Copy env: `cp .env.example .env` — set `EXPO_PUBLIC_API_BASE_URL` (see [local development workflow](guides/local-development-workflow.md)).
 3. `npm install`
 4. Generate native project (first time or after config plugin changes): `npm run prebuild` (Android-only)
 5. Android dev client (two terminals):

--- a/docs/guides/local-development-workflow.md
+++ b/docs/guides/local-development-workflow.md
@@ -1,0 +1,146 @@
+# Local development workflow
+
+How to run **fluent-mobile** against a real Fluent API. The app syncs server data into on-device SQLite via `syncAllData()` — there is no mobile mock seed.
+
+Pick **one** API path by setting `EXPO_PUBLIC_API_BASE_URL` in `.env`. No code changes required to switch.
+
+| Path | When to use |
+|------|-------------|
+| **Hosted dev** | See shared remote data; no Docker |
+| **Local Docker** | Seed your own Postgres; iterate on API locally; work offline from the API |
+
+Web app (login / project UI in browser): https://dev.app.fluent.bible
+
+---
+
+## Prerequisites
+
+- Node **≥ 24.14.0**, **npm**
+- Android Studio + emulator (API 33+), or a physical Android device with USB debugging
+- **Custom dev client** — this app does not run in Expo Go (see [README](../../README.md))
+- For **Path B** only: Docker Desktop or Podman, plus a clone of [fluent-api](https://github.com/eten-tech-foundation/fluent-api)
+
+---
+
+## Shared mobile setup (both paths)
+
+From the `fluent-mobile` repo root:
+
+```bash
+npm install
+cp .env.example .env
+npm run prebuild    # expo prebuild --clean --platform android
+```
+
+Set `EXPO_PUBLIC_API_BASE_URL` in `.env` per path below, then run (two terminals):
+
+```bash
+npm start
+npm run android
+```
+
+Sign in with email/password (Better Auth). After login, sync populates local SQLite; screens read from the DB.
+
+### What works after sync vs what needs a server
+
+| Feature | After sync (offline OK) | Needs server |
+|---------|-------------------------|--------------|
+| Browse Projects / My Work / chapters | Yes | Initial sync |
+| View synced verses | Yes | Initial sync |
+| Recording UI (local) | Yes | — |
+| Upload recordings | No | Yes |
+| Re-sync / pull updates | No | Yes |
+| Login / password reset | No | Yes |
+
+---
+
+## Path A — Hosted dev (no Docker)
+
+Use when you want to exercise the app against **shared dev data** deployed from `main`.
+
+### 1. Configure API URL
+
+In `.env`:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=https://dev.api.fluent.bible
+```
+
+This is the same backend as the Azure host `scribe-server-dev-*.azurewebsites.net`; the custom domain is preferred.
+
+### 2. Log in
+
+You need a **team dev account** that exists on hosted dev. The local Docker-only user `t@fluent.local` does **not** exist there.
+
+Ask your team for credentials (e.g. a translator test account). You can verify login first at https://dev.app.fluent.bible.
+
+### 3. Important: shared database
+
+Hosted dev uses a **shared Postgres**. Do **not** seed or bulk-modify data there — you would affect other developers.
+
+Read-only Postgres access may be provided for inspection/debugging only; the mobile app never connects to Postgres directly.
+
+---
+
+## Path B — Local Docker API
+
+Use when you want your **own** seeded Postgres, local API changes, or no dependency on hosted dev.
+
+### 1. Start fluent-api
+
+In a separate clone of [fluent-api](https://github.com/eten-tech-foundation/fluent-api):
+
+```bash
+cp .env.example .env
+# Set BETTER_AUTH_SECRET (see fluent-api README: openssl rand -hex 32)
+
+./fapi.sh up
+./fapi.sh db:init    # migrations + all seeds (interactive confirm)
+```
+
+This runs Postgres + API + worker on **port 9999** (Podman or Docker Compose, auto-detected).
+
+### 2. Configure mobile API URL
+
+In fluent-mobile `.env`:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=http://10.0.2.2:9999
+```
+
+`10.0.2.2` is the Android emulator alias for the host machine's `localhost`. Use your machine's LAN IP if testing on a physical device.
+
+### 3. Log in
+
+Default seeded translator (after `db:init`):
+
+| Field | Value |
+|-------|-------|
+| Email | `t@fluent.local` |
+| Password | `t@123456` |
+
+Project manager: `pm@fluent.local` / `pm@123456`
+
+**My Work:** After [fluent-api#207](https://github.com/eten-tech-foundation/fluent-api/issues/207) (local dev project seeder) lands, sync will populate My Work. Until then, master data and dev users exist but project/chapter assignments may be empty.
+
+---
+
+## Verification (CI commands)
+
+From `fluent-mobile` repo root:
+
+```bash
+npm run format:check && npm run lint && npm run typecheck && npm test -- --ci
+```
+
+Tests default `EXPO_PUBLIC_API_BASE_URL=http://localhost:9999` via `jest.env.cjs` — no live API required for CI.
+
+Do **not** use `FLUENT_USER_EMAIL` or legacy `@env` imports.
+
+---
+
+## Related docs
+
+- [Agent onboarding](../AGENT_ONBOARDING.md) — architecture, layer rules, EAS preview
+- [QA preview testing](./qa-preview-testing.md) — install preview APKs from PRs
+- [README — full machine setup](../../README.md) — JDK, Android Studio, emulator

--- a/docs/guides/local-development-workflow.md
+++ b/docs/guides/local-development-workflow.md
@@ -39,7 +39,7 @@ npm start
 npm run android
 ```
 
-Sign in with email/password (Better Auth). After login, sync populates local SQLite; screens read from the DB.
+Sign in with email/password (Better Auth). Some read-only reference data can be fetched without a session, but user/project data requires auth. After login, sync populates local SQLite; screens read from the DB.
 
 ### What works after sync vs what needs a server
 
@@ -120,13 +120,6 @@ Default seeded translator (after `db:init`):
 | Password | `t@123456` |
 
 Project manager: `pm@fluent.local` / `pm@123456`
-
-If login fails (e.g. password drift on an old volume), reset inside the API container:
-
-```bash
-./fapi.sh run db:set-password pm@fluent.local pm@123456
-./fapi.sh run db:set-password t@fluent.local t@123456
-```
 
 ### 4. My Work on local Docker
 

--- a/docs/guides/local-development-workflow.md
+++ b/docs/guides/local-development-workflow.md
@@ -121,7 +121,23 @@ Default seeded translator (after `db:init`):
 
 Project manager: `pm@fluent.local` / `pm@123456`
 
-**My Work:** After [fluent-api#207](https://github.com/eten-tech-foundation/fluent-api/issues/207) (local dev project seeder) lands, sync will populate My Work. Until then, master data and dev users exist but project/chapter assignments may be empty.
+If login fails (e.g. password drift on an old volume), reset inside the API container:
+
+```bash
+./fapi.sh run db:set-password pm@fluent.local pm@123456
+./fapi.sh run db:set-password t@fluent.local t@123456
+```
+
+### 4. My Work on local Docker
+
+`db:init` seeds org, dev users, languages, books, bibles, and texts — but **not** projects or chapter assignments. After sync you can sign in and browse master data; **My Work may be empty**.
+
+To populate My Work locally, either:
+
+- **Use Path A (hosted dev)** when you need assignment-rich testing (`https://dev.api.fluent.bible` + team credentials), or
+- **Create a project in the web app** against your local API (run [fluent-web](https://github.com/eten-tech-foundation/fluent-web) pointed at `http://localhost:9999`, sign in as `pm@fluent.local`, create a project, assign chapters to `t@fluent.local`), then re-sync on mobile.
+
+Mobile SQLite is always filled by **sync hydration** — there is no mobile-side seed.
 
 ---
 

--- a/plugins/withRNScreensFragmentFactory.js
+++ b/plugins/withRNScreensFragmentFactory.js
@@ -4,7 +4,8 @@ const PLUGIN = 'withRNScreensFragmentFactory';
 const FRAGMENT_FACTORY_IMPORT =
   'import com.swmansion.rnscreens.fragment.restoration.RNScreensFragmentFactory';
 const IMPORT_ANCHOR = /^import .+/m;
-const ON_CREATE_ANCHOR = /override fun onCreate\(savedInstanceState: Bundle\?\)/;
+const ON_CREATE_ANCHOR =
+  /override fun onCreate\(savedInstanceState: Bundle\?\)/;
 
 function mergeOrAppend({
   tag,


### PR DESCRIPTION
### 👉 TLDR

Documents the final local development workflow for fluent-mobile: point `EXPO_PUBLIC_API_BASE_URL` at a real Fluent API, sign in with Better Auth, and let `syncAllData()` hydrate SQLite. This keeps the mobile app out of the seed-data business: no mobile mock seed, no offline auth bypass, and no fluent-api seeder dependency.

### 👀 Reviewer Checklist

- [x] GitHub issues linked
- [x] How to verify steps included
- [x] Docs clarify hosted dev vs local Docker data expectations

### 🗣️ Details

Refs #108
Refs #119

Epic #119 was narrowed to documentation after confirming hosted dev is available and fluent-api already has the core Docker seed path for reference/master data and dev users. Hosted dev is the recommended path for realistic assignment-rich synced data. Local Docker remains useful for local API work; mobile sync will reflect whatever project/chapter data exists in that local API database.

This PR updates:

- `docs/guides/local-development-workflow.md` — hosted dev + local Docker setup, auth/sync expectations, My Work caveat for local Docker
- `docs/AGENT_ONBOARDING.md` — link to the workflow guide
- `README.md` — quick pointer and env var examples

Out of scope by design:

- Mobile SQLite fixture seeding / mock mode
- Offline auth bypass
- fluent-api project/chapter-assignment seeder automation
- Password reset workflow documentation

### ✅ How to verify

1. Read `docs/guides/local-development-workflow.md` and confirm it accurately says mobile SQLite is populated by API sync, not local fixtures.
2. Confirm the README and onboarding links resolve.
3. Run gates:

```bash
npm run format:check
npm run lint
npm run typecheck
npm test -- --ci
```

Latest local run passed.

### 🎬 Find Yourself a Solid Gif

https://media.giphy.com/media/3o7btPCcdNniyf0ArS/giphy.gif