### PR TITLE
[#173]: Adopt Phase 1 agent/process docs

### DIFF
--- a/.cursor/commands/create-pr-branch.md
+++ b/.cursor/commands/create-pr-branch.md
@@ -5,12 +5,14 @@
 Creates a new git branch using the team naming convention:
 
 ```text
-{author}/{type}/{ticket-id}-{slug-from-title}
+{author}/{type}/{issue-number}-{slug-from-title}
 ```
 
-**Example:** `mrace/chore/fluent-123-add-cursorai-rules`
+**Example:** `mrace/chore/173-phase1-agent-process-docs`
 
 Run with `/create-pr-branch` in Cursor chat.
+
+**Tracker:** GitHub Issues for this repo right now — see [docs/issue-tracking.md](../../docs/issue-tracking.md).
 
 ## Branch name format
 
@@ -18,25 +20,28 @@ Run with `/create-pr-branch` in Cursor chat.
 | ------- | ------ | ------- |
 | `author` | Local part of `git config user.email` | `mrace` |
 | `type` | `feature`, `fix`, or `chore` only | `chore` |
-| `ticket-id` | Linear identifier, lowercase | `fluent-123` |
-| `slug` | Meaningful words from ticket title | `add-cursorai-rules` |
+| `issue-number` | GitHub issue number | `173` |
+| `slug` | Meaningful words from issue title | `phase1-agent-process-docs` |
 
-**Full pattern:** `{author}/{type}/{ticket-id}-{slug}`
+**Full pattern:** `{author}/{type}/{issue-number}-{slug}`
 
 ## When you run this command
 
 Execute these steps in order. Do not skip validation or user confirmation before creating the branch.
 
-### 1. Resolve ticket ID
+### 1. Resolve issue number
 
-- If the user message or recent conversation already includes a Linear ticket (e.g. `FLUENT-123`), use it.
-- Otherwise, **ask once**: "What's the Linear ticket ID? (e.g. FLUENT-123)"
-- Normalize to uppercase team prefix + number (e.g. `FLUENT-123`).
+- If the user message or recent conversation already includes a GitHub issue (e.g. `#173` or `173`), use it.
+- Otherwise, **ask once**: "What's the GitHub issue number? (e.g. 173)"
+- Normalize to digits only for the branch segment.
 
-### 2. Fetch Linear ticket
+### 2. Fetch GitHub issue
 
-- Use the Linear MCP `get_issue` tool with the ticket ID.
-- If the ticket is not found, report the error and stop.
+```bash
+gh issue view NNN --repo eten-tech-foundation/fluent-mobile --json number,title,labels,body
+```
+
+If the issue is not found, report the error and stop.
 
 ### 3. Resolve branch author prefix
 
@@ -55,36 +60,34 @@ If `user.email` is unset, ask the user to configure git (`git config user.email 
 
 Use **only** these three types.
 
-**Infer from Linear (in order):**
+**Infer from the GitHub issue (in order):**
 
 | Signal | Type |
 | ------ | ---- |
 | Labels contain `bug`, `bugfix`, `hotfix`, `defect` | `fix` |
-| Labels contain `chore`, `maintenance`, `tech-debt`, `dependencies` | `chore` |
+| Labels contain `chore`, `maintenance`, `tech-debt`, `dependencies`, `documentation` | `chore` |
 | Labels contain `feature`, `story`, `enhancement` | `feature` |
 | Title starts with or contains strong fix signals: `fix`, `fixes`, `fixed`, `bug`, `hotfix`, `resolve` | `fix` |
 | Title signals: `add`, `implement`, `introduce`, `support`, `enable` | `feature` |
-| Title signals: `replace`, `migrate`, `upgrade`, `bump`, `refactor`, `remove`, `cleanup`, `chore`, `update` (non-user-facing) | `chore` |
+| Title signals: `replace`, `migrate`, `upgrade`, `bump`, `refactor`, `remove`, `cleanup`, `chore`, `update`, `adopt`, `docs` (non-user-facing) | `chore` |
 
 If still ambiguous, use **AskQuestion** with: feature / fix / chore (default from best guess).
 
 ### 5. Build title slug
 
-From the Linear **title** (not description):
+From the GitHub issue **title** (not description):
 
 1. Remove prefixes like `[Mobile App]`, `(Mobile)`, etc.
 2. Lowercase the title.
 3. Split into words (alphanumeric tokens); split camelCase into words when obvious.
 4. **Drop filler words:** `a`, `an`, `the`, `and`, `or`, `but`, `for`, `with`, `from`, `into`, `to`, `of`, `in`, `on`, `at`, `by`, `as`, `is`, `are`, `was`, `were`, `be`, `been`, `being`, `this`, `that`, `these`, `those`, `it`, `its`, `via`, `using`, `use`, `please`
-5. Keep **3–6 meaningful words**; cap slug length (~45 chars after ticket id).
+5. Keep **3–6 meaningful words**; cap slug length (~45 chars after issue number).
 6. Join with single hyphens; lowercase `a-z0-9-` only.
-
-**Ticket segment:** lowercase identifier, e.g. `fluent-123`.
 
 **Final branch name:**
 
 ```text
-{author}/{type}/{ticket-id}-{slug}
+{author}/{type}/{issue-number}-{slug}
 ```
 
 ### 6. Pre-flight checks
@@ -104,8 +107,8 @@ git branch --list '{proposed-branch-name}'
 Show a short summary before creating:
 
 ```text
-Branch: mrace/chore/fluent-123-add-cursorai-rules
-Ticket: FLUENT-123 — Add Cursor AI rules
+Branch: mrace/chore/173-phase1-agent-process-docs
+Issue:  #173 — Adopt Phase 1 agent/process docs
 Base:   main @ abc1234
 ```
 
@@ -114,7 +117,7 @@ Ask: **"Create this branch?"** (or create immediately if the user was explicit).
 ### 8. Create branch
 
 ```bash
-git checkout -b "{author}/{type}/{ticket-id}-{slug}"
+git checkout -b "{author}/{type}/{issue-number}-{slug}"
 ```
 
 If branching from `main` explicitly and behind:
@@ -129,8 +132,8 @@ Report success and remind them to use `/create-pr` when ready.
 ## Integration
 
 - Pairs with `/create-pr` and `/generate-pr-description`.
-- Linear ticket in branch name enables automatic ticket detection in `/create-pr`.
-- PR title format: `[TICKET-ID]: Description` (team PR conventions).
+- Issue number in the branch name enables automatic detection in `/create-pr`.
+- PR title format: `[#NNN]: Description` (see [docs/issue-tracking.md](../../docs/issue-tracking.md)).
 
 ## Author setup (one-time per machine)
 
@@ -143,8 +146,8 @@ git config --global user.email "you@gloo.us"
 
 | User says | Action |
 | --------- | ------ |
-| `/create-pr-branch` | Ask for ticket ID, then run workflow |
-| `/create-pr-branch FLUENT-123` | Fetch ticket, propose branch, create after confirm |
+| `/create-pr-branch` | Ask for issue number, then run workflow |
+| `/create-pr-branch 173` | Fetch issue, propose branch, create after confirm |
 
 ## Rules
 
@@ -152,4 +155,4 @@ git config --global user.email "you@gloo.us"
 - **Never** use branch types outside `feature`, `fix`, `chore`.
 - **Never** force-push or delete branches unless the user explicitly asks.
 - **Always** show the final branch name before `git checkout -b`.
-- Prefer Linear MCP for ticket title; do not guess the slug from memory if the ticket can be fetched.
+- Prefer `gh issue view` for the title; do not guess the slug from memory if the issue can be fetched.

--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -2,16 +2,18 @@
 
 ## Overview
 
-Automated PR creation for **fluent-mobile** when you run `/create-pr`. Creates a GitHub PR with title, description from the repo template, and draft settings. Integrates Linear tickets and branch analysis when available.
+Automated PR creation for **fluent-mobile** when you run `/create-pr`. Creates a GitHub PR with title, description from the repo template, and draft settings. Integrates **GitHub Issues** and branch analysis.
 
-Complements team PR conventions (title `[TICKET-ID]: Description`, verification gates). Does not merge PRs.
+Complements team PR conventions (title `[#NNN]: Description`, verification gates). Does not merge PRs.
+
+**Tracker:** GitHub Issues — [docs/issue-tracking.md](../../docs/issue-tracking.md).
 
 ## What happens
 
 1. **Validate prerequisites** — branch pushed (or push with user approval), quality gates, clean intent for draft PR
-2. **Fetch Linear ticket** — from branch name via Linear MCP when possible
+2. **Fetch GitHub issue** — from branch name via `gh issue view` when possible
 3. **Analyze branch** — commits, files changed, change type
-4. **Generate title** — `[TICKET-ID]: Title` from Linear + branch
+4. **Generate title** — `[#NNN]: Title` from issue + branch
 5. **Fill template** — [`.cursor/templates/pr-template.md`](../templates/pr-template.md)
 6. **Reviewers / labels** — use team defaults if configured below; otherwise omit or ask user
 7. **Create draft PR** — via `gh pr create`
@@ -42,72 +44,62 @@ See [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) for full command 
 
 ## Title format
 
-**Always:** `TICKET-ID: Title text`
+**Always:** `[#NNN]: Title text` (or `#NNN: Title text`)
 
-**With Linear:**
+**With GitHub issue:**
 
-- Branch `mrace/chore/fluent-123-add-cursor-rules` + Linear → `FLUENT-123: Add Cursor AI rules`
+- Branch `mrace/chore/173-phase1-agent-process-docs` + issue → `[#173]: Adopt Phase 1 agent/process docs`
 
-**Without Linear (fallback):**
+**Without issue (fallback):**
 
 - `fix/sync-retry-logic` → `Fix: Sync retry logic`
-- Strip `[Mobile App]` or similar prefixes from Linear titles
+- Strip `[Mobile App]` or similar prefixes from issue titles
 
 ## Template
 
 Load [`.cursor/templates/pr-template.md`](../templates/pr-template.md) and pre-fill:
 
-**From Linear:**
+**From GitHub issue:**
 
-- TLDR, Summary (issue / root cause / solution), Related Issue URL, business impact when present
+- TLDR, Details, `Closes #NNN` when the PR completes the issue
 
 **From branch analysis:**
 
-- Technical Changes (files, line counts, key diffs)
-- Type of Change checkboxes
-- How to Test (npm setup, Metro + `npm run android`)
-
-**Manual (reviewer adds):**
-
-- Screenshots for UI changes
-- Why This Solution (technical reasoning)
+- Technical changes (files, line counts)
+- Type of change checkboxes
+- How to verify (npm setup, Metro + `npm run android` when relevant)
 
 **Delivery guardrails** (root [`AGENTS.md`](../../AGENTS.md)):
 
 - Leave **Acceptance criteria**, **Scope**, and **Android device tested** checkboxes **unchecked** unless verified.
 - Do **not** auto-check device QA for native / mic / camera / filesystem / permissions changes.
 - Do **not** mark such PRs ready for review until a human records device results.
-- Deferred AC requires a ticket-level waiver and linked follow-up issues — not only a PR “known limitations” note.
+- Deferred AC requires an issue-level waiver and linked follow-up issues — not only a PR “known limitations” note.
 
-Keep output under ~400 lines; no nested fenced code blocks inside the PR body code block when pasting via `/generate-pr-description` rules.
+Keep output under ~400 lines; no nested fenced code blocks inside the PR body.
 
-## Linear integration
+## GitHub issue integration
 
-- Detect ticket patterns from branch: `TEAM-123`, lowercase in branch segment `team-123`
-- Use Linear MCP `get_issue`; graceful fallback to git-only context
-- Link PR to Linear in **Related Issue**
+- Detect issue number from branch: `…/173-…` or leading `173-…`
+- Fetch with `gh issue view NNN --repo eten-tech-foundation/fluent-mobile`
+- Body must include `Closes #NNN` on its own line under Details when the PR completes the issue
 
 ## GitHub (`gh`)
 
 ```bash
-gh pr create --draft --title "TICKET-ID: Title" --body-file /tmp/pr-body.md
+gh pr create --draft --title "[#NNN]: Title" --body-file /tmp/pr-body.md
 ```
 
-**Reviewers / labels (confirm for this repo):**
-
-- Reviewers: `<!-- e.g. @org/team-name -->` — replace with fluent-mobile defaults when known
-- Labels: `<!-- e.g. mobile, react-native -->` — replace when known
-
-If unknown, create PR without reviewers/labels and tell the user to add them in GitHub.
+**Reviewers / labels:** omit if unknown; tell the user to add them in GitHub.
 
 ## Package manager
 
-Use **npm** only in PR text and test steps (`npm install`, `npm run lint`, etc.). Do not reference pnpm or yarn.
+Use **npm** only in PR text and test steps. Do not reference pnpm or yarn.
 
 ## Framework notes
 
-- **Expo SDK 56** + **CNG** (RN **0.85**, React **19.2.3**), **Android-only** for now
-- PR CI: lint, test, typecheck, `expo-doctor`, `expo install --check` (`.github/workflows/quality-gates.yml`); native compile via EAS preview label
+- **Expo SDK 56** + **CNG** (RN **0.85**, React **19.2.3**), **Android-only**
+- PR CI: lint, test, typecheck, `expo-doctor`, `expo install --check` (see [docs/ci.md](../../docs/ci.md)); native compile via EAS preview label
 - EAS project ID: `b0919574-f268-4768-b3bd-7cfa5172bbab`
 
 ## Branch analysis
@@ -120,20 +112,15 @@ Use **npm** only in PR text and test steps (`npm install`, `npm run lint`, etc.)
 
 Type `/create-pr` in Cursor chat.
 
-**Good for:**
-
-- Branches with Linear ticket IDs in the name
-- Branches without tickets (git-only analysis)
-- Doc-only changes (chore/docs type)
-
 **After creation:**
 
 1. Review auto-filled body (confirm AC / Scope / device-QA checkboxes match reality per [`AGENTS.md`](../../AGENTS.md))
 2. Add screenshots if UI changed
 3. Confirm reviewers/labels
-4. Mark ready for review only when CI gates **and** delivery guardrails pass (AC met or waived in ticket; device QA when required). Do not merge unless user explicitly asks.
+4. Mark ready for review only when CI gates **and** delivery guardrails pass. Do not merge unless user explicitly asks.
 
 ## Related commands
 
 - `/create-pr-branch` — create branch before work
 - `/generate-pr-description` — body only, manual GitHub PR creation
+- `/onboard`, `/dep-bump` — setup and dependency changes

--- a/.cursor/commands/dep-bump.md
+++ b/.cursor/commands/dep-bump.md
@@ -1,0 +1,78 @@
+# /dep-bump — change a dependency the Expo way
+
+You are adding, upgrading, aligning, or removing a dependency in **fluent-mobile**.
+Naive `npm install <pkg>@latest` is often **wrong** here: this is an Expo SDK **56**
+CNG app (Android-only, custom dev client — not Expo Go). Two health checks must stay
+green after dependency work:
+
+- `npx expo install --check` — Expo-managed packages at SDK-compatible versions
+- `npm run doctor` (`expo-doctor`) — config / native compatibility
+
+Proceed autonomously and report what you did; only stop at hard gates below.
+
+`$ARGUMENTS` = package(s) to add/bump. If empty, **align + validate** the current tree.
+
+## Critical facts
+
+- **Use `npx expo install <pkg>`** for anything Expo knows about (resolves SDK 56–compatible versions). Use plain `npm install` only for pure-JS packages Expo has no opinion on — then still re-run the checks.
+- **`npm run prebuild` is destructive** (`expo prebuild --clean --platform android`). Run it only when the change adds/removes a **native** module or config plugin. Pure-JS deps do not need it. **Never** pass `--platform ios` or omit the platform.
+- Package manager is **npm** only (`package-lock.json`). Do not use yarn/pnpm.
+- Agent-authored lockfile / doctor fixes still need a **ticketed PR** — never push to `main` ([delivery.mdc](../rules/delivery.mdc)).
+
+## Flow
+
+### 1. Inspect working tree
+
+```bash
+git status --porcelain
+git branch --show-current
+```
+
+Warn if on `main` or if unrelated dirty files exist. Do not commit unless the user asks.
+
+### 2. Apply the change
+
+- **Add/bump Expo-aware package(s):** `npx expo install <pkg>…`
+- **Align tree only:** `npx expo install --fix` when doctor / install-check reports drift
+- **Pure-JS:** `npm install <pkg>` then re-check
+
+### 3. Validate (blocking for this command)
+
+```bash
+npx expo install --check
+npm run doctor
+```
+
+If doctor reports SDK patch drift, `npx expo install --fix` and re-run doctor.
+
+### 4. Native regen (only if needed)
+
+If a native module or `app.config.ts` / plugin changed:
+
+```bash
+npm run prebuild
+```
+
+Do not commit generated `android/`.
+
+### 5. App gates
+
+```bash
+npm run format:check
+npm run lint
+npm run typecheck
+npm test -- --ci
+```
+
+Report pass/fail. If gates fail, fix or surface clearly — do not claim success.
+
+### 6. Report
+
+Summarize: packages touched, whether prebuild ran, doctor/install-check outcome, what to re-test on Android (especially if native).
+
+## Related
+
+- [docs/ci.md](../../docs/ci.md)
+- [docs/guides/dependabot-process.md](../../docs/guides/dependabot-process.md)
+- [`.cursor/rules/dependabot-workflow.mdc`](../rules/dependabot-workflow.mdc)
+- `/handle-dependabot` for Dependabot PR processing

--- a/.cursor/commands/generate-pr-description.md
+++ b/.cursor/commands/generate-pr-description.md
@@ -23,36 +23,36 @@ Every run **must** output a suggested title before the description block. Do not
 
 ### Format
 
-`TICKET-ID: Title text` — present tense, sentence case for title text after the colon.
+`[#NNN]: Title text` — present tense, sentence case for title text after the colon.
 
 | Source | Title ID | Example |
 |--------|----------|---------|
-| GitHub issue branch (`38-cloud-sync-status-icon`) | `#38` | `#38: Build cloud sync status icon` |
-| Linear branch segment (`fluent-123-…`) | `FLUENT-123` | `FLUENT-123: Sync retry handling` |
+| GitHub issue in branch (`…/173-…` or `38-…`) | `#173` | `[#173]: Adopt Phase 1 agent/process docs` |
 | No ticket | descriptive prefix | `Chore: Add Cursor AI rules` |
+
+**Tracker:** GitHub Issues ([docs/issue-tracking.md](../../docs/issue-tracking.md)).
 
 ### Title synthesis (apply in order)
 
-1. **Detect ticket ID** from branch name:
+1. **Detect issue number** from branch name:
+   - Author/type path: `mrace/chore/173-phase1-…` → `#173`
    - Leading digits + hyphen: `38-cloud-sync-status-icon` → `#38`
-   - Linear slug: `…/fluent-123-…` or `fluent-123-…` → `FLUENT-123` (uppercase team prefix)
 2. **Fetch issue title** when ID found:
-   - GitHub: `gh issue view N --repo eten-tech-foundation/fluent-mobile --json title`
-   - Linear: MCP when `LINEAR`/`FLUENT`/`CORE` pattern
+   - `gh issue view N --repo eten-tech-foundation/fluent-mobile --json title`
 3. **Normalize issue title** for PR title text:
    - Strip prefixes like `[Mobile App]`
    - Sentence case (first word capitalized; proper nouns unchanged)
-   - Keep concise (~60 chars after colon); trim filler ("Implement", "Add support for") only if redundant with ticket scope
-4. **Fallback** when no issue: derive from branch slug after ticket segment (`cloud-sync-status-icon` → `Cloud sync status icon`) or top commit subject (strip `#38:` prefix)
-5. **Never** output a generic title like "Update files" or only the ticket ID with no description
+   - Keep concise (~60 chars after colon); trim filler ("Implement", "Add support for") only if redundant with issue scope
+4. **Fallback** when no issue: derive from branch slug after issue segment (`cloud-sync-status-icon` → `Cloud sync status icon`) or top commit subject (strip `#38:` prefix)
+5. **Never** output a generic title like "Update files" or only the issue number with no description
 
 ### Title examples (this repo)
 
 | Branch | Issue title | Suggested PR title |
 |--------|-------------|-------------------|
-| `38-cloud-sync-status-icon` | Build Cloud Sync Status Icon | `#38: Build cloud sync status icon` |
-| `45-my-work-tab` | Build My Work tab | `#45: Build My Work tab` |
-| `mrace/fix/fluent-456-sync-retry` | — | `FLUENT-456: Sync retry handling` |
+| `mrace/chore/173-phase1-agent-process-docs` | Adopt Phase 1… | `[#173]: Adopt Phase 1 agent/process docs` |
+| `38-cloud-sync-status-icon` | Build Cloud Sync Status Icon | `[#38]: Build cloud sync status icon` |
+| `45-my-work-tab` | Build My Work tab | `[#45]: Build My Work tab` |
 
 ## Generation steps
 
@@ -67,7 +67,7 @@ gh issue view <N> --repo eten-tech-foundation/fluent-mobile --json title,body   
 1. Load template from `.cursor/templates/pr-template.md`
 2. **Synthesize PR title** (mandatory — see above)
 3. Detect branch type: `feature/`, `fix/`, `chore/` → suggest change type checkbox
-4. Fetch GitHub/Linear issue when ticket ID present
+4. Fetch GitHub issue when issue number present (`Closes #NNN` in Details)
 5. Pre-fill Technical Changes and Testing from diff + [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) gates
 
 ## Output format
@@ -107,8 +107,7 @@ gh issue view <N> --repo eten-tech-foundation/fluent-mobile --json title,body   
 
 ## Ticket patterns
 
-- GitHub issues: `#123` in PR title and **Related Issue** link
-- Linear: `FLUENT-123`, `CORE-123`, etc. (uppercase in title; lowercase in branch segment)
+- GitHub issues: `[#123]` / `#123` in PR title; `Closes #123` under Details when the PR completes the issue
 
 ## Quality checklist (pre-fill reminders)
 

--- a/.cursor/commands/onboard.md
+++ b/.cursor/commands/onboard.md
@@ -1,0 +1,66 @@
+# /onboard — fluent-mobile developer onboarding
+
+You are guiding a developer through setting up (or repairing) their local
+**fluent-mobile** environment. Be concise. Do **not** auto-install or mutate the
+machine without the developer's go-ahead.
+
+**Android-only permanently** — never suggest iOS, CocoaPods, or `expo run:ios`.
+
+## Step 1 — Fresh-clone sequence
+
+Native `android/` is gitignored (CNG). Generate it before the first Android run.
+
+```bash
+# Toolchain: Node >= 24.14.0, npm >= 10, Android Studio + SDK + JDK 17
+nvm use 24                    # or otherwise match package.json engines
+npm install
+cp .env.example .env          # set EXPO_PUBLIC_API_BASE_URL (see below)
+npm run prebuild              # expo prebuild --clean --platform android
+```
+
+Then run (two terminals, or use `npm run android` which builds the dev client):
+
+```bash
+npm start
+npm run android
+```
+
+Emulator API host: `.env.example` uses `http://10.0.2.2:9999` for host `localhost:9999`.
+Hosted / Docker API paths: [docs/guides/local-development-workflow.md](../../docs/guides/local-development-workflow.md).
+
+## Step 2 — Check environment (read-only)
+
+Summarize PASS / WARN / FAIL for:
+
+| Check | Expectation |
+| ----- | ----------- |
+| Node | `>= 24.14.0` (`node -v` vs `package.json` `engines`) |
+| npm | `>= 10` |
+| `.env` | Present; `EXPO_PUBLIC_API_BASE_URL` non-empty |
+| `android/` | Present after `npm run prebuild` (optional until first device run) |
+| Expo MCP | Authenticated before SDK/EAS work ([expo-mcp.mdc](../rules/expo-mcp.mdc)) |
+
+Offer fixes only after the developer agrees. Safe non-destructive fixes:
+
+- Missing `.env` → `cp .env.example .env`
+- Wrong Node → `nvm install 24 && nvm use 24`
+- Missing `android/` → `npm run prebuild`
+
+## Step 3 — Sanity commands
+
+```bash
+npm run lint
+npm run typecheck
+npm test -- --ci
+npm run doctor          # after native-impacting / dependency changes
+```
+
+## Step 4 — Point at docs
+
+- [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) — architecture map
+- [docs/issue-tracking.md](../../docs/issue-tracking.md) — GitHub Issues + PR linking
+- [docs/ci.md](../../docs/ci.md) — CI inventory
+- [README.md](../../README.md) — human setup
+
+Finish when env checks are green (or WARs are acknowledged), then remind them to
+start Metro and launch the Android dev client.

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": ".cursor/hooks/session-env-check.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/session-env-check.sh
+++ b/.cursor/hooks/session-env-check.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Cursor sessionStart — warn-only env blockers for fluent-mobile.
+# Never denies tools; never exits non-zero for missing optional state.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT" || exit 0
+
+WARNINGS=()
+
+# Node engines: package.json says >= 24.14.0
+if command -v node >/dev/null 2>&1; then
+  NODE_V="$(node -v 2>/dev/null | sed 's/^v//')"
+  MAJOR="$(printf '%s' "$NODE_V" | cut -d. -f1)"
+  MINOR="$(printf '%s' "$NODE_V" | cut -d. -f2)"
+  PATCH="$(printf '%s' "$NODE_V" | cut -d. -f3)"
+  if [ -z "$MAJOR" ] || [ "$MAJOR" -lt 24 ] || { [ "$MAJOR" -eq 24 ] && [ "${MINOR:-0}" -lt 14 ]; }; then
+    WARNINGS+=("Node $NODE_V is below engines (>= 24.14.0). Use nvm use 24 (or install Node 24.14+).")
+  fi
+else
+  WARNINGS+=("node not found on PATH. Install Node >= 24.14.0.")
+fi
+
+if [ ! -f .env ]; then
+  WARNINGS+=("Missing .env — run: cp .env.example .env and set EXPO_PUBLIC_API_BASE_URL.")
+elif ! grep -qE '^[[:space:]]*EXPO_PUBLIC_API_BASE_URL[[:space:]]*=[[:space:]]*[^[:space:]]+' .env 2>/dev/null; then
+  WARNINGS+=("EXPO_PUBLIC_API_BASE_URL is empty or missing in .env (see .env.example).")
+fi
+
+if [ ${#WARNINGS[@]} -eq 0 ]; then
+  exit 0
+fi
+
+MSG="$(printf '%s\n' "${WARNINGS[@]}")"
+if command -v python3 >/dev/null 2>&1; then
+  ESCAPED="$(printf '%s' "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+  printf '{"additional_context":%s}\n' "$ESCAPED"
+else
+  # Fallback: single-line JSON without python
+  ESCAPED="$(printf '%s' "$MSG" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')"
+  printf '{"additional_context":"%s"}\n' "$ESCAPED"
+fi
+
+exit 0

--- a/.cursor/rules/commands.mdc
+++ b/.cursor/rules/commands.mdc
@@ -39,7 +39,7 @@ Report what ran and the outcome. If a step was skipped, say why.
 
 ## PR workflow
 
-Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-description`, `/create-pr`. Align with team PR title format: `[TICKET-ID]: Description`.
+Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-description`, `/create-pr`, `/onboard`, `/dep-bump`, `/handle-dependabot`. Align with team PR title format: `[#NNN]: Description` (GitHub Issues — [docs/issue-tracking.md](../../docs/issue-tracking.md)). CI map: [docs/ci.md](../../docs/ci.md).
 
 ## Do not run without user request
 

--- a/.cursor/rules/delivery.mdc
+++ b/.cursor/rules/delivery.mdc
@@ -11,9 +11,9 @@ alwaysApply: true
 
 Every change — including infra, CI, docs, Dependabot follow-ups, and `expo install --fix` — goes through:
 
-1. **Linear ticket** — required; ask if missing (`FLUENT-###`)
-2. **Feature branch** — `{author}/{type}/{ticket-id}-{slug}` (see `/create-pr-branch`)
-3. **Pull request** — title `[TICKET-ID]: Description`; body `Refs [TICKET-ID]` under Details
+1. **GitHub issue** — required; ask if missing (`#NNN`). See [docs/issue-tracking.md](../../docs/issue-tracking.md). (Linear is not the tracker for this repo right now.)
+2. **Feature branch** — `{author}/{type}/{issue-number}-{slug}` (see `/create-pr-branch`)
+3. **Pull request** — title `[#NNN]: Description`; body `Closes #NNN` under Details when the PR completes the issue
 4. **Human merge** — agents open PRs and push **feature branches only**; never merge on GitHub unless the user explicitly asks for a Dependabot squash merge in that session
 
 Allowed on `main` locally: `git checkout main`, `git pull`, read-only validation after merges. **Not allowed:** `git push origin main`, commits on `main`, or opening PRs with `main` as the head branch.

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -13,6 +13,13 @@ alwaysApply: false
 - Architecture layers or sync flow change
 - New risk areas or conventions are introduced
 
+## Issue tracking & CI
+
+- [docs/issue-tracking.md](../../docs/issue-tracking.md) — GitHub Issues, branch naming, PR linking (`Closes #NNN`)
+- [docs/ci.md](../../docs/ci.md) — workflow inventory + future required-check guardrail
+
+Update these when tracker policy or CI workflows change.
+
 ## Cursor rules
 
 Keep `.cursor/rules/*.mdc` in sync with onboarding — short pointers only; avoid duplicating full onboarding content.
@@ -28,6 +35,17 @@ Keep `.cursor/rules/*.mdc` in sync with onboarding — short pointers only; avoi
 ## PR template
 
 [.cursor/templates/pr-template.md](../templates/pr-template.md) — update if required PR sections or verification steps change.
+
+## Nested hot-path notes
+
+Short pointers next to code (keep thin; link to full guides):
+
+- [src/services/AGENTS.md](../../src/services/AGENTS.md)
+- [src/db/AGENTS.md](../../src/db/AGENTS.md)
+
+## Session env hook
+
+Warn-only Cursor `sessionStart` hook: [`.cursor/hooks.json`](../hooks.json) + [`.cursor/hooks/session-env-check.sh`](../hooks/session-env-check.sh). Never deny tools.
 
 ## Style
 

--- a/.cursor/templates/pr-template.md
+++ b/.cursor/templates/pr-template.md
@@ -1,140 +1,48 @@
-## 🔥 TLDR
-<!-- One sentence summary: What was broken/needed and how you fixed it -->
+### TLDR
 
+<!-- 2–4 sentences: what changed, why, and impact. -->
 
-## 📋 Summary
-- **Issue**: <!-- What problem were you solving? -->
-- **Root Cause**: <!-- What was causing the issue? -->
-- **Solution**: <!-- How did you fix it? -->
-- **Impact**: <!-- What's the positive outcome? -->
+### Reviewer checklist
 
-**Related Issue:** <!-- Link to Linear ticket/issue -->
+- [ ] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
+- [ ] How to verify steps completed or valid waiver noted below
+- [ ] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
+- [ ] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
+- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device
 
-**Type of Change:**
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] ✨ New feature (non-breaking change that adds functionality) 
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📚 Documentation update
-- [ ] 🔧 Maintenance/refactor (no functional changes)
+### Details
 
-### Acceptance criteria
-<!-- See AGENTS.md — done means ticket AC, not green CI alone -->
-- [ ] All ticket acceptance criteria met, **or** unmet AC waived **in the ticket** with linked follow-up issues
-- [ ] No “known limitations” in this PR body without a ticket-level waiver + follow-up link
+Closes #<!-- issue number this PR completes -->
 
----
+<!-- Short summary. For fixes: root cause + solution. -->
 
-## 🔧 Technical Changes
+**Type of change:**
 
-### Key Files Modified
-<!-- List the main files changed and what was changed -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] Maintenance / refactor
 
-**`filename.tsx`**
-```tsx
-// Show key code changes with before/after if helpful
-- // Old code that was problematic
-+ // New improved code
-```
+#### Technical changes
 
-**Lines changed**: ~X lines modified | **Files modified**: X
+<!-- Key files — use **`path/to/file`** and bullets. Avoid nested ``` fences in PR bodies. -->
 
-### Dependencies & Configuration
-- [ ] No new dependencies
-- [ ] New dependencies: <!-- List any new packages -->
-- [ ] No config changes  
-- [ ] Environment/build config changes: <!-- Describe -->
-- [ ] No database changes
-- [ ] Database/storage changes: <!-- Describe with migration info -->
+#### Testing
 
-### Scope
-<!-- See AGENTS.md — one ticket = one PR -->
-- [ ] Changes are limited to this ticket; no adjacent tickets implemented or stubbed without approval
+<!-- What you ran (`npm run lint`, `npm run typecheck`, `npm test -- --ci`, …) OR waiver + rationale. -->
 
----
+### How to verify
 
-## ✅ Testing & Quality Checklist
+<!-- Numbered steps for reviewers OR "Manual verification waived" + rationale. -->
 
-### Testing Completed
-- [ ] Android device tested (REQUIRED for native / mic / camera / filesystem / permissions changes — do **not** check unless verified on a device; see `AGENTS.md`)
-- [ ] ✅ Unit tests added/updated and passing
-- [ ] ✅ Edge cases considered and tested
+1. <!-- e.g. npm run format:check && npm run lint && npm run typecheck && npm test -- --ci -->
+2. <!-- manual / Android steps when behavior changed -->
 
-### Code Quality (fluent-mobile gates)
-- [ ] ✅ `npm run lint`
-- [ ] ✅ `npm run format:check`
-- [ ] ✅ `npm run typecheck`
-- [ ] ✅ `npm test -- --ci`
-- [ ] ✅ Self-reviewed the code changes
+**Expected:** <!-- What reviewers should confirm -->
 
----
+### Follow-ups
 
-## 📸 Screenshots/Recordings
-<!-- Add screenshots for UI changes or screen recordings for interactions -->
+<!-- Deferred AC must link follow-up issues (ticket-level waiver; see AGENTS.md). -->
 
-
----
-
-## 🎯 Why This Solution?
-<!-- Explain why you chose this approach over alternatives -->
-1. **Reason 1**: <!-- Key benefit or requirement addressed -->
-2. **Reason 2**: <!-- Technical or business justification -->
-3. **Reason 3**: <!-- Long-term maintainability or performance benefit -->
-
-## 📱 Before/After
-- **Before**: <!-- What was the previous behavior/state? -->
-- **After**: <!-- What's the new behavior/state? -->
-
----
-
-## ⚠️ Breaking Changes
-<!-- List any breaking changes and migration instructions -->
-- [ ] No breaking changes
-- [ ] Breaking changes documented below:
-
-
----
-
-## 📊 Performance Impact
-<!-- Assess performance implications -->
-
-**Bundle Size:** <!-- Impact on app size -->
-- [ ] No significant impact (< 1MB)
-- [ ] Minor increase (1-5MB) 
-- [ ] Significant increase (> 5MB) - justified because:
-
-**Runtime Performance:**
-- [ ] No performance impact
-- [ ] Performance improvements
-- [ ] Potential performance concern - mitigated by:
-
-**Battery/Memory:**
-- [ ] No impact on battery or memory usage
-- [ ] Optimizations that improve battery/memory
-- [ ] Potential impact - acceptable because:
-
----
-
-## 🧪 How to Test
-<!-- Step-by-step instructions for reviewers -->
-
-**Prerequisites:** Node 24+, `npm install`, copy `.env.example` → `.env`, Metro + `npm run android`
-
-**Steps:**
-1. <!-- Step 1 -->
-2. <!-- Step 2 -->  
-3. <!-- Step 3 -->
-
-**Expected:** <!-- What reviewers should verify -->
-
----
-
-## 🔗 Additional Context
-<!-- Any additional information that reviewers should know -->
-
-
-**Deployment Notes:** <!-- Special deployment considerations -->
-
-
-**Follow-up Tasks:** <!-- Deferred AC must link to follow-up issues (ticket-level waiver required; see AGENTS.md) -->
 - [ ] <!-- e.g. #NNN — deferred AC description -->
-- [ ] <!-- Future task 2 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,5 +52,7 @@ On feature PRs with heavy agent co-authorship, reviewers should prioritize **sco
 ## Related
 
 - Delivery / branch / PR process: [`.cursor/rules/delivery.mdc`](.cursor/rules/delivery.mdc)
+- Issue tracking (GitHub Issues): [docs/issue-tracking.md](docs/issue-tracking.md)
 - CI command order: [`.cursor/rules/commands.mdc`](.cursor/rules/commands.mdc)
+- CI inventory: [docs/ci.md](docs/ci.md)
 - PR body template: [`.cursor/templates/pr-template.md`](.cursor/templates/pr-template.md)

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -215,6 +215,10 @@ When adding features: mock `op-sqlite`, navigation, and sync in screen tests fol
 
 - Human setup: [README.md](../README.md)
 - Agent delivery guardrails: [`AGENTS.md`](../AGENTS.md)
+- Issue tracking (GitHub Issues): [issue-tracking.md](issue-tracking.md)
+- CI inventory: [ci.md](ci.md)
 - Cursor rules: [`.cursor/rules/`](../.cursor/rules/) — **Android-only:** [android-only.mdc](../.cursor/rules/android-only.mdc)
 - Dependabot: [guides/dependabot-process.md](guides/dependabot-process.md) — use with `.cursor/rules/dependabot-workflow.mdc`
 - PR template: [`.cursor/templates/pr-template.md`](../.cursor/templates/pr-template.md)
+- Slash commands: `/onboard`, `/dep-bump`, `/create-pr-branch`, `/create-pr`, `/handle-dependabot` (see [`.cursor/commands/`](../.cursor/commands/))
+- Hot-path notes: [src/services/AGENTS.md](../src/services/AGENTS.md), [src/db/AGENTS.md](../src/db/AGENTS.md)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,59 @@
+# CI & quality gates
+
+This repo runs GitHub Actions on pushes and pull requests. This doc maps what runs today and records a **future** guardrail so we do not brick merges if we later make checks required.
+
+## Workflows
+
+| Workflow | Jobs (check name) | Purpose |
+| -------- | ----------------- | ------- |
+| `lint.yml` | `Lint & Format` | ESLint + Prettier (`format:check`) |
+| `test.yml` | `Unit Tests` | Jest (`npm test -- --ci`) |
+| `quality-gates.yml` | `TypeScript`, `expo-doctor`, `expo install --check` | Typecheck + Expo SDK / native-module alignment |
+| `preview-build.yml` | Preview OTA / Android EAS | On-demand when PR has label `preview-build` |
+| `eas-build.yml` | Tag → version sync | Production release path on `v*` tags |
+
+Local mirrors (run before claiming PR-ready):
+
+```bash
+npm run format:check
+npm run lint
+npm run typecheck
+npm test -- --ci
+```
+
+After dependency / Dependabot work, also:
+
+```bash
+npm ci
+npm run doctor
+```
+
+See [`.cursor/rules/commands.mdc`](../.cursor/rules/commands.mdc).
+
+## What is required today
+
+Branch protection / required status checks may change over time. Treat the table above as the **workflow inventory**. Before marking a PR ready, assume lint, test, typecheck, and Expo health jobs must be green unless a maintainer says otherwise.
+
+**This Phase 1 docs change does not alter branch protection or add new required checks.**
+
+## Preview / native compile
+
+- JS-only preview OTA vs native Android APK is decided by `preview-build.yml` + [`.github/scripts/eas-resolve-android-build.sh`](../.github/scripts/eas-resolve-android-build.sh)
+- Human QA steps: [guides/qa-preview-testing.md](guides/qa-preview-testing.md)
+- Production: tag `v*` → `eas-build.yml` + [`.eas/README.md`](../.eas/README.md)
+
+## Future guardrail — do not brick required checks
+
+If we later mark lint/test/typecheck as **required** status checks **and** want docs-only PRs to skip heavy jobs:
+
+1. Keep `on: pull_request` **without** a workflow-level `paths:` filter on those workflows.
+2. Put path scoping in a `changes` job (`dorny/paths-filter`) and skip leaf jobs with `if:` so they still **post** a `skipped` check (treated as passing).
+3. **Never** add a workflow-level `paths:` filter alone on a required check — the check never posts → PRs sit on “Expected — Waiting for status” forever.
+
+Do **not** implement that skip pattern until the team explicitly wants required checks + docs-only fast path. Until then, full CI on every PR is fine and safer.
+
+## Related
+
+- [issue-tracking.md](issue-tracking.md)
+- [AGENT_ONBOARDING.md](AGENT_ONBOARDING.md)
+- [guides/dependabot-process.md](guides/dependabot-process.md)

--- a/docs/issue-tracking.md
+++ b/docs/issue-tracking.md
@@ -1,0 +1,58 @@
+# Issue tracking (fluent-mobile)
+
+## Where to file work
+
+**GitHub Issues:** https://github.com/eten-tech-foundation/fluent-mobile/issues
+
+For now, **GitHub Issues** are the ticket tracker for this repo (not Linear). Prefer a GitHub issue for every non-trivial change before opening a PR.
+
+## Labels
+
+Use existing repo labels when they fit (`documentation`, `bug`, Dependabot labels, etc.). Do not invent a large label taxonomy in docs — keep labels light until the team agrees on a board.
+
+## Branch naming
+
+```text
+{author}/{type}/{issue-number}-{short-slug}
+```
+
+Examples:
+
+- `mrace/chore/173-phase1-agent-process-docs`
+- `mrace/fix/88-auth-token-accessor`
+- `mrace/feature/113-api-client-standard`
+
+| Segment | Values |
+| ------- | ------ |
+| `author` | Local part of `git config user.email` (e.g. `mrace`) |
+| `type` | `feature`, `fix`, or `chore` only |
+| `issue-number` | GitHub issue number (digits only in the branch segment) |
+| `slug` | 3–6 meaningful words from the issue title |
+
+See [`.cursor/commands/create-pr-branch.md`](../.cursor/commands/create-pr-branch.md).
+
+## Pull requests
+
+- **Base branch:** `main`
+- **Title:** `[#NNN]: Short description` (or `#NNN: Short description`) — match existing PR style in this repo
+- **Body:** link the issue under Details:
+  - `Closes #NNN` when the PR **completes** the issue (auto-closes on merge to `main`)
+  - For related work that must stay open, say “Part of #NNN” in prose, or link manually in the PR sidebar — do not use a closing keyword
+- **Template:** [`.cursor/templates/pr-template.md`](../.cursor/templates/pr-template.md) — generate with `/generate-pr-description` or `/create-pr`
+
+### Closing keywords
+
+Use [GitHub closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) (`Closes`, `Fixes`, `Resolves`) when the PR finishes the issue.
+
+`Refs #NNN` is **not** a GitHub closing keyword — it will not auto-close. Prefer `Closes #NNN` for completed work.
+
+## Agents / delivery
+
+- Never push commits to `main` — feature branch + PR only ([delivery.mdc](../.cursor/rules/delivery.mdc))
+- Done means acceptance criteria, not green CI alone ([AGENTS.md](../AGENTS.md))
+- Dependabot PRs: follow [guides/dependabot-process.md](guides/dependabot-process.md)
+
+## Related
+
+- [docs/ci.md](ci.md) — CI workflows and required-check guardrails
+- [docs/AGENT_ONBOARDING.md](AGENT_ONBOARDING.md) — setup and architecture map

--- a/src/db/AGENTS.md
+++ b/src/db/AGENTS.md
@@ -1,0 +1,26 @@
+# src/db — local SQLite
+
+Agents: UI reads here after sync; writes happen only in the repository. See [`.cursor/rules/architecture.mdc`](../../.cursor/rules/architecture.mdc).
+
+| File | Role |
+| ---- | ---- |
+| `schema.ts` | `CREATE TABLE` statements |
+| `index.ts` | Open DB, pragmas, create tables |
+| `db.ts` | `getDatabase()` / `setDatabase()` singleton |
+| `repository.ts` | Inserts/upserts in transactions |
+| `queries.ts` | SELECTs for UI |
+
+## Rules
+
+- Call `getDatabase()` only **after** `initializeDatabase()` (throws otherwise).
+- **No migration framework yet** — schema edits affect existing device DB files; change carefully.
+- Foreign keys are enabled in init; use transactions in `repository.ts`.
+- Screens must not write SQL — use `queries.ts` / `repository.ts`.
+
+## Adding a synced entity
+
+1. Table in `schema.ts`
+2. Types in `src/types/db/types.ts`
+3. API + sync step (`services/`)
+4. Inserts in `repository.ts`
+5. Reads in `queries.ts` if UI needs them

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -1,0 +1,23 @@
+# src/services — HTTP, auth, sync orchestration
+
+Agents: keep this layer thin. Full contract: [docs/guides/api-client-standard.md](../../docs/guides/api-client-standard.md). Architecture: [`.cursor/rules/architecture.mdc`](../../.cursor/rules/architecture.mdc).
+
+## Rules
+
+- **Screens never call `fetch`.** Add endpoints on `FluentAPI` in `api.ts` (via `httpClient`).
+- **SQLite-first reads** — UI loads from `src/db/queries.ts` after sync; do not add react-query list hooks for projects/chapters/verses.
+- **Auth** — bearer via `authToken` / `authedRequest`; `publicRequest` has no bearer. Mobile headers on auth calls only (`signIn`, `forgotPassword`, `signOut`).
+- **Sync** — orchestration + retries live in `sync.ts`; persist through `src/db/repository.ts`; KV timestamps/counts in `storage.ts`.
+- **Errors** — `ApiError` / `AuthError`; no raw response bodies in logs.
+
+## Adding an endpoint
+
+1. Types in `src/types/api/`
+2. Method on `FluentAPI`
+3. Sync step + repository write if data is cached locally
+4. Unit-test with mocked `fetch` (see `*.test.ts` siblings)
+
+## Do not
+
+- Put business SQL in this folder (use `repository` / `queries`)
+- Commit secrets or edit `.env` in PRs


### PR DESCRIPTION
### TLDR

Add high-value agent/process docs and Cursor commands to fluent-mobile — no new required CI checks, CODEOWNERS, or merge blockers.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #173`)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — N/A (docs/process only)

### Details

Closes #173

Adds issue-tracking + CI docs, a slimmer PR template, `/onboard` + `/dep-bump`, a warn-only session env hook, nested `src/services` / `src/db` AGENTS notes, and updates delivery/PR commands to use **GitHub Issues** (not Linear).

**Type of change:**

- [x] Documentation
- [x] Maintenance / refactor

#### Technical changes

- **`docs/issue-tracking.md`**, **`docs/ci.md`** — tracker + workflow inventory; future required-check `paths:` guardrail documented only
- **`.cursor/templates/pr-template.md`** — shorter; keeps AGENTS AC/scope/device-QA
- **`.cursor/commands/onboard.md`**, **`dep-bump.md`** — Android-only / Expo-correct flows
- **`.cursor/hooks.json`** + **`session-env-check.sh`** — warn-only `sessionStart`
- **`src/services/AGENTS.md`**, **`src/db/AGENTS.md`** — hot-path pointers
- Delivery / PR slash commands + `docs.mdc` / onboarding / `AGENTS.md` wired to GitHub Issues

#### Testing

- `npm run format:check` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test -- --ci` — 41 passed, 1 skipped

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Skim `docs/issue-tracking.md` and `docs/ci.md` — no workflow YAML behavior changes in this PR
3. Confirm `.cursor/hooks.json` only registers warn-only `sessionStart` (no deny hooks)

**Expected:** Docs/commands land; CI/branch protection unchanged; session hook never blocks edits.

### Follow-ups

- [ ] Later: fail-open convention guard / fluent code-reviewer only after repeated agent mistakes (out of scope for #173)