### PR TITLE
chore: Enforce npm-only package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,13 +29,13 @@ yarn-error.log
 # testing
 /coverage
 
-# Yarn
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions
+# Other package managers — npm only (see package.json preinstall)
+.pnp.cjs
+.pnp.loader.mjs
+.pnp.js
+.yarn/
+yarn.lock
+pnpm-lock.yaml
 
 # Environment files
 .env

--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ Requires an [Expo access token](https://expo.dev/settings/access-tokens) and acc
 
 ## Troubleshooting
 
+**Accidentally ran `yarn` or `pnpm` (bootsplash / semver / PnP errors)**
+This repo uses **npm only** (`package-lock.json`). Muscle memory from other projects can run `yarn install` and leave Yarn PnP files (`.pnp.cjs`) that break `expo start`. `preinstall` blocks `yarn install` / `pnpm install`; if you already ran the wrong tool, reset and reinstall:
+
+```bash
+rm -rf .pnp.cjs .pnp.loader.mjs .pnp.js yarn.lock pnpm-lock.yaml .yarn node_modules
+npm install
+npm start
+```
+
 **`Failed to download remote update` / `No returned query result` on launch**
 Local dev builds must not check Expo OTA on startup. Rebuild after pulling latest `main`:
 

--- a/docs/guides/local-development-workflow.md
+++ b/docs/guides/local-development-workflow.md
@@ -15,7 +15,7 @@ Web app (login / project UI in browser): https://dev.app.fluent.bible
 
 ## Prerequisites
 
-- Node **≥ 24.14.0**, **npm**
+- Node **≥ 24.14.0**, **npm** (not yarn/pnpm — `preinstall` enforces npm; see [README troubleshooting](../../README.md#troubleshooting))
 - Android Studio + emulator (API 33+), or a physical Android device with USB debugging
 - **Custom dev client** — this app does not run in Expo Go (see [README](../../README.md))
 - For **Path B** only: Docker Desktop or Podman, plus a clone of [fluent-api](https://github.com/eten-tech-foundation/fluent-api)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fluent-mobile",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@op-engineering/op-sqlite": "^15.2.11",
         "@react-native-community/netinfo": "^12.0.1",
@@ -56,7 +57,8 @@
         "typescript": "~6.0.3"
       },
       "engines": {
-        "node": ">= 24.14.0"
+        "node": ">= 24.14.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "main": "index.js",
+  "packageManager": "npm@10.9.8",
   "scripts": {
+    "preinstall": "npx only-allow npm",
     "android": "expo run:android",
     "lint": "eslint .",
     "start": "expo start",
@@ -64,7 +66,8 @@
     "typescript": "~6.0.3"
   },
   "engines": {
-    "node": ">= 24.14.0"
+    "node": ">= 24.14.0",
+    "npm": ">=10.0.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.6",


### PR DESCRIPTION
### 👉 TLDR
Adds guardrails so developers who habitually use yarn on other projects don't accidentally break fluent-mobile with Yarn PnP. Blocks `yarn install` / `pnpm install`, documents recovery steps, and ignores stray lockfiles/PnP artifacts.

### 👀 Reviewer Checklist
- [x] How to verify

### 🗣️ Details
Prevents the `react-native-bootsplash` / `semver` / PnP error when someone runs `yarn start` after `yarn install` in this npm-only repo.

Changes:
- `preinstall`: `npx only-allow npm`
- `packageManager`: `npm@10.9.8` (Corepack rejects yarn/pnpm)
- `engines.npm`: `>=10.0.0`
- `.gitignore`: `.pnp.*`, `yarn.lock`, `pnpm-lock.yaml`, `.yarn/`
- README troubleshooting + local dev workflow note

### ✅ How to verify
1. `npm install` — succeeds
2. `yarn install` — fails with npm-only message (Corepack or `only-allow`)
3. `npm start` — Metro starts without bootsplash/semver PnP error
4. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci` — all pass

### 🎬 Find Yourself a Solid Gif
https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif