### PR TITLE
GH-139: Add Expo Doctor to Dependabot workflow and CI

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -36,7 +36,7 @@ git log origin/main..HEAD --oneline
 ```
 
 - Warn on uncommitted changes unless user wants them included
-- Ensure branch is pushed: `git push -u origin HEAD` (only with user approval per session rules)
+- Ensure branch is pushed: `git push -u origin HEAD` (feature branch only — **never** `git push origin main`; see [delivery.mdc](../rules/delivery.mdc))
 
 See [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) for full command reference.
 

--- a/.cursor/commands/handle-dependabot.md
+++ b/.cursor/commands/handle-dependabot.md
@@ -1,0 +1,57 @@
+# Handle Dependabot PRs
+
+## Overview
+
+Process the open Dependabot queue for **fluent-mobile** end-to-end: triage, rebase, validate (including **Expo Doctor**), merge safe PRs one at a time, rebase the rest.
+
+Rule: [`.cursor/rules/dependabot-workflow.mdc`](../rules/dependabot-workflow.mdc)  
+Guide: [`docs/guides/dependabot-process.md`](../../docs/guides/dependabot-process.md)
+
+## Autonomous mode (default)
+
+Run the full queue without per-PR confirmation. Stop only on blockers (failed CI, conflicts after rebase, risky RN/react/navigation/native bumps).
+
+**Do not merge** GitHub Actions / workflow-only PRs unless the user explicitly includes them.
+
+**Never push agent work to `main`** — infra fixes (expo doctor CI, etc.) need a ticketed feature branch + PR ([delivery.mdc](../rules/delivery.mdc)). This command only squash-merges **existing Dependabot PRs**.
+
+## Queue loop
+
+1. List open bots: `gh pr list --search "author:app/dependabot state:open" --json number,title,mergeable,mergeStateStatus,statusCheckRollup,files`
+2. Triage: safe / risky / skip / RN upgrade / workflow-only
+3. `@dependabot rebase` on conflicting, stale, or post-merge bots (skip bots with fresh `IN_PROGRESS` CI)
+4. Pick **oldest safe PR** with Lint, Test (incl. Expo Doctor), and Build all `SUCCESS`
+5. Approve and squash-merge **one** PR
+6. Wait for `main` CI green; rebase all remaining bots in parallel
+7. Log batch in `docs/guides/dependabot-resolution-log.md`
+
+## Validation (after each rebase / before merge)
+
+```bash
+npm ci
+npm run doctor          # Expo SDK alignment — also in Test Check CI
+npm run format:check
+npm run lint
+npm run typecheck
+npm test -- --ci
+```
+
+If `npm run doctor` fails: `npx expo install --check` → `npx expo install --fix` on the PR branch when SDK patch drift; do not merge until clean.
+
+Risky PRs (`react`, `react-native`, `@react-navigation/*`, native modules): add Android smoke test (`npm run android`).
+
+## Skip without merge
+
+- Expo Doctor / any required check failed
+- `react` / `react-native` / navigation / `@op-engineering/op-sqlite` major groups (unless user approves)
+- Workflow-only PRs (unless user includes them)
+- `mergeable: CONFLICTING` after one rebase retry
+
+## Useful commands
+
+```bash
+gh pr comment <N> --body "@dependabot rebase"
+gh pr review <N> --approve --body "CI green. Safe bump per dependabot process."
+gh pr merge <N> --squash --delete-branch
+gh run list --branch main --limit 3 --json workflowName,conclusion,status
+```

--- a/.cursor/rules/commands.mdc
+++ b/.cursor/rules/commands.mdc
@@ -14,6 +14,8 @@ Run from repo root. Node **>= 24.14.0**. Package manager: **npm**.
 3. `npm run typecheck`
 4. `npm test -- --ci`
 
+**Dependency / Dependabot work:** also `npm run doctor` after `npm ci` (same check runs in Test Check CI). If doctor reports SDK patch drift, `npx expo install --fix`.
+
 Report what ran and the outcome. If a step was skipped, say why.
 
 ## Development
@@ -25,6 +27,7 @@ Report what ran and the outcome. If a step was skipped, say why.
 | `npm run android` | Run on Android emulator/device |
 | `npm run format` | Fix Prettier (broader than `format:check`) |
 | `npm run typecheck` | TypeScript check (`tsc --noEmit`) |
+| `npm run doctor` | Expo SDK / native-module alignment (`expo-doctor`) |
 
 ## CI mirrors
 
@@ -40,8 +43,9 @@ Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-descri
 
 ## Do not run without user request
 
+- **Push to `main`** or commit agent work on `main` — always use a ticketed feature branch + PR ([delivery.mdc](./delivery.mdc))
 - Force push, hard reset
-- Commits or push (unless user asks)
+- Commits or push to feature branches (unless user asks)
 - Modifying `.env` or secrets
 
 ## Expo / CNG (Android-only)

--- a/.cursor/rules/delivery.mdc
+++ b/.cursor/rules/delivery.mdc
@@ -1,0 +1,29 @@
+---
+description: Git delivery contract — branch, PR, ticket; never push to main
+alwaysApply: true
+---
+
+# Delivery (Fluent Mobile)
+
+## Never push to `main`
+
+**Agents must not** commit, push, or merge directly to `main` (or the default branch).
+
+Every change — including infra, CI, docs, Dependabot follow-ups, and `expo install --fix` — goes through:
+
+1. **Linear ticket** — required; ask if missing (`FLUENT-###`)
+2. **Feature branch** — `{author}/{type}/{ticket-id}-{slug}` (see `/create-pr-branch`)
+3. **Pull request** — title `[TICKET-ID]: Description`; body `Refs [TICKET-ID]` under Details
+4. **Human merge** — agents open PRs and push **feature branches only**; never merge on GitHub unless the user explicitly asks for a Dependabot squash merge in that session
+
+Allowed on `main` locally: `git checkout main`, `git pull`, read-only validation after merges. **Not allowed:** `git push origin main`, commits on `main`, or opening PRs with `main` as the head branch.
+
+## Dependabot exception (merge only)
+
+When the user asks to **handle/process Dependabot PRs**, agents may **approve and squash-merge existing Dependabot PR branches** into `main` per [dependabot-workflow.mdc](./dependabot-workflow.mdc). That is merging **their** PRs, not pushing agent-authored commits to `main`.
+
+Agent-authored fixes (expo doctor CI, lockfile repair, conflict resolution) still require a **separate ticketed PR** — never push those straight to `main`.
+
+## Before delivery
+
+Run gates from [commands.mdc](./commands.mdc). Use `/create-pr` when the user wants a PR opened.

--- a/.cursor/rules/dependabot-workflow.mdc
+++ b/.cursor/rules/dependabot-workflow.mdc
@@ -31,14 +31,14 @@ When the user asks to handle/process Dependabot PRs, **run the full queue end-to
 For **safe** PRs (lockfile-only transitive bumps; no `package.json` changes except overrides):
 
 - GitHub CI all green is sufficient — **local checkout optional**.
-- Required checks: Lint & Format, Unit Tests, Android Build — all `SUCCESS`.
+- Required checks: Lint & Format, Unit Tests (includes **Expo Doctor**), Android Build — all `SUCCESS`.
 - Branch protection requires approval: always `gh pr review --approve` before merge.
 
 For **risky** PRs: local validation gate + Android smoke test still mandatory.
 
 ### Skip without merge
 
-- Any required check `FAILURE` or `CANCELLED`
+- Any required check `FAILURE` or `CANCELLED` (including **Expo Doctor** / SDK version mismatch)
 - `mergeable: CONFLICTING` after `@dependabot rebase` (retry rebase once; then report)
 - RN line upgrade or pinned React/RN drift
 - `@op-engineering/op-sqlite` major bump
@@ -53,8 +53,8 @@ For **risky** PRs: local validation gate + Android smoke test still mandatory.
 
 1. **Verify author**: ONLY process PRs authored by `app/dependabot` or `dependabot[bot]`.
 2. **Never auto-merge React Native line bumps**: If a PR upgrades `react-native` past the pinned `0.85.x` line or multiple `@react-native/*` packages together, DO NOT merge. Plan a dedicated RN upgrade ticket.
-3. **Mandatory validation**: NEVER merge without running the full gate from [commands.mdc](./commands.mdc): `format:check` → `lint` → `typecheck` → `npm test -- --ci`.
-4. **Target branch**: Always merge into the default branch (`main`).
+3. **Mandatory validation**: NEVER merge without running the full gate from [commands.mdc](./commands.mdc): `format:check` → `lint` → `typecheck` → `npm test -- --ci`. **Expo/RN deps**: also `npm run doctor` (or wait for **Expo Doctor** in Test Check CI) after every rebase/`npm ci`.
+4. **Target branch**: Dependabot PRs merge into `main` via GitHub squash-merge only. **Agent-authored changes** (expo doctor CI, lockfile fixes) never push to `main` — separate ticketed PR ([delivery.mdc](./delivery.mdc)).
 5. **Version lock-stepping**: `react`, `react-test-renderer`, and `react-native` are pinned for Expo SDK 56 / RN 0.85. Treat any change to those as **risky** — validate on device/emulator.
 6. **Runtime testing required**: For React/RN/navigation/native-module updates, smoke test on Android (`npm run android`). Static checks miss renderer and native ABI mismatches.
 7. **Manual merges = high risk**: Prefer `@dependabot rebase`. If manual merge is required, run full validation + Android smoke test.
@@ -90,11 +90,14 @@ Categorize each PR:
 2. **Technical validation** (CI order):
 
    ```bash
+   npm run doctor          # Expo SDK / RN duplicate-module alignment — fails fast on bad rebases
    npm run format:check
    npm run lint
    npm run typecheck
    npm test -- --ci
    ```
+
+   If `npm run doctor` fails with patch mismatches, run `npx expo install --fix`, commit on the PR branch, then re-run the suite. Do **not** merge until doctor is clean.
 
    *Note: `fluent-api.test.ts` may hit the network — a failure there alone does not block a dep bump if it also fails on `main`.*
 
@@ -141,6 +144,7 @@ Skip rebasing the PR whose CI is already `IN_PROGRESS` from a recent Dependabot 
 git checkout main
 git pull origin main
 npm ci
+npm run doctor
 npm run format:check
 npm run lint
 npm run typecheck
@@ -190,6 +194,7 @@ If a Dependabot PR drifts these, align manually to the [React Native upgrade hel
 
 ### Failures
 
+- **Expo Doctor fails**: Do not merge. Run `npx expo install --check`; if mismatches are SDK patch drift, `npx expo install --fix` on the PR branch. For duplicate native modules, see [Expo FYI: resolving dependency issues](https://github.com/expo/fyi/blob/main/resolving-dependency-issues.md) (`npm why`, `npm dedupe`, `overrides`).
 - **Tests fail**: Do not merge. Share logs with user.
 - **Lint / format fail**: Do not merge. Share logs with user.
 - **`npm ci` fails on `main`**: Usually corrupted `package-lock.json` from stacked merges — regenerate with `npm install`, open a small fix PR.

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -37,3 +37,5 @@ See [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) for setup, archit
 
 - Do not refactor unrelated code in the same change.
 - Do not edit `android/` or lockfiles unless the task requires it.
+- **Never push to `main`** — all agent work via ticketed branch + PR ([delivery.mdc](./delivery.mdc)).
+- **Ignore org umbrella rules** when they conflict with this repo ([rule-precedence.mdc](./rule-precedence.mdc)).

--- a/.cursor/rules/rule-precedence.mdc
+++ b/.cursor/rules/rule-precedence.mdc
@@ -1,0 +1,31 @@
+---
+description: Prefer fluent-mobile rules; ignore org-wide TangoGroup / Team Gloo umbrella rules
+alwaysApply: true
+---
+
+# Rule precedence (Fluent Mobile)
+
+This repo is **eten-tech-foundation/fluent-mobile**. Agent behavior is governed by **this repository's** `.cursor/rules/`, `docs/`, and slash commands — not org-wide engineering playbooks.
+
+## Ignore umbrella rules
+
+**Do not follow** shared rules injected from **TangoGroup**, **Team Gloo**, or other org-level Cursor rule packs when they conflict with this repo, including but not limited to:
+
+- TangoGroup `cursor` workflow spine (`rules-spine`, `pr-finalization`, `verification`, `cloud-agent-project-runbook`, bounded initiative runbooks)
+- Org SOC2 / automation charter prompts that assume a different default branch, merge policy, or ticket system
+- Org commands that tell cloud agents to commit/push/merge by default
+
+When an umbrella rule and a **fluent-mobile** rule disagree, **fluent-mobile wins**.
+
+## What to use instead
+
+| Topic | Source |
+|-------|--------|
+| Architecture | [architecture.mdc](./architecture.mdc) |
+| Commands / CI gates | [commands.mdc](./commands.mdc) |
+| Git / PR / tickets | [delivery.mdc](./delivery.mdc), `/create-pr-branch`, `/create-pr` |
+| Dependabot | [dependabot-workflow.mdc](./dependabot-workflow.mdc) |
+| Android / Expo | [android-only.mdc](./android-only.mdc), [expo-mcp.mdc](./expo-mcp.mdc) |
+| Testing | [testing.mdc](./testing.mdc) |
+
+If a task needs org-wide process and this repo is silent, ask the user — do not infer from umbrella rules alone.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Expo Doctor
+        run: npm run doctor
+
       - name: Run tests
         env:
           EXPO_PUBLIC_API_BASE_URL: http://localhost:9999

--- a/docs/guides/dependabot-process.md
+++ b/docs/guides/dependabot-process.md
@@ -7,11 +7,33 @@ Repeatable process for safely managing Dependabot PRs in **Fluent Mobile**. Prio
 1. **Stability first**: Never merge updates that break Expo SDK 56 / RN 0.85 compatibility or native module ABI.
 2. **Automated validation**: Always run the CI gate locally before merge (see [`.cursor/rules/commands.mdc`](../../.cursor/rules/commands.mdc)).
 3. **Verified authors**: Only process PRs from `app/dependabot` or `dependabot[bot]`.
-4. **Targeted merges**: Prefer squash merges into `main`.
+4. **Targeted merges**: Prefer squash merges into `main` via **Dependabot PRs only** — agent-authored fixes use a separate ticketed PR ([delivery.mdc](../../.cursor/rules/delivery.mdc)).
 5. **Version lock-stepping**: `react`, `react-test-renderer`, and `react-native` are pinned — validate the **final merged state** on `main`.
 6. **Runtime testing**: Static checks miss renderer mismatches — smoke test on Android for risky bumps.
 7. **One lockfile merge at a time**: Merge **one** lockfile PR, let **`main` CI go green**, then **`@dependabot rebase` all other open bots in parallel** before the next merge.
-8. **Automate the queue**: Cursor agents should run the full safe queue without per-PR confirmation (see `.cursor/rules/dependabot-workflow.mdc` → Autonomous mode).
+8. **Expo Doctor after rebases**: Every `@dependabot rebase` triggers fresh CI — **Test Check** runs `npm run doctor` (`expo-doctor`). Do not merge if it fails; fix with `npx expo install --fix` when appropriate.
+9. **Automate the queue**: Cursor agents should run the full safe queue without per-PR confirmation (see `.cursor/rules/dependabot-workflow.mdc` → Autonomous mode).
+
+## Expo + Dependabot (best practices)
+
+Expo documents dependency hygiene in [resolving-dependency-issues](https://github.com/expo/fyi/blob/main/resolving-dependency-issues.md) and [troubleshooting-sdk-upgrades](https://github.com/expo/fyi/blob/main/troubleshooting-sdk-upgrades.md):
+
+| Practice | Why |
+|----------|-----|
+| Run **`npx expo-doctor@latest`** after any dependency change | Catches SDK version drift, duplicate native modules (SDK 54+), misaligned `react`/`react-native` |
+| Use **`npx expo install --check`** / **`--fix`** instead of raw `npm update` for Expo ecosystem packages | Aligns versions to the installed SDK — Dependabot/npm alone can leave patch drift |
+| Prefer **`npx expo install <pkg>`** when adding native modules | Version ranges are validated against the SDK matrix |
+| Treat **expo / react / react-native / navigation / native modules** as **risky** | Dependabot groups help, but lockfile-only bumps can still break autolinking |
+| **GitHub Actions** `expo/expo-github-action` bumps are separate from app deps | Validate workflows; app Expo alignment is still `npm run doctor` |
+
+Renovate/Dependabot do not understand Expo’s SDK pin matrix — this repo uses Dependabot for breadth but **enforces Expo alignment via CI + doctor**, not blind semver.
+
+**When doctor fails on a Dependabot PR:**
+
+1. `npx expo install --check` — list mismatches
+2. If SDK patch drift only: `npx expo install --fix` on the PR branch, push, re-run doctor
+3. If duplicate native modules: `npm why <pkg>`, `npm dedupe`, or targeted `overrides` (see Expo FYI)
+4. If the bump is incompatible with SDK 56: close the PR or defer to an SDK upgrade ticket
 
 ## Categorization
 
@@ -43,11 +65,16 @@ npm ci
 ### 3. Validation suite (CI order)
 
 ```bash
+npm run doctor
 npm run format:check
 npm run lint
 npm run typecheck
 npm test -- --ci
 ```
+
+**Expo Doctor** runs in GitHub **Test Check** on every PR push (including post-rebase). Local `npm run doctor` mirrors CI — run it after `npm ci` when triaging locally.
+
+If doctor fails, see [Expo + Dependabot (best practices)](#expo--dependabot-best-practices) above.
 
 Android build (mirrors `.github/workflows/build.yml`):
 
@@ -98,6 +125,7 @@ After merging multiple PRs:
 git checkout main
 git pull origin main
 npm ci
+npm run doctor
 npm run format:check
 npm run lint
 npm run typecheck

--- a/docs/guides/dependabot-resolution-log.md
+++ b/docs/guides/dependabot-resolution-log.md
@@ -20,6 +20,23 @@ Resolved: 2026-06-10
 
 ---
 
+## Batch: `main` (2026-06-30)
+
+Resolved: 2026-06-30
+
+| PR | Title / scope | Change applied |
+|----|---------------|----------------|
+| #72 | react group | **Closed** — pinned React/RN; dedicated ticket required |
+| #73 | navigation group | **Closed** — risky; needs Android smoke test |
+| #74 | testing group | **Closed** — failed CI |
+| #130 | dev-tools group (9 updates) | **Closed** — failed CI |
+
+**Left open:** #129 (@babel/core, merge candidate), #81/#127/#128 (GitHub Actions — separate review).
+
+**Verification run:** N/A (closed without merge)
+
+---
+
 ## Template (copy for each batch)
 
 ### Branch: `<branch-name>` (date)
@@ -34,6 +51,7 @@ Resolved: YYYY-MM-DD
 
 **Verification run:**
 
+- [ ] `npm run doctor`
 - [ ] `npm run format:check`
 - [ ] `npm run lint`
 - [ ] `npm run typecheck`

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@react-navigation/stack": "^7.8.4",
         "@tanstack/react-query": "^5.96.1",
         "babel-preset-expo": "~56.0.0",
-        "expo": "~56.0.11",
-        "expo-build-properties": "~56.0.18",
+        "expo": "~56.0.12",
+        "expo-build-properties": "~56.0.19",
         "expo-dev-client": "~56.0.20",
         "expo-updates": "~56.0.19",
         "lucide-react-native": "^0.544.0",
@@ -2303,13 +2303,40 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@expo/config-plugins": {
-      "version": "56.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.8.tgz",
-      "integrity": "sha512-phTuyBhgVLfqUHMjQkAfRtbyoY6yTxoKja1awtpVnEkoJDxPJuXx1KX5uvq1eZtt4bJQ08OBJ6P95INqRSHpRg==",
+    "node_modules/@expo/code-signing-certificates": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
+      "integrity": "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==",
       "license": "MIT",
       "dependencies": {
+        "node-forge": "^1.3.3"
+      }
+    },
+    "node_modules/@expo/config": {
+      "version": "56.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.9.tgz",
+      "integrity": "sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~56.0.8",
         "@expo/config-types": "^56.0.5",
+        "@expo/json-file": "^10.2.0",
+        "@expo/require-utils": "^56.1.3",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4"
+      }
+    },
+    "node_modules/@expo/config-plugins": {
+      "version": "56.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.9.tgz",
+      "integrity": "sha512-/6a/S9USwx8OC9tGjHxbviLFiBHyueN3aoNWMLvWDEJoZ1CIVW800ZBzwXq/FYNK2qzcN1LxFmQtzD1zeFQKNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^56.0.6",
         "@expo/json-file": "~10.2.0",
         "@expo/plist": "^0.7.0",
         "@expo/require-utils": "^56.1.3",
@@ -2337,10 +2364,22 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "56.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.5.tgz",
-      "integrity": "sha512-GsAHO/MwW9ZRdgnmyfRXqVGLCP/zejD6rWnp5OROp8mBGRObKm4HfrjlUyT1skjMwCj1OrURx9ZfIc6yeBAkIA==",
+      "version": "56.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.6.tgz",
+      "integrity": "sha512-4Y6Aum5J4Re5NnxGVofRNe1aDwUBOmWhQYkynZsqzRtX/zEA1ADUeyHXuEckv9YD9djiyT7bKtLt5gKL3mA6VQ==",
       "license": "MIT"
+    },
+    "node_modules/@expo/config/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@expo/devcert": {
       "version": "1.2.1",
@@ -2424,18 +2463,6 @@
         "node": ">=20.12.0"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/@expo/spawn-async": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
-      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.6"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@expo/fingerprint/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2466,13 +2493,40 @@
         "node": ">=10"
       }
     },
-    "node_modules/@expo/inline-modules": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.11.tgz",
-      "integrity": "sha512-ZlIfKL61DPnW8YUTdMEjMA31xrDDV6p7Xi8rWYyhd5qXBV8MwGwjuJ7vKeaVaMjRqxJk1N9lv7zlfyvQpRCNNw==",
+    "node_modules/@expo/image-utils": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.10.1.tgz",
+      "integrity": "sha512-YDeefvmYdihS7Wp3ESDUVnOgOSWmj2Cczm9lVNDdm4MqQLdAKm/LPYg83HtFQPfefRlAxyHrQR/O9kIXN9C1Wg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.8"
+        "@expo/require-utils": "^56.1.3",
+        "@expo/spawn-async": "^1.8.0",
+        "chalk": "^4.0.0",
+        "getenv": "^2.0.0",
+        "jimp-compact": "0.16.1",
+        "parse-png": "^2.1.0",
+        "semver": "^7.6.0"
+      }
+    },
+    "node_modules/@expo/image-utils/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/inline-modules": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.12.tgz",
+      "integrity": "sha512-SNIZr/HWfIQPTZBwmukItxpc7ws1SgMUywYq1dnQvDknQDjJcuWAasIRFUjsK15yQ1xb4G5CP7VHtbN3V4lENg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~56.0.9"
       }
     },
     "node_modules/@expo/json-file": {
@@ -2493,36 +2547,6 @@
       "dependencies": {
         "@expo/config": "~56.0.9",
         "chalk": "^4.1.2"
-      }
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@expo/config": {
-      "version": "56.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.9.tgz",
-      "integrity": "sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-plugins": "~56.0.8",
-        "@expo/config-types": "^56.0.5",
-        "@expo/json-file": "^10.2.0",
-        "@expo/require-utils": "^56.1.3",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4"
-      }
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@expo/metro": {
@@ -2561,373 +2585,221 @@
         "walker": "^1.0.8"
       }
     },
-    "node_modules/@expo/metro/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+    "node_modules/@expo/osascript": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.0.tgz",
+      "integrity": "sha512-wKIXL8UtbuX4KwavPasIW3CUcgTbYfjzLcgUhjyKUAYDEqMaf6gmU1bqz3ffBPTokmX+G8/vFG1ZuI9etQWukA==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
+        "@expo/spawn-async": "^1.8.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=12"
       }
     },
-    "node_modules/@expo/metro/node_modules/ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+    "node_modules/@expo/package-manager": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.0.tgz",
+      "integrity": "sha512-s3W3eZafJDEyVL7W/jxj2Nz3eONKxSCU604S5xj8ijrVaRz83x0DnZznLf/UXQEI1w+FyibH68nHeQyk767b1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/json-file": "^11.0.0",
+        "@expo/spawn-async": "^1.8.0",
+        "chalk": "^4.0.0",
+        "npm-package-arg": "^11.0.0",
+        "ora": "^3.4.0",
+        "resolve-workspace-root": "^2.0.0"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.0.tgz",
+      "integrity": "sha512-pHJCETqFL5x5BzNV6cEPwjwuECgGmnl0bNmfHIJ6LM1tlh2eVXi5HEdit3zby/JO/B8Otk5cgcqtJXgvvUat3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "license": "MIT"
     },
-    "node_modules/@expo/metro/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
-      "license": "MIT"
+    "node_modules/@expo/package-manager/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "node_modules/@expo/metro/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+    "node_modules/@expo/package-manager/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.35.0"
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
-      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+    "node_modules/@expo/package-manager/node_modules/log-symbols/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "accepts": "^2.0.0",
-        "ci-info": "^2.0.0",
-        "connect": "^3.6.5",
-        "debug": "^4.4.0",
-        "error-stack-parser": "^2.0.6",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.35.0",
-        "image-size": "^1.0.2",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "jsc-safe-url": "^0.2.2",
-        "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-config": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-file-map": "0.84.4",
-        "metro-resolver": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-symbolicate": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "metro-transform-worker": "0.84.4",
-        "mime-types": "^3.0.1",
-        "nullthrows": "^1.1.1",
-        "serialize-error": "^2.1.0",
-        "source-map": "^0.5.6",
-        "throat": "^5.0.0",
-        "ws": "^7.5.10",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "metro": "src/cli.js"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=4"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro-babel-transformer": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
-      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+    "node_modules/@expo/package-manager/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.25.2",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.84.4",
-        "nullthrows": "^1.1.1"
+        "mimic-fn": "^1.0.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=4"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro-cache": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
-      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+    "node_modules/@expo/package-manager/node_modules/ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
       "license": "MIT",
       "dependencies": {
-        "exponential-backoff": "^3.1.1",
-        "flow-enums-runtime": "^0.0.6",
-        "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.84.4"
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=6"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro-cache-key": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
-      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+    "node_modules/@expo/package-manager/node_modules/ora/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "license": "MIT",
       "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=4"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro-config": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
-      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+    "node_modules/@expo/package-manager/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
       "license": "MIT",
       "dependencies": {
-        "connect": "^3.6.5",
-        "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.7.0",
-        "metro": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "yaml": "^2.6.1"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=4"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro-core": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
-      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+    "node_modules/@expo/package-manager/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "license": "MIT",
       "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.84.4"
+        "ansi-regex": "^4.1.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+        "node": ">=6"
       }
     },
-    "node_modules/@expo/metro/node_modules/metro-file-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
-      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+    "node_modules/@expo/package-manager/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "fb-watchman": "^2.0.0",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "nullthrows": "^1.1.1",
-        "walker": "^1.0.7"
+        "has-flag": "^3.0.0"
       },
       "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-minify-terser": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
-      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "terser": "^5.15.0"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-resolver": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
-      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-runtime": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
-      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-source-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
-      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.84.4",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.84.4",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-symbolicate": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
-      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.84.4",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-transform-plugins": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
-      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-transform-worker": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
-      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "metro": "0.84.4",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-minify-terser": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/ob1": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
-      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=4"
       }
     },
     "node_modules/@expo/plist": {
@@ -2939,6 +2811,45 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@expo/prebuild-config": {
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.16.tgz",
+      "integrity": "sha512-ce9ENfPWO4WUWUVQz0OaqL3KYZ7YofP8O35ncnn7CHCaKwQ7BqxcCGJbh+qvP1UjlWeNB3CjHPrXXJ3bnZwlJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~56.0.9",
+        "@expo/config-plugins": "~56.0.9",
+        "@expo/config-types": "^56.0.6",
+        "@expo/image-utils": "^0.10.1",
+        "@expo/json-file": "^10.2.0",
+        "@react-native/normalize-colors": "0.85.3",
+        "debug": "^4.3.1",
+        "expo-modules-autolinking": "~56.0.16",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@expo/require-utils": {
@@ -2971,6 +2882,18 @@
       "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
       "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
       "license": "MIT"
+    },
+    "node_modules/@expo/spawn-async": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
+      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@expo/sudo-prompt": {
       "version": "9.3.2",
@@ -7235,9 +7158,9 @@
       }
     },
     "node_modules/dnssd-advertise": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.4.tgz",
-      "integrity": "sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.6.tgz",
+      "integrity": "sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==",
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -8170,15 +8093,15 @@
       }
     },
     "node_modules/expo": {
-      "version": "56.0.11",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.11.tgz",
-      "integrity": "sha512-YqF+q+JqfobDU5yFym3h1vQqzbl7rFiDB4wAJEyK6NK+KLeyf4pfzydQcNTyqLXQKcQBG1reBJExfDShoAYTzw==",
+      "version": "56.0.12",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.12.tgz",
+      "integrity": "sha512-FxgdI/Yqva6iJOThZIHfvxlKPxs4EC4uScUnEswwSArR/Fj9k430O13R590LcOQTsdNsjIs+GBHwjfoAY6vmAQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^56.1.15",
+        "@expo/cli": "^56.1.16",
         "@expo/config": "~56.0.9",
-        "@expo/config-plugins": "~56.0.8",
+        "@expo/config-plugins": "~56.0.9",
         "@expo/devtools": "~56.0.2",
         "@expo/dom-webview": "~56.0.5",
         "@expo/fingerprint": "^0.19.4",
@@ -8191,10 +8114,10 @@
         "expo-asset": "~56.0.17",
         "expo-constants": "~56.0.18",
         "expo-file-system": "~56.0.8",
-        "expo-font": "~56.0.6",
+        "expo-font": "~56.0.7",
         "expo-keep-awake": "~56.0.3",
-        "expo-modules-autolinking": "~56.0.15",
-        "expo-modules-core": "~56.0.16",
+        "expo-modules-autolinking": "~56.0.16",
+        "expo-modules-core": "~56.0.17",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -8232,9 +8155,9 @@
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "56.0.18",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-56.0.18.tgz",
-      "integrity": "sha512-at03ytur1Vfyl9ddtRMqIdSyR/oV57GM04+NZ5rhFTF0mC7dmKzxS9RBb34KHDPdT8UwUt7KsKbzYD1lnxLAKg==",
+      "version": "56.0.19",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-56.0.19.tgz",
+      "integrity": "sha512-InoviXcxWosNp4cC7L3SWoiY99Xr2HdgN+LYHb6mUm/BBVxy1mIMrZR+3PJ2gwDZzW6EJNDz8ioASWGHBTmzpA==",
       "license": "MIT",
       "dependencies": {
         "@expo/schema-utils": "^56.0.0",
@@ -8344,9 +8267,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "56.0.15",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.15.tgz",
-      "integrity": "sha512-WqpBFwLzn7DsrUkWltIjVmAjwuI1VdQ2jRMlvk1nh2kVadwdJBkSjUBQWRifsEePNhiMT/rFOovBolUU/ARt5w==",
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.16.tgz",
+      "integrity": "sha512-9JnL4N46P8ubDpDIfWolDn7nxU2j1rY67xY/dNVuyH0m+HG+r/JI16VYtjIf4COpZtEuFo4D3h3MBeFzGucMnw==",
       "license": "MIT",
       "dependencies": {
         "@expo/require-utils": "^56.1.3",
@@ -8356,18 +8279,6 @@
       },
       "bin": {
         "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
-      }
-    },
-    "node_modules/expo-modules-autolinking/node_modules/@expo/spawn-async": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
-      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.6"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/expo-modules-autolinking/node_modules/commander": {
@@ -8380,13 +8291,13 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "56.0.16",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.16.tgz",
-      "integrity": "sha512-IVdT0CnqOpQCPdemA5rb50CPbbhWeJePnvuH0yUmOmyMkNky8WVOdRQtVicoIv4CCG5hDrzPIxULD4YOHZ5CHg==",
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.17.tgz",
+      "integrity": "sha512-5J8whnT7Ccp+BrFClLmpF76omBqn95VZExroTm01Dgjm4vpty1Rb7U3we+ZUceNHtRd07Lw30u7FNfDgIhEbRQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.2.2",
-        "expo-modules-jsi": "~56.0.9",
+        "expo-modules-jsi": "~56.0.10",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -8401,9 +8312,9 @@
       }
     },
     "node_modules/expo-modules-jsi": {
-      "version": "56.0.9",
-      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.9.tgz",
-      "integrity": "sha512-2lfDkRcsP/Qh2upS+nu0MS0tfGsghc6ehTivzbgM5nJz0MGYhAJxCJSeendWM+aOQutQAwzsoxrNT0nW8lRAwA==",
+      "version": "56.0.10",
+      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.10.tgz",
+      "integrity": "sha512-fHZcFpYO/o62GYa6fJyAQJZcAShzhoN0iMMDzbr7vD3ewET6e1vAlTonbEakN9F0VHEgBFJ4NREy87uwVcpCuA==",
       "license": "MIT",
       "peerDependencies": {
         "react-native": "*"
@@ -8470,27 +8381,6 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-updates/node_modules/@expo/code-signing-certificates": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
-      "integrity": "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==",
-      "license": "MIT",
-      "dependencies": {
-        "node-forge": "^1.3.3"
-      }
-    },
-    "node_modules/expo-updates/node_modules/@expo/spawn-async": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
-      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.6"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -8506,15 +8396,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/expo-updates/node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/expo-updates/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -8525,18 +8406,18 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "56.1.15",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.15.tgz",
-      "integrity": "sha512-ik6++YzURB2d/mSEfYwbuNa19uOWZwVHy9THCQ/pPr6mzplKl4w9I4nlYF9lx7oluNC3NvxsSZ8/rgpVKEOJTA==",
+      "version": "56.1.16",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.16.tgz",
+      "integrity": "sha512-VBQn0mqAwc67b9Cn0RVXyeodghomAx5xGRhA/bXaQzuxDjMQk0zIOb6pXMZX7yiIwJW66UZt/zQiJNSv6aWJYw==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
         "@expo/config": "~56.0.9",
-        "@expo/config-plugins": "~56.0.8",
+        "@expo/config-plugins": "~56.0.9",
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.3.0",
         "@expo/image-utils": "^0.10.1",
-        "@expo/inline-modules": "^0.0.11",
+        "@expo/inline-modules": "^0.0.12",
         "@expo/json-file": "^10.2.0",
         "@expo/log-box": "^56.0.13",
         "@expo/metro": "~56.0.0",
@@ -8545,9 +8426,9 @@
         "@expo/osascript": "^2.6.0",
         "@expo/package-manager": "^1.12.1",
         "@expo/plist": "^0.7.0",
-        "@expo/prebuild-config": "^56.0.15",
+        "@expo/prebuild-config": "^56.0.16",
         "@expo/require-utils": "^56.1.3",
-        "@expo/router-server": "^56.0.13",
+        "@expo/router-server": "^56.0.14",
         "@expo/schema-utils": "^56.0.0",
         "@expo/spawn-async": "^1.8.0",
         "@expo/ws-tunnel": "^2.0.0",
@@ -8639,33 +8520,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/code-signing-certificates": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
-      "integrity": "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==",
-      "license": "MIT",
-      "dependencies": {
-        "node-forge": "^1.3.3"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/config": {
-      "version": "56.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.9.tgz",
-      "integrity": "sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-plugins": "~56.0.8",
-        "@expo/config-types": "^56.0.5",
-        "@expo/json-file": "^10.2.0",
-        "@expo/require-utils": "^56.1.3",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4"
-      }
-    },
     "node_modules/expo/node_modules/@expo/dom-webview": {
       "version": "56.0.5",
       "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-56.0.5.tgz",
@@ -8689,21 +8543,6 @@
       },
       "engines": {
         "node": ">=20.12.0"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/image-utils": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.10.1.tgz",
-      "integrity": "sha512-YDeefvmYdihS7Wp3ESDUVnOgOSWmj2Cczm9lVNDdm4MqQLdAKm/LPYg83HtFQPfefRlAxyHrQR/O9kIXN9C1Wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/require-utils": "^56.1.3",
-        "@expo/spawn-async": "^1.8.0",
-        "chalk": "^4.0.0",
-        "getenv": "^2.0.0",
-        "jimp-compact": "0.16.1",
-        "parse-png": "^2.1.0",
-        "semver": "^7.6.0"
       }
     },
     "node_modules/expo/node_modules/@expo/log-box": {
@@ -8760,62 +8599,6 @@
         "expo": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/osascript": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.6.0.tgz",
-      "integrity": "sha512-QvqDBlJXa8CS2vRORJ4wEflY1m0vVI07uSJdIRgBrLxRPBcsrXxrtU7+wXRXMqfq9zLwNP9XbvRsXF2omoDylg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/spawn-async": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/package-manager": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.12.1.tgz",
-      "integrity": "sha512-fQLiFAcFRWF53mtuLK32SUJQ1ahhrTcBZPZPedYTiUT5ha5FF+UO6bPtCc0Y/hgj0/m3HCGBAuSHjbg2kI9oPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/json-file": "^10.2.0",
-        "@expo/spawn-async": "^1.8.0",
-        "chalk": "^4.0.0",
-        "npm-package-arg": "^11.0.0",
-        "ora": "^3.4.0",
-        "resolve-workspace-root": "^2.0.0"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/prebuild-config": {
-      "version": "56.0.15",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.15.tgz",
-      "integrity": "sha512-6GC+QjdCkzp/5wjsqgfu/B2+2yf5MyZMtzf9szIPrLt9uKhzV2PdyM0vU0kvbj1YT8weHCtO7bsrzimman0sjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~56.0.9",
-        "@expo/config-plugins": "~56.0.8",
-        "@expo/config-types": "^56.0.5",
-        "@expo/image-utils": "^0.10.1",
-        "@expo/json-file": "^10.2.0",
-        "@react-native/normalize-colors": "0.85.3",
-        "debug": "^4.3.1",
-        "expo-modules-autolinking": "~56.0.15",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/spawn-async": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
-      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.6"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/expo/node_modules/@expo/ws-tunnel": {
@@ -8923,9 +8706,9 @@
       }
     },
     "node_modules/expo/node_modules/expo-font": {
-      "version": "56.0.6",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-56.0.6.tgz",
-      "integrity": "sha512-D4s72Aei844C2s8Vy61qMr6wLEjv6BMrXA1oyRQ0x8LJBbpm5gyogUohc0lABUURVLCqsnBIDdztegl3hktmmg==",
+      "version": "56.0.7",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-56.0.7.tgz",
+      "integrity": "sha512-hpU/vRwPzsby9lPGkA4blDqLIIXYzoWnCZHr6PxvcWbY/uPObAiyhh6q+e0WYsB65SthK+PLH95jEnVag7fwEg==",
       "license": "MIT",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
@@ -9003,15 +8786,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/expo/node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/expo/node_modules/onetime": {
@@ -9844,6 +9618,21 @@
       "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.10.tgz",
       "integrity": "sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w==",
       "license": "MIT"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -12624,6 +12413,366 @@
         "node": ">= 8"
       }
     },
+    "node_modules/metro": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.35.0",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-config": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-file-map": "0.84.4",
+        "metro-resolver": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-symbolicate": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "metro-transform-worker": "0.84.4",
+        "mime-types": "^3.0.1",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-babel-transformer": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-cache": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "license": "MIT",
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-cache-key": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-config": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "connect": "^3.6.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-core": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-file-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-minify-terser": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-resolver": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-source-map/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro-symbolicate": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-symbolicate/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro-transform-plugins": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-transform-worker": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.84.4",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-minify-terser": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/metro/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
+    },
+    "node_modules/metro/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/metro/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/metro/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -12883,6 +13032,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-html-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
@@ -12945,9 +13103,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12992,6 +13150,18 @@
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ob1": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -13550,9 +13720,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -14536,19 +14706,6 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
-    "node_modules/react-native/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.33.3.tgz",
@@ -14557,12 +14714,6 @@
       "dependencies": {
         "hermes-parser": "0.33.3"
       }
-    },
-    "node_modules/react-native/node_modules/ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "license": "MIT"
     },
     "node_modules/react-native/node_modules/commander": {
       "version": "12.1.0",
@@ -14588,341 +14739,6 @@
         "hermes-estree": "0.33.3"
       }
     },
-    "node_modules/react-native/node_modules/metro": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
-      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "accepts": "^2.0.0",
-        "ci-info": "^2.0.0",
-        "connect": "^3.6.5",
-        "debug": "^4.4.0",
-        "error-stack-parser": "^2.0.6",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.35.0",
-        "image-size": "^1.0.2",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "jsc-safe-url": "^0.2.2",
-        "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-config": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-file-map": "0.84.4",
-        "metro-resolver": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-symbolicate": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "metro-transform-worker": "0.84.4",
-        "mime-types": "^3.0.1",
-        "nullthrows": "^1.1.1",
-        "serialize-error": "^2.1.0",
-        "source-map": "^0.5.6",
-        "throat": "^5.0.0",
-        "ws": "^7.5.10",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "metro": "src/cli.js"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-babel-transformer": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
-      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.84.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
-      "license": "MIT"
-    },
-    "node_modules/react-native/node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.35.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-cache": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
-      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
-      "license": "MIT",
-      "dependencies": {
-        "exponential-backoff": "^3.1.1",
-        "flow-enums-runtime": "^0.0.6",
-        "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.84.4"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-cache-key": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
-      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-config": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
-      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "connect": "^3.6.5",
-        "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.7.0",
-        "metro": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-core": "0.84.4",
-        "metro-runtime": "0.84.4",
-        "yaml": "^2.6.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-core": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
-      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.84.4"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-file-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
-      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "fb-watchman": "^2.0.0",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "nullthrows": "^1.1.1",
-        "walker": "^1.0.7"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-minify-terser": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
-      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "terser": "^5.15.0"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-resolver": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
-      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-runtime": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
-      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-source-map": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
-      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.84.4",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.84.4",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-symbolicate": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
-      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.84.4",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-transform-plugins": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
-      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro-transform-worker": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
-      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "metro": "0.84.4",
-        "metro-babel-transformer": "0.84.4",
-        "metro-cache": "0.84.4",
-        "metro-cache-key": "0.84.4",
-        "metro-minify-terser": "0.84.4",
-        "metro-source-map": "0.84.4",
-        "metro-transform-plugins": "0.84.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
-    "node_modules/react-native/node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
-      "license": "MIT"
-    },
-    "node_modules/react-native/node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.35.0"
-      }
-    },
-    "node_modules/react-native/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/react-native/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/react-native/node_modules/ob1": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
-      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
     "node_modules/react-native/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -14933,15 +14749,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/react-native/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-native/node_modules/ws": {
@@ -16432,9 +16239,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{js,ts,tsx,json,css,md}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
+    "doctor": "npx expo-doctor@latest"
   },
   "dependencies": {
     "@op-engineering/op-sqlite": "^15.2.11",
@@ -22,8 +23,8 @@
     "@react-navigation/stack": "^7.8.4",
     "@tanstack/react-query": "^5.96.1",
     "babel-preset-expo": "~56.0.0",
-    "expo": "~56.0.11",
-    "expo-build-properties": "~56.0.18",
+    "expo": "~56.0.12",
+    "expo-build-properties": "~56.0.19",
     "expo-dev-client": "~56.0.20",
     "expo-updates": "~56.0.19",
     "lucide-react-native": "^0.544.0",


### PR DESCRIPTION
### 👉 TLDR

Adds `expo-doctor` to Test Check CI and the Dependabot agent workflow so dependency rebases catch Expo SDK drift before merge. Also adds agent delivery rules (never push to `main`; ticketed PRs only) and repo rule precedence over org umbrella rules.

### 👀 Reviewer Checklist

- [x] GitHub issue linked
- [x] How to verify steps included

### 🗣️ Details

Refs GH-139

https://github.com/eten-tech-foundation/fluent-mobile/issues/139

- **`npm run doctor`** — wraps `expo-doctor@latest`
- **Test Check CI** — runs doctor after `npm ci` on every PR push (including post-`@dependabot rebase`)
- **Expo patch alignment** — `expo@~56.0.12`, `expo-build-properties@~56.0.19` via `expo install --fix`
- **Dependabot docs** — doctor gate in process, workflow rule, resolution log, `/handle-dependabot` command
- **`delivery.mdc`** — all agent work via feature branch + PR; never push to `main`
- **`rule-precedence.mdc`** — ignore conflicting TangoGroup / Team Gloo umbrella rules

### ✅ How to verify

1. `npm ci && npm run doctor` — expect 21/21 checks passed
2. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
3. Confirm `.github/workflows/test.yml` includes the Expo Doctor step
4. Skim `.cursor/rules/delivery.mdc` and `dependabot-process.md` Expo Doctor section

### 🎬 Find Yourself a Solid Gif

![doctor](https://media.giphy.com/media/3o7TKqnN349PBUtGFO/giphy.gif)