### PR TITLE
[#137]: Harden app shell when API URL unset or unreachable

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { View, ActivityIndicator, Text } from 'react-native';
+import { View, ActivityIndicator, Text, TouchableOpacity } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import BootSplash from 'react-native-bootsplash';
 import { logger } from './src/utils/logger';
+import { readApiBaseUrl } from './src/config/apiBaseUrl';
 import { initializeDatabase } from './src/db/index';
 import { syncAllData } from './src/services/sync';
 import { getActiveUserId } from './src/services/storage';
@@ -16,19 +17,41 @@ import {
 import AppNavigator from './src/navigation/AppNavigator';
 import { onAuthSessionExpired } from './src/services/syncEvents';
 import { setActiveToken } from './src/services/api';
+import { checkServerReachable } from './src/services/connectivity';
 import { appStyles } from './src/app/appStyles';
 import { theme } from './src/theme';
 
 const log = logger.create('App');
+
+const API_CONFIG_ERROR =
+  'EXPO_PUBLIC_API_BASE_URL is not set. Copy .env.example to .env, set the API URL, then rebuild the app. See docs/guides/local-development-workflow.md.';
+
+function apiUnreachableMessage(apiUrl: string): string {
+  return `Cannot reach the API at ${apiUrl}. Start fluent-api (./fapi.sh up) or use hosted dev — see docs/guides/local-development-workflow.md.`;
+}
+
+type InitBlock = {
+  message: string;
+  canRetry: boolean;
+};
 
 function App() {
   const [dbReady, setDbReady] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [postLoginSyncActive, setPostLoginSyncActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [initBlock, setInitBlock] = useState<InitBlock | null>(null);
+  const [initAttempt, setInitAttempt] = useState(0);
 
   const handleSignOut = () => {
     setIsAuthenticated(false);
+  };
+
+  const handleRetryInit = () => {
+    setInitBlock(null);
+    setError(null);
+    setDbReady(false);
+    setInitAttempt(attempt => attempt + 1);
   };
 
   useEffect(() => {
@@ -44,33 +67,60 @@ function App() {
       try {
         await initializeDatabase();
 
-        const activeUserId = getActiveUserId();
-
-        if (activeUserId) {
-          const hasToken = await hasCredentials(activeUserId);
-          if (hasToken) {
-            const creds = await getCredentials(activeUserId);
-            setActiveToken(creds?.token ?? null);
-            setIsAuthenticated(true);
-            setDbReady(true);
-            return;
-          }
+        const apiUrl = readApiBaseUrl();
+        if (!apiUrl) {
+          setInitBlock({ message: API_CONFIG_ERROR, canRetry: true });
+          setDbReady(true);
+          return;
         }
 
-        const storedUserIds = await getAllStoredUserIds();
-        log.info('Stored user IDs in keychain', { storedUserIds });
+        const restoreSession = async (): Promise<boolean> => {
+          const activeUserId = getActiveUserId();
 
-        if (storedUserIds.length > 0) {
-          const userId = storedUserIds[0];
-          const creds = await getCredentials(userId);
-          if (creds?.token) {
-            const { switchActiveUser } = await import('./src/services/storage');
-            switchActiveUser(userId);
-            setActiveToken(creds.token);
-            setIsAuthenticated(true);
-            setDbReady(true);
-            return;
+          if (activeUserId) {
+            const hasToken = await hasCredentials(activeUserId);
+            if (hasToken) {
+              const creds = await getCredentials(activeUserId);
+              setActiveToken(creds?.token ?? null);
+              setIsAuthenticated(true);
+              return true;
+            }
           }
+
+          const storedUserIds = await getAllStoredUserIds();
+          log.info('Stored user IDs in keychain', { storedUserIds });
+
+          if (storedUserIds.length > 0) {
+            const userId = storedUserIds[0];
+            const creds = await getCredentials(userId);
+            if (creds?.token) {
+              const { switchActiveUser } = await import(
+                './src/services/storage'
+              );
+              switchActiveUser(userId);
+              setActiveToken(creds.token);
+              setIsAuthenticated(true);
+              return true;
+            }
+          }
+
+          return false;
+        };
+
+        const sessionRestored = await restoreSession();
+        if (sessionRestored) {
+          setDbReady(true);
+          return;
+        }
+
+        const reachable = await checkServerReachable();
+        if (!reachable) {
+          setInitBlock({
+            message: apiUnreachableMessage(apiUrl),
+            canRetry: true,
+          });
+          setDbReady(true);
+          return;
         }
 
         setDbReady(true);
@@ -82,7 +132,7 @@ function App() {
     };
 
     initApp();
-  }, []);
+  }, [initAttempt]);
 
   useEffect(() => {
     if (!dbReady) {
@@ -119,16 +169,32 @@ function App() {
       <GestureHandlerRootView style={appStyles.containerAppInit}>
         <SafeAreaProvider>
           <View style={appStyles.containerAppInit}>
-            {error ? (
-              <Text style={appStyles.errorTextAppInit}>Error: {error}</Text>
-            ) : (
-              <>
-                <ActivityIndicator size="large" color={theme.colors.primary} />
-                <Text style={appStyles.loadingTextAppInit}>
-                  Initializing...
-                </Text>
-              </>
-            )}
+            <ActivityIndicator size="large" color={theme.colors.primary} />
+            <Text style={appStyles.loadingTextAppInit}>Initializing...</Text>
+          </View>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
+    );
+  }
+
+  if (initBlock || error) {
+    const message = initBlock?.message ?? error;
+    const canRetry = initBlock?.canRetry ?? false;
+
+    return (
+      <GestureHandlerRootView style={appStyles.containerAppInit}>
+        <SafeAreaProvider>
+          <View style={appStyles.containerAppInit}>
+            <Text style={appStyles.errorTextAppInit}>{message}</Text>
+            {canRetry ? (
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={handleRetryInit}
+                style={appStyles.retryButtonAppInit}
+              >
+                <Text style={appStyles.retryButtonTextAppInit}>Retry</Text>
+              </TouchableOpacity>
+            ) : null}
           </View>
         </SafeAreaProvider>
       </GestureHandlerRootView>

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -84,6 +84,10 @@ jest.mock('../src/services/api', () => ({
   setActiveToken: jest.fn(),
 }));
 
+jest.mock('../src/services/connectivity', () => ({
+  checkServerReachable: jest.fn(() => Promise.resolve(true)),
+}));
+
 describe('App', () => {
   it('renders navigator after initialization', async () => {
     const { getByTestId } = render(<App />);

--- a/src/app/appStyles.ts
+++ b/src/app/appStyles.ts
@@ -466,10 +466,22 @@ export const appStyles = StyleSheet.create({
     backgroundColor: '#0b50d0',
   },
   errorTextAppInit: {
-    color: 'red',
+    color: '#fff',
     fontSize: 14,
     padding: 20,
     textAlign: 'center',
   },
-  loadingTextAppInit: { marginTop: 10, fontSize: 14 },
+  retryButtonAppInit: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+  },
+  retryButtonTextAppInit: {
+    color: '#0b50d0',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  loadingTextAppInit: { marginTop: 10, fontSize: 14, color: '#fff' },
 });

--- a/src/config/apiBaseUrl.ts
+++ b/src/config/apiBaseUrl.ts
@@ -1,5 +1,10 @@
-export function getApiBaseUrl(): string {
+export function readApiBaseUrl(): string | null {
   const url = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+  return url || null;
+}
+
+export function getApiBaseUrl(): string {
+  const url = readApiBaseUrl();
   if (!url) {
     throw new Error(
       'EXPO_PUBLIC_API_BASE_URL is required. Copy .env.example to .env and set EXPO_PUBLIC_API_BASE_URL.',


### PR DESCRIPTION
### 👉 TLDR

Shows a clear startup error (with Retry) when `EXPO_PUBLIC_API_BASE_URL` is missing or the API health check fails for unauthenticated launches. Returning users with a stored session still enter offline — no mock seed or auth bypass.

### 👀 Reviewer Checklist

- [ ] GitHub issues linked
- [ ] How to verify steps are accurate

### 🗣️ Details

Refs #137
Refs #119

Reduced scope from descoped #107: configuration/connectivity UX only.

### ✅ How to verify

1. Remove `EXPO_PUBLIC_API_BASE_URL` from `.env`, rebuild → config error with doc pointer.
2. Point URL at unreachable host, fresh install → unreachable error; tap Retry after starting API.
3. Sign in, stop API, relaunch → app opens with cached data (no block).
4. Gates:

```bash
npm run format:check && npm run lint && npm run typecheck && npm test -- --ci
```

All passed on PR branch.

### 🎬 Find Yourself a Solid Gif

https://media.giphy.com/media/3o7aTskHEdDG99Tvmw/giphy.gif