### PR TITLE
[#88]: Harden API token injection with authToken accessor

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -15,7 +15,7 @@ alwaysApply: true
 
 | Layer | File(s) | Responsibility |
 |-------|---------|----------------|
-| HTTP | `services/api.ts` | `fetch`, endpoints; `Authorization: Bearer` via `getHeaders()`/`_activeToken` on `request()` only; `publicRequest()` has no bearer; `MOBILE_HEADERS` (`x-client-type: mobile`, `User-Agent: fluent-mobile`) on auth calls only (`signIn`, `forgotPassword`, `signOut`) |
+| HTTP | `services/api.ts` | `fetch`, endpoints; `Authorization: Bearer` via `buildHeaders()`/`authToken` on `request()` only; `publicRequest()` has no bearer; `MOBILE_HEADERS` (`x-client-type: mobile`, `User-Agent: fluent-mobile`) on auth calls only (`signIn`, `forgotPassword`, `signOut`) |
 | Sync | `services/sync.ts` | Orchestration, retries, sync steps |
 | KV | `services/storage.ts` | Sync timestamps, counts, errors |
 | Schema | `db/schema.ts` | `CREATE TABLE` statements |

--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,7 @@ import {
 } from './src/services/keychain';
 import AppNavigator from './src/navigation/AppNavigator';
 import { onAuthSessionExpired } from './src/services/syncEvents';
-import { setActiveToken } from './src/services/api';
+import { authToken } from './src/services/authToken';
 import { appStyles } from './src/app/appStyles';
 import { theme } from './src/theme';
 
@@ -34,7 +34,7 @@ function App() {
   useEffect(() => {
     return onAuthSessionExpired(() => {
       log.info('Session expired — returning to login');
-      setActiveToken(null);
+      authToken.set(null);
       setIsAuthenticated(false);
     });
   }, []);
@@ -50,7 +50,7 @@ function App() {
           const hasToken = await hasCredentials(activeUserId);
           if (hasToken) {
             const creds = await getCredentials(activeUserId);
-            setActiveToken(creds?.token ?? null);
+            authToken.set(creds?.token ?? null);
             setIsAuthenticated(true);
             setDbReady(true);
             return;
@@ -66,7 +66,7 @@ function App() {
           if (creds?.token) {
             const { switchActiveUser } = await import('./src/services/storage');
             switchActiveUser(userId);
-            setActiveToken(creds.token);
+            authToken.set(creds.token);
             setIsAuthenticated(true);
             setDbReady(true);
             return;

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -79,9 +79,12 @@ jest.mock('../src/services/keychain', () => ({
   getAllStoredUserIds: jest.fn(() => Promise.resolve([])),
 }));
 
-// API
-jest.mock('../src/services/api', () => ({
-  setActiveToken: jest.fn(),
+// Auth token
+jest.mock('../src/services/authToken', () => ({
+  authToken: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
 }));
 
 describe('App', () => {

--- a/src/app/screens/SettingsScreen.tsx
+++ b/src/app/screens/SettingsScreen.tsx
@@ -18,7 +18,8 @@ import {
   LOGOUT_UNSYNCED_TITLE,
 } from '../../constants/messages';
 import { getPendingUploadCount } from '../../db/queries';
-import { FluentAPI, setActiveToken } from '../../services/api';
+import { FluentAPI } from '../../services/api';
+import { authToken } from '../../services/authToken';
 import { clearCredentials, getCredentials } from '../../services/keychain';
 import {
   getActiveUserId,
@@ -83,11 +84,11 @@ export default function SettingsScreen({ onSignOut }: SettingsScreenProps) {
     if (remaining.length > 0) {
       const nextUserId = remaining[0];
       const creds = await getCredentials(nextUserId);
-      setActiveToken(creds?.token ?? null);
+      authToken.set(creds?.token ?? null);
       switchActiveUser(nextUserId);
       navigation.goBack();
     } else {
-      setActiveToken(null);
+      authToken.set(null);
       kvStorage.removeItemSync(KV_KEYS.ACTIVE_USER_ID);
       kvStorage.removeItemSync(KV_KEYS.USER_ID);
       kvStorage.removeItemSync(KV_KEYS.USER_EMAIL);

--- a/src/app/tabs/LoginScreen.tsx
+++ b/src/app/tabs/LoginScreen.tsx
@@ -18,7 +18,7 @@ import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../../types/navigation/types';
-import { setActiveToken } from '../../services/api';
+import { authToken } from '../../services/authToken';
 import { appStyles as styles } from '../appStyles';
 
 const log = logger.create('LoginScreen');
@@ -81,7 +81,7 @@ export default function LoginScreen({ onLoginSuccess }: LoginScreenProps) {
       setIsLoggingIn(true);
       const response = await FluentAPI.signIn(loginEmail.trim(), loginPassword);
       await saveTempCredentials(response.token);
-      setActiveToken(response.token);
+      authToken.set(response.token);
       kvStorage.setItemSync(KV_KEYS.USER_EMAIL, response.user.email);
       onLoginSuccess(response.user.email);
     } catch (e: unknown) {

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -14,7 +14,8 @@ import {
   switchActiveUser,
 } from '../../services/storage';
 import { clearCredentials, getCredentials } from '../../services/keychain';
-import { FluentAPI, setActiveToken } from '../../services/api';
+import { FluentAPI } from '../../services/api';
+import { authToken } from '../../services/authToken';
 import { logger } from '../../utils/logger';
 
 const log = logger.create('UserSettingsMenu');
@@ -65,7 +66,7 @@ export function UserSettingsMenu({
     if (userId === getActiveUserId()) return;
 
     const creds = await getCredentials(userId);
-    setActiveToken(creds?.token ?? null);
+    authToken.set(creds?.token ?? null);
     switchActiveUser(userId);
     onUserSwitched?.();
   };
@@ -89,11 +90,11 @@ export function UserSettingsMenu({
     if (remaining.length > 0) {
       const nextUserId = remaining[0];
       const creds = await getCredentials(nextUserId);
-      setActiveToken(creds?.token ?? null);
+      authToken.set(creds?.token ?? null);
       switchActiveUser(nextUserId);
       onUserSwitched?.();
     } else {
-      setActiveToken(null);
+      authToken.set(null);
       kvStorage.removeItemSync(KV_KEYS.ACTIVE_USER_ID);
       kvStorage.removeItemSync(KV_KEYS.USER_ID);
       kvStorage.removeItemSync(KV_KEYS.USER_EMAIL);

--- a/src/services/api.auth.test.ts
+++ b/src/services/api.auth.test.ts
@@ -2,7 +2,35 @@ jest.mock('./connectivity', () => ({
   checkServerReachable: jest.fn(),
 }));
 
-import { FluentAPI, setActiveToken } from './api';
+import { buildHeaders, FluentAPI } from './api';
+import { authToken } from './authToken';
+
+describe('buildHeaders', () => {
+  beforeEach(() => {
+    authToken.set(null);
+  });
+
+  it('omits Authorization when no token is set', () => {
+    expect(buildHeaders()).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('includes Authorization when a token is set', () => {
+    authToken.set('session-abc');
+    expect(buildHeaders()).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer session-abc',
+    });
+  });
+
+  it('merges extra headers', () => {
+    authToken.set('session-abc');
+    expect(buildHeaders({ 'x-client-type': 'mobile' })).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer session-abc',
+      'x-client-type': 'mobile',
+    });
+  });
+});
 
 describe('FluentAPI auth', () => {
   const fetchMock = jest.fn();
@@ -12,7 +40,7 @@ describe('FluentAPI auth', () => {
     jest
       .spyOn(globalThis, 'fetch')
       .mockImplementation(fetchMock as unknown as typeof fetch);
-    setActiveToken(null);
+    authToken.set(null);
   });
 
   afterEach(() => {
@@ -56,7 +84,7 @@ describe('FluentAPI auth', () => {
   });
 
   it('getUserProjects throws AuthError on 401 responses', async () => {
-    setActiveToken('revoked-token');
+    authToken.set('revoked-token');
 
     fetchMock.mockResolvedValue({
       ok: false,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from '../config/apiBaseUrl';
 import { logger } from '../utils/logger';
+import { authToken } from './authToken';
 import { parseApiErrorMessage } from './apiError';
 import { AuthError } from './authError';
 import { resolveSessionToken } from './sessionToken';
@@ -34,21 +35,20 @@ function summarizeApiErrorResponse(
   return metadata;
 }
 
-let _activeToken: string | null = null;
-
-export function setActiveToken(token: string | null): void {
-  _activeToken = token;
-}
-
 const MOBILE_HEADERS = {
   'x-client-type': 'mobile',
   'User-Agent': 'fluent-mobile',
 };
 
-async function getHeaders(): Promise<Record<string, string>> {
+/** Builds authenticated request headers; synchronous and testable. */
+export function buildHeaders(
+  extra?: Record<string, string>,
+): Record<string, string> {
+  const token = authToken.get();
   return {
     'Content-Type': 'application/json',
-    ...(_activeToken && { Authorization: `Bearer ${_activeToken}` }),
+    ...(token && { Authorization: `Bearer ${token}` }),
+    ...extra,
   };
 }
 
@@ -63,20 +63,18 @@ async function publicRequest(endpoint: string, options?: RequestInit) {
     },
   });
   if (!res.ok) {
-    try {
-      const errorBody = await res.json();
-      throw new Error(errorBody?.message ?? `API failed: ${res.status}`);
-    } catch (e) {
-      if (e instanceof Error && e.message !== `API failed: ${res.status}`)
-        throw e;
-      throw new Error(`API failed: ${res.status}`);
-    }
+    const errorBody = await res.text();
+    log.error(
+      'Public API error',
+      summarizeApiErrorResponse(res.status, errorBody),
+    );
+    throw new Error(parseApiErrorMessage(res.status, errorBody));
   }
   return res.json();
 }
 
 async function request(endpoint: string, options?: RequestInit) {
-  const headers = await getHeaders();
+  const headers = buildHeaders();
   const res = await fetch(`${getApiBaseUrl()}${endpoint}`, {
     ...options,
     headers: { ...headers, ...options?.headers },

--- a/src/services/authToken.test.ts
+++ b/src/services/authToken.test.ts
@@ -1,0 +1,22 @@
+import { authToken } from './authToken';
+
+describe('authToken', () => {
+  beforeEach(() => {
+    authToken.set(null);
+  });
+
+  it('returns null when no token is set', () => {
+    expect(authToken.get()).toBeNull();
+  });
+
+  it('stores and returns a token', () => {
+    authToken.set('session-abc');
+    expect(authToken.get()).toBe('session-abc');
+  });
+
+  it('clears a previously set token', () => {
+    authToken.set('session-abc');
+    authToken.set(null);
+    expect(authToken.get()).toBeNull();
+  });
+});

--- a/src/services/authToken.ts
+++ b/src/services/authToken.ts
@@ -1,0 +1,9 @@
+let token: string | null = null;
+
+/** In-memory bearer token for authenticated API requests. */
+export const authToken = {
+  get: (): string | null => token,
+  set: (next: string | null): void => {
+    token = next;
+  },
+};

--- a/src/services/sync.auth.test.ts
+++ b/src/services/sync.auth.test.ts
@@ -1,5 +1,6 @@
 import { AuthError } from './authError';
-import { FluentAPI, setActiveToken } from './api';
+import { FluentAPI } from './api';
+import { authToken } from './authToken';
 import {
   clearCredentials,
   getCredentials,
@@ -18,6 +19,13 @@ import {
   setSyncError,
 } from './storage';
 
+jest.mock('./authToken', () => ({
+  authToken: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
 jest.mock('./api', () => ({
   FluentAPI: {
     getLanguages: jest.fn().mockResolvedValue([]),
@@ -28,7 +36,6 @@ jest.mock('./api', () => ({
     getChapterAssignments: jest.fn().mockResolvedValue({ data: [] }),
     getBibleTexts: jest.fn(),
   },
-  setActiveToken: jest.fn(),
 }));
 
 jest.mock('./keychain', () => ({
@@ -126,7 +133,7 @@ describe('syncAllData auth handling', () => {
     );
 
     expect(clearCredentials).toHaveBeenCalledWith('2');
-    expect(setActiveToken).toHaveBeenCalledWith(null);
+    expect(authToken.set).toHaveBeenCalledWith(null);
     expect(syncEvents.emitAuthSessionExpired).toHaveBeenCalled();
     expect(FluentAPI.getUserProjects).not.toHaveBeenCalled();
   });
@@ -155,7 +162,7 @@ describe('syncAllData auth handling', () => {
 
     expect(FluentAPI.getUserProjects).toHaveBeenCalledTimes(1);
     expect(clearCredentials).toHaveBeenCalledWith('2');
-    expect(setActiveToken).toHaveBeenCalledWith(null);
+    expect(authToken.set).toHaveBeenCalledWith(null);
     expect(syncEvents.emitAuthSessionExpired).toHaveBeenCalled();
     expect(setSyncError).toHaveBeenCalledWith(
       'sync_error_projects',
@@ -265,7 +272,7 @@ describe('syncAllUsers auth handling', () => {
     expect(FluentAPI.getUserProjects).toHaveBeenCalledTimes(2);
     expect(FluentAPI.getUserProjects).toHaveBeenCalledWith(1);
     expect(FluentAPI.getUserProjects).toHaveBeenCalledWith(2);
-    expect(setActiveToken).toHaveBeenLastCalledWith('user-2-token');
+    expect(authToken.set).toHaveBeenLastCalledWith('user-2-token');
     expect(setUserLastSyncedAt).toHaveBeenCalledWith('1', expect.any(String));
     expect(setUserLastSyncedAt).toHaveBeenCalledWith('2', expect.any(String));
     expect(syncEvents.emitSyncComplete).toHaveBeenCalled();
@@ -279,7 +286,7 @@ describe('syncAllUsers auth handling', () => {
     );
 
     expect(clearCredentials).toHaveBeenCalledWith('2');
-    expect(setActiveToken).toHaveBeenCalledWith(null);
+    expect(authToken.set).toHaveBeenCalledWith(null);
     expect(syncEvents.emitAuthSessionExpired).toHaveBeenCalled();
     expect(FluentAPI.getUserProjects).not.toHaveBeenCalled();
     expect(syncEvents.emitSyncComplete).toHaveBeenCalled();
@@ -304,7 +311,7 @@ describe('syncAllUsers auth handling', () => {
     expect(clearCredentials).not.toHaveBeenCalledWith('2');
     expect(syncEvents.emitAuthSessionExpired).not.toHaveBeenCalled();
     expect(FluentAPI.getUserProjects).toHaveBeenCalledTimes(2);
-    expect(setActiveToken).toHaveBeenLastCalledWith('user-2-token');
+    expect(authToken.set).toHaveBeenLastCalledWith('user-2-token');
   });
 
   it('runs full bible text sync when any user had a full assignment sync', async () => {

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -49,7 +49,7 @@ import {
   emitSyncStart,
   emitAuthSessionExpired,
 } from './syncEvents';
-import { setActiveToken } from './api';
+import { authToken } from './authToken';
 
 const log = logger.create('SyncService');
 
@@ -63,7 +63,7 @@ function getErrorMessage(error: unknown): string {
 async function handleSyncAuthFailure(userId: string): Promise<void> {
   await clearCredentials(userId);
   if (userId === getActiveUserId()) {
-    setActiveToken(null);
+    authToken.set(null);
     emitAuthSessionExpired();
   }
 }
@@ -443,7 +443,7 @@ export async function syncAllUsers(): Promise<void> {
       }
 
       log.info('Syncing user', { userId });
-      setActiveToken(creds.token);
+      authToken.set(creds.token);
       const userIdNum = Number(userId);
       const userLastSyncedAt = getUserLastSyncedAt(userId) || undefined;
       const hasUserProjects = await userHasLocalProjects(userIdNum);
@@ -502,7 +502,7 @@ export async function syncAllUsers(): Promise<void> {
     const restoredCreds = currentActiveUserId
       ? await getCredentials(currentActiveUserId)
       : null;
-    setActiveToken(restoredCreds?.token ?? null);
+    authToken.set(restoredCreds?.token ?? null);
 
     if (activeUserSyncOk) {
       const now = new Date().toISOString();
@@ -525,7 +525,7 @@ export async function syncAllUsers(): Promise<void> {
     const restoredCreds = currentActiveUserId
       ? await getCredentials(currentActiveUserId)
       : null;
-    setActiveToken(restoredCreds?.token ?? null);
+    authToken.set(restoredCreds?.token ?? null);
     log.error('Sync all users failed', { error: getErrorMessage(error) });
     throw error;
   } finally {
@@ -550,7 +550,7 @@ export async function syncAllData(isIncremental = false, email?: string) {
         await handleSyncAuthFailure(existingUserIdStr);
         throw new AuthError('No session token. Please sign in again.');
       }
-      setActiveToken(creds.token);
+      authToken.set(creds.token);
     } else {
       const user = await syncUser(email);
       userId = user.id;


### PR DESCRIPTION
### 👉 TLDR

Replaces the mutable `_activeToken` singleton in `api.ts` with a dedicated `authToken` accessor and synchronous `buildHeaders()`. This is the first auth hardening ticket from the newbase handoff redo — it unblocks #89 (expo-secure-store) and #93 (session bootstrap).

### 👀 Reviewer Checklist

- [x] GitHub issues linked
- [x] How to verify

### 🗣️ Details

Refs #88

Epic: #115 (Authentication)

Replaces offshore handoff anti-pattern (mutable global token in `api.ts`) with an explicit, testable accessor. `publicRequest` now logs sanitized failure metadata consistent with authenticated requests.

### ✅ How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Start local fluent-api on `:9999`; set `EXPO_PUBLIC_API_BASE_URL=http://10.0.2.2:9999` in `.env`
3. Sign in → confirm sync completes
4. Sign out / switch account → confirm token clears and re-auth works

### 🎬 Find Yourself a Solid Gif

https://media.giphy.com/media/3o7TKSjRrfIPjeiVy/giphy.gif