### PR TITLE
[#146]: Add upload/download over cellular toggle to Sync page

### DIFF
--- a/src/app/screens/SyncScreen.tsx
+++ b/src/app/screens/SyncScreen.tsx
@@ -1,13 +1,15 @@
-import { useState } from 'react';
 import { theme } from '../../theme';
+import { useEffect, useState } from 'react';
 import { useSync } from '../../hooks/useSync';
 import { Pause, Play, X } from 'lucide-react-native';
 import { SyncPageStatus } from '../../types/sync/types';
 import { useNavigation } from '@react-navigation/native';
 import { getPendingUploadCount } from '../../db/queries';
 import { listIconStrokeWidth } from '../../theme/iconSpecs';
+import { usePreferences } from '../../hooks/usePreferences';
 import { useConnectivity } from '../../hooks/useConnectivity';
 import { usePendingUploads } from '../../hooks/usePendingUploads';
+import { SettingsToggleRow } from '../../components/ui/SettingsListRow';
 import { ScreenContainer } from '../../components/layout/ScreenContainer';
 import { UploadProgressBar } from '../../components/ui/UploadProgressBar';
 import { StackScreenHeader } from '../../components/layout/StackScreenHeader';
@@ -34,8 +36,10 @@ export default function SyncScreen() {
   );
   const [status, setStatus] = useState<SyncPageStatus>('pending');
 
-  const { isOnline } = useConnectivity();
+  const { isOnline, isWifi } = useConnectivity();
+  const { uploadOverCellular, setUploadOverCellular } = usePreferences();
   const { hasPendingUploads } = usePendingUploads(refreshKey);
+  const effectivelyOnline = isOnline && (isWifi || uploadOverCellular);
 
   // Once the real sync finishes, re-check the pending count directly
   // (rather than relying on hasPendingUploads above, which only refetches
@@ -58,18 +62,32 @@ export default function SyncScreen() {
     },
   });
 
+  useEffect(() => {
+    if (status === 'syncing' && isOnline && !isWifi && !uploadOverCellular) {
+      setStatus('paused');
+    }
+  }, [status, isOnline, isWifi, uploadOverCellular]);
+
+  const handleSyncNow = () => {
+    if (isOnline && !isWifi && !uploadOverCellular) {
+      return;
+    }
+    triggerSync();
+    setStatus('syncing');
+  };
+
   return (
-    <ScreenContainer edges={['top']}>
+    <ScreenContainer edges={['bottom']}>
       <StackScreenHeader title="Sync" onBack={() => navigation.goBack()} />
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <View style={styles.statusSection}>
           <SyncStatusIndicator
             status={status}
-            isOnline={isOnline}
+            isOnline={effectivelyOnline}
             hasPendingUploads={hasPendingUploads}
           />
 
-          {renderStatusLine(status, isOnline, hasPendingUploads)}
+          {renderStatusLine(status, effectivelyOnline, hasPendingUploads)}
         </View>
 
         <View style={styles.uploadSection}>
@@ -87,7 +105,7 @@ export default function SyncScreen() {
           real Pause/Resume/Cancel/Sync Now wired to #150's engine.
         */}
         <View style={styles.controlsSection}>
-          {renderMockControls(status, setStatus, triggerSync)}
+          {renderMockControls(status, setStatus, handleSyncNow)}
         </View>
         {/*
           TODO: render the already-drafted downloads queue section here
@@ -95,6 +113,14 @@ export default function SyncScreen() {
           the action controls, and both this section and the
           "Upload complete" state can be visible simultaneously.
         */}
+        <View style={styles.cellularSection}>
+          <SettingsToggleRow
+            title="Upload/Download over cellular"
+            subtitle="Use mobile data to upload recordings when WiFi isn't available."
+            value={uploadOverCellular}
+            onValueChange={setUploadOverCellular}
+          />
+        </View>
       </ScrollView>
     </ScreenContainer>
   );
@@ -230,14 +256,14 @@ function renderSecondaryContent(
 // 'pending' (uploads still queued, nothing actively running); that mapping
 // isn't spec'd anywhere, just a reasonable guess for demo purposes.
 //
-// Only "Sync Now" (pending state) calls the real triggerSync(), so
+// Only "Sync Now" (pending state) calls the gated sync handler, so
 // there's at least one working manual-sync path until #151 wires up the
 // real thing. Pause, Resume, and Cancel remain visual-only — there's no
 // real pause/resume/cancel behavior to call yet (that's #150).
 function renderMockControls(
   status: SyncPageStatus,
   setStatus: (status: SyncPageStatus) => void,
-  triggerSync: () => void,
+  onSyncNow: () => void,
 ) {
   switch (status) {
     case 'syncing':
@@ -283,10 +309,7 @@ function renderMockControls(
           Icon={Play}
           variant="primary"
           fullWidth
-          onPress={() => {
-            triggerSync();
-            setStatus('syncing');
-          }}
+          onPress={onSyncNow}
         />
       );
 
@@ -371,10 +394,7 @@ const styles = StyleSheet.create({
   },
   content: {
     alignItems: 'center',
-    paddingHorizontal: theme.spacing.md,
-    paddingTop: theme.spacing.lg,
     paddingBottom: theme.spacing.lg,
-    gap: theme.spacing.md,
   },
   statusSection: {
     width: '100%',
@@ -382,18 +402,27 @@ const styles = StyleSheet.create({
     paddingVertical: theme.spacing.xl,
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.cardBackground,
   },
 
   uploadSection: {
     width: '100%',
-    paddingVertical: theme.spacing.lg,
     borderBottomWidth: 1,
+    paddingVertical: theme.spacing.lg,
+    paddingHorizontal: theme.spacing.md,
     borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.cardBackground,
   },
 
   controlsSection: {
-    width: '100%',
+    width: '90%',
     paddingVertical: theme.spacing.lg,
+  },
+
+  cellularSection: {
+    width: '100%',
+    backgroundColor: theme.colors.cardBackground,
+    overflow: 'hidden',
   },
   pausedLabel: {
     fontSize: theme.typography.sizes.md,
@@ -451,6 +480,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: theme.colors.border,
     borderRadius: theme.radius.lg,
+    backgroundColor: theme.colors.cardBackground,
   },
   controlButtonPrimary: {
     backgroundColor: theme.colors.primary,

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,10 +1,51 @@
-import { useEffect, useState } from 'react';
-import { subscribeToConnectivity } from '../services/connectivity';
+import { useCallback, useEffect, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import {
+  getConnectivitySnapshot,
+  subscribeToConnectivity,
+} from '../services/connectivity';
 
 export function useConnectivity() {
   const [isOnline, setIsOnline] = useState(true);
+  const [isWifi, setIsWifi] = useState(true);
 
-  useEffect(() => subscribeToConnectivity(setIsOnline), []);
+  const updateConnectivity = useCallback(
+    ({
+      isOnline: online,
+      isWifi: wifi,
+    }: {
+      isOnline: boolean;
+      isWifi: boolean;
+    }) => {
+      setIsOnline(online);
+      setIsWifi(wifi);
+    },
+    [],
+  );
 
-  return { isOnline };
+  useEffect(
+    () =>
+      subscribeToConnectivity((online, wifi) => {
+        updateConnectivity({ isOnline: online, isWifi: wifi });
+      }),
+    [updateConnectivity],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+
+      void getConnectivitySnapshot().then(snapshot => {
+        if (!cancelled) {
+          updateConnectivity(snapshot);
+        }
+      });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [updateConnectivity]),
+  );
+
+  return { isOnline, isWifi };
 }

--- a/src/hooks/useSyncStatus.test.ts
+++ b/src/hooks/useSyncStatus.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useSyncStatus } from './useSyncStatus';
+
+jest.mock('./useConnectivity', () => ({
+  useConnectivity: jest.fn(),
+}));
+
+jest.mock('./usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+jest.mock('./usePendingUploads', () => ({
+  usePendingUploads: jest.fn(),
+}));
+
+jest.mock('./useLocalSyncHealth', () => ({
+  useLocalSyncHealth: jest.fn(),
+}));
+
+import { useConnectivity } from './useConnectivity';
+import { usePreferences } from './usePreferences';
+import { usePendingUploads } from './usePendingUploads';
+import { useLocalSyncHealth } from './useLocalSyncHealth';
+
+const mockUseConnectivity = useConnectivity as jest.MockedFunction<
+  typeof useConnectivity
+>;
+const mockUsePreferences = usePreferences as jest.MockedFunction<
+  typeof usePreferences
+>;
+const mockUsePendingUploads = usePendingUploads as jest.MockedFunction<
+  typeof usePendingUploads
+>;
+const mockUseLocalSyncHealth = useLocalSyncHealth as jest.MockedFunction<
+  typeof useLocalSyncHealth
+>;
+
+describe('useSyncStatus cellular gate', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockUsePendingUploads.mockReturnValue({
+      pendingCount: 0,
+      hasPendingUploads: false,
+    });
+    mockUseLocalSyncHealth.mockReturnValue({
+      needsDownloadSync: false,
+      checking: false,
+    });
+  });
+
+  it('treats cellular as offline for sync chrome when uploadOverCellular is off', async () => {
+    mockUseConnectivity.mockReturnValue({ isOnline: true, isWifi: false });
+    mockUsePreferences.mockReturnValue({
+      uploadOverCellular: false,
+      preferences: { uploadOverCellular: false },
+      setUploadOverCellular: jest.fn(),
+      setPreferences: jest.fn(),
+      reload: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useSyncStatus({ isSyncing: false, refreshKey: 0 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isOnline).toBe(false);
+      expect(result.current.status).toBe('offline_synced');
+    });
+  });
+
+  it('allows cellular when uploadOverCellular is on', async () => {
+    mockUseConnectivity.mockReturnValue({ isOnline: true, isWifi: false });
+    mockUsePreferences.mockReturnValue({
+      uploadOverCellular: true,
+      preferences: { uploadOverCellular: true },
+      setUploadOverCellular: jest.fn(),
+      setPreferences: jest.fn(),
+      reload: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useSyncStatus({ isSyncing: false, refreshKey: 0 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isOnline).toBe(true);
+      expect(result.current.status).toBe('online_synced');
+    });
+  });
+});

--- a/src/hooks/useSyncStatus.ts
+++ b/src/hooks/useSyncStatus.ts
@@ -18,6 +18,7 @@ export function useSyncStatus({
   const { pendingCount, hasPendingUploads } = usePendingUploads(refreshKey);
   const { needsDownloadSync } = useLocalSyncHealth(refreshKey);
 
+  // "Online" for sync chrome means allowed to sync: WiFi, or cellular when opted in.
   const effectivelyOnline = isOnline && (isWifi || uploadOverCellular);
 
   return {

--- a/src/hooks/useSyncStatus.ts
+++ b/src/hooks/useSyncStatus.ts
@@ -1,3 +1,4 @@
+import { usePreferences } from './usePreferences';
 import { useConnectivity } from './useConnectivity';
 import { useLocalSyncHealth } from './useLocalSyncHealth';
 import { usePendingUploads } from './usePendingUploads';
@@ -12,18 +13,21 @@ export function useSyncStatus({
   isSyncing,
   refreshKey = 0,
 }: UseSyncStatusOptions) {
-  const { isOnline } = useConnectivity();
+  const { isOnline, isWifi } = useConnectivity();
+  const { uploadOverCellular } = usePreferences();
   const { pendingCount, hasPendingUploads } = usePendingUploads(refreshKey);
   const { needsDownloadSync } = useLocalSyncHealth(refreshKey);
 
+  const effectivelyOnline = isOnline && (isWifi || uploadOverCellular);
+
   return {
     status: deriveSyncStatus({
-      isOnline,
+      isOnline: effectivelyOnline,
       isSyncing,
       hasPendingUploads,
       needsDownloadSync,
     }),
-    isOnline,
+    isOnline: effectivelyOnline,
     pendingCount,
     hasPendingUploads,
     needsDownloadSync,

--- a/src/services/connectivity.test.ts
+++ b/src/services/connectivity.test.ts
@@ -1,0 +1,96 @@
+import NetInfo from '@react-native-community/netinfo';
+import { waitFor } from '@testing-library/react-native';
+import {
+  getConnectivitySnapshot,
+  subscribeToConnectivity,
+} from './connectivity';
+
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    configure: jest.fn(),
+    fetch: jest.fn(),
+    addEventListener: jest.fn(),
+  },
+}));
+
+const mockNetInfo = NetInfo as unknown as {
+  configure: jest.Mock;
+  fetch: jest.Mock;
+  addEventListener: jest.Mock;
+};
+
+type ConnectivityState = {
+  isConnected: boolean | null;
+  type: string;
+};
+
+describe('connectivity', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fetchMock.mockResolvedValue({ ok: true });
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(fetchMock as unknown as typeof fetch);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('getConnectivitySnapshot reports wifi when NetInfo type is wifi', async () => {
+    mockNetInfo.fetch.mockResolvedValue({
+      isConnected: true,
+      type: 'wifi',
+    });
+
+    await expect(getConnectivitySnapshot()).resolves.toEqual({
+      isOnline: true,
+      isWifi: true,
+    });
+  });
+
+  it('getConnectivitySnapshot reports non-wifi cellular as isWifi false', async () => {
+    mockNetInfo.fetch.mockResolvedValue({
+      isConnected: true,
+      type: 'cellular',
+    });
+
+    await expect(getConnectivitySnapshot()).resolves.toEqual({
+      isOnline: true,
+      isWifi: false,
+    });
+  });
+
+  it('subscribeToConnectivity forwards isOnline and isWifi', async () => {
+    const listener = jest.fn();
+    const handlers: Array<(state: ConnectivityState) => void> = [];
+
+    mockNetInfo.fetch.mockResolvedValue({
+      isConnected: true,
+      type: 'wifi',
+    });
+    mockNetInfo.addEventListener.mockImplementation(
+      (handler: (state: ConnectivityState) => void) => {
+        handlers.push(handler);
+        return jest.fn();
+      },
+    );
+
+    const unsubscribe = subscribeToConnectivity(listener);
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalledWith(true, true);
+    });
+
+    handlers[0]?.({ isConnected: true, type: 'cellular' });
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalledWith(true, false);
+    });
+
+    unsubscribe();
+  });
+});

--- a/src/services/connectivity.ts
+++ b/src/services/connectivity.ts
@@ -53,25 +53,47 @@ export async function resolveServerOnline(
   return checkServerReachable();
 }
 
+async function resolveConnectivityState(state: {
+  isConnected: boolean | null;
+  type: string;
+}): Promise<{ isOnline: boolean; isWifi: boolean }> {
+  const isOnline = await resolveServerOnline(state.isConnected);
+  return {
+    isOnline,
+    isWifi: state.type === 'wifi',
+  };
+}
+
+export async function getConnectivitySnapshot(): Promise<{
+  isOnline: boolean;
+  isWifi: boolean;
+}> {
+  ensureNetInfoConfigured();
+  return resolveConnectivityState(await NetInfo.fetch());
+}
+
 export function subscribeToConnectivity(
-  onChange: (isOnline: boolean) => void,
+  onChange: (isOnline: boolean, isWifi: boolean) => void,
 ): () => void {
   ensureNetInfoConfigured();
 
   let cancelled = false;
 
-  const evaluate = async (isConnected: boolean | null) => {
-    const isOnline = await resolveServerOnline(isConnected);
+  const evaluate = async (state: {
+    isConnected: boolean | null;
+    type: string;
+  }) => {
+    const { isOnline, isWifi } = await resolveConnectivityState(state);
     if (!cancelled) {
-      onChange(isOnline);
+      onChange(isOnline, isWifi);
     }
   };
 
   const unsubscribe = NetInfo.addEventListener(state => {
-    void evaluate(state.isConnected);
+    void evaluate(state);
   });
 
-  void NetInfo.fetch().then(state => evaluate(state.isConnected));
+  void NetInfo.fetch().then(evaluate);
 
   return () => {
     cancelled = true;


### PR DESCRIPTION
### 🗣️ Details

Closes #146

Mirrors the existing Settings “Upload/Download over cellular” preference on the Sync page, adds WiFi detection, and gates Sync chrome / Sync Now when on cellular with the toggle off.

**Ticket-level waivers** (recorded on #146):
- Real pause of in-flight sync/upload engine → #150
- Download worker cellular gating → #201

### ✅ Checklist

- [x] Sync page toggle mirrors Settings via `usePreferences`
- [x] WiFi vs cellular detection (`isWifi`)
- [x] Sync Now no-ops on cellular when toggle is off; status treats cellular as offline when opted out
- [x] Connectivity / preference-gate tests
- [x] Rebased onto `main` after #187 squash (no lockfile churn)

### 🧪 How to verify

**Automated**
- [x] CI on this PR
- Local: `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`

**Manual**
- [ ] Settings toggle and Sync toggle stay in sync
- [ ] On cellular with toggle off: Sync status looks offline-ish / Sync Now does not start
- [ ] On WiFi (or cellular with toggle on): Sync Now works as before