### PR TITLE
[#193]: Update settings menu to reorganize account actions

### DIFF
--- a/src/components/ui/UserSettingsMenu.test.tsx
+++ b/src/components/ui/UserSettingsMenu.test.tsx
@@ -121,8 +121,8 @@ describe('UserSettingsMenu', () => {
     const { getByText, getByTestId, queryByText } = renderMenu();
 
     expect(getByText('Accounts')).toBeTruthy();
-    expect(getByText('Active User')).toBeTruthy();
-    expect(getByText('Other User')).toBeTruthy();
+    expect(getByText('active@example.com')).toBeTruthy();
+    expect(getByText('other@example.com')).toBeTruthy();
     expect(getByTestId('settings-menu-add-user')).toBeTruthy();
     expect(getByText('Add User')).toBeTruthy();
     expect(queryByText('Switch User')).toBeNull();
@@ -181,7 +181,7 @@ describe('UserSettingsMenu', () => {
   it('does nothing when tapping the already-active user', async () => {
     const { getByText } = renderMenu();
 
-    fireEvent.press(getByText('Active User'));
+    fireEvent.press(getByText('active@example.com'));
 
     expect(mockGetCredentials).not.toHaveBeenCalled();
     expect(mockSwitchActiveUser).not.toHaveBeenCalled();
@@ -192,7 +192,7 @@ describe('UserSettingsMenu', () => {
     mockGetCredentials.mockResolvedValueOnce({ token: 'valid-token' });
     const { getByText } = renderMenu();
 
-    fireEvent.press(getByText('Other User'));
+    fireEvent.press(getByText('other@example.com'));
 
     await waitFor(() => {
       expect(mockAuthTokenSet).toHaveBeenCalledWith('valid-token');
@@ -206,7 +206,7 @@ describe('UserSettingsMenu', () => {
     mockGetCredentials.mockResolvedValueOnce(null);
     const { getByText } = renderMenu();
 
-    fireEvent.press(getByText('Other User'));
+    fireEvent.press(getByText('other@example.com'));
 
     await waitFor(() => {
       expect(Alert.alert).toHaveBeenCalledWith(
@@ -222,7 +222,7 @@ describe('UserSettingsMenu', () => {
     mockGetCredentials.mockResolvedValueOnce({ token: '' });
     const { getByText } = renderMenu();
 
-    fireEvent.press(getByText('Other User'));
+    fireEvent.press(getByText('other@example.com'));
 
     await waitFor(() => {
       expect(Alert.alert).toHaveBeenCalled();

--- a/src/components/ui/UserSettingsMenu.test.tsx
+++ b/src/components/ui/UserSettingsMenu.test.tsx
@@ -8,39 +8,20 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-const mockAuthTokenSet = jest.fn();
-jest.mock('../../services/authToken', () => ({
-  authToken: { set: (...args: unknown[]) => mockAuthTokenSet(...args) },
-}));
-
-const mockGetCredentials = jest.fn();
-const mockClearCredentials = jest.fn();
-jest.mock('../../services/keychain', () => ({
-  getCredentials: (...args: unknown[]) => mockGetCredentials(...args),
-  clearCredentials: (...args: unknown[]) => mockClearCredentials(...args),
-}));
-
-const mockSwitchActiveUser = jest.fn();
 const mockGetActiveUserId = jest.fn();
-const mockGetKnownUserIds = jest.fn();
-const mockSetItemSync = jest.fn();
 jest.mock('../../services/storage', () => ({
   getActiveUserId: (...args: unknown[]) => mockGetActiveUserId(...args),
-  getKnownUserIds: (...args: unknown[]) => mockGetKnownUserIds(...args),
-  kvStorage: { setItemSync: (...args: unknown[]) => mockSetItemSync(...args) },
-  KV_KEYS: { KNOWN_USER_IDS: 'known_user_ids' },
-  switchActiveUser: (...args: unknown[]) => mockSwitchActiveUser(...args),
+  getKnownUserIds: jest.fn(),
   MAX_DEVICE_ACCOUNTS: 3,
 }));
 
-const mockSignOutApi = jest.fn();
-jest.mock('../../services/api', () => ({
-  FluentAPI: { signOut: (...args: unknown[]) => mockSignOutApi(...args) },
-}));
-
-const mockSignOut = jest.fn();
-jest.mock('../../services/authSession', () => ({
-  signOut: (...args: unknown[]) => mockSignOut(...args),
+const mockSwitchToDeviceAccount = jest.fn();
+const mockSignOutCurrentDeviceAccount = jest.fn();
+jest.mock('../../services/accountSession', () => ({
+  switchToDeviceAccount: (...args: unknown[]) =>
+    mockSwitchToDeviceAccount(...args),
+  signOutCurrentDeviceAccount: (...args: unknown[]) =>
+    mockSignOutCurrentDeviceAccount(...args),
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -93,14 +74,9 @@ describe('UserSettingsMenu', () => {
   const anchor = { top: 0, left: 0 };
 
   beforeEach(() => {
-    // resetAllMocks (not clearAllMocks) — clearAllMocks only wipes call
-    // history, it leaves queued mockReturnValueOnce/mockResolvedValueOnce
-    // values in place, which then leak into the next test.
     jest.resetAllMocks();
 
     mockGetActiveUserId.mockReturnValue('active-1');
-    mockGetKnownUserIds.mockReturnValue(['active-1', 'other-2']);
-    mockSignOutApi.mockResolvedValue(undefined);
     setDeviceAccountsResult();
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
@@ -183,27 +159,25 @@ describe('UserSettingsMenu', () => {
 
     fireEvent.press(getByText('active@example.com'));
 
-    expect(mockGetCredentials).not.toHaveBeenCalled();
-    expect(mockSwitchActiveUser).not.toHaveBeenCalled();
+    expect(mockSwitchToDeviceAccount).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
   });
 
   it('switches successfully when the target user has a valid session', async () => {
-    mockGetCredentials.mockResolvedValueOnce({ token: 'valid-token' });
+    mockSwitchToDeviceAccount.mockResolvedValueOnce(undefined);
     const { getByText } = renderMenu();
 
     fireEvent.press(getByText('other@example.com'));
 
     await waitFor(() => {
-      expect(mockAuthTokenSet).toHaveBeenCalledWith('valid-token');
-      expect(mockSwitchActiveUser).toHaveBeenCalledWith('other-2');
+      expect(mockSwitchToDeviceAccount).toHaveBeenCalledWith('other-2');
       expect(onClose).toHaveBeenCalled();
       expect(onUserSwitched).toHaveBeenCalled();
     });
   });
 
-  it('shows an alert and does not switch when credentials are missing', async () => {
-    mockGetCredentials.mockResolvedValueOnce(null);
+  it('shows an alert when switch fails', async () => {
+    mockSwitchToDeviceAccount.mockRejectedValueOnce(new Error('missing'));
     const { getByText } = renderMenu();
 
     fireEvent.press(getByText('other@example.com'));
@@ -214,46 +188,34 @@ describe('UserSettingsMenu', () => {
         expect.stringContaining('corrupted'),
       );
     });
-    expect(mockSwitchActiveUser).not.toHaveBeenCalled();
     expect(onUserSwitched).not.toHaveBeenCalled();
   });
 
-  it('shows an alert when the stored session has no token', async () => {
-    mockGetCredentials.mockResolvedValueOnce({ token: '' });
-    const { getByText } = renderMenu();
-
-    fireEvent.press(getByText('other@example.com'));
-
-    await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalled();
+  it('signs out and notifies when switched to another account', async () => {
+    mockSignOutCurrentDeviceAccount.mockResolvedValueOnce({
+      kind: 'switched',
+      userId: 'other-2',
     });
-    expect(mockSwitchActiveUser).not.toHaveBeenCalled();
-  });
-
-  it('signs out and picks the next known user when remaining accounts exist', async () => {
-    mockGetKnownUserIds.mockReturnValue(['active-1', 'other-2']);
-    mockGetCredentials.mockResolvedValueOnce({ token: 'next-token' });
 
     const { getByText } = renderMenu();
     fireEvent.press(getByText('Sign Out'));
 
     await waitFor(() => {
-      expect(mockClearCredentials).toHaveBeenCalledWith('active-1');
-      expect(mockSwitchActiveUser).toHaveBeenCalledWith('other-2');
+      expect(mockSignOutCurrentDeviceAccount).toHaveBeenCalled();
       expect(onUserSwitched).toHaveBeenCalled();
-      expect(mockSignOut).not.toHaveBeenCalled();
+      expect(onSignOut).not.toHaveBeenCalled();
     });
   });
 
   it('fully signs out when no accounts remain', async () => {
-    mockGetKnownUserIds.mockReturnValue(['active-1']);
-    setDeviceAccountsResult({ accounts: [activeAccount] });
+    mockSignOutCurrentDeviceAccount.mockResolvedValueOnce({
+      kind: 'signed_out',
+    });
 
     const { getByText } = renderMenu();
     fireEvent.press(getByText('Sign Out'));
 
     await waitFor(() => {
-      expect(mockSignOut).toHaveBeenCalled();
       expect(onSignOut).toHaveBeenCalled();
     });
   });

--- a/src/components/ui/UserSettingsMenu.test.tsx
+++ b/src/components/ui/UserSettingsMenu.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Alert, Modal } from 'react-native';
+import { Alert } from 'react-native';
 import { UserSettingsMenu } from './UserSettingsMenu';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -23,12 +23,10 @@ jest.mock('../../services/keychain', () => ({
 const mockSwitchActiveUser = jest.fn();
 const mockGetActiveUserId = jest.fn();
 const mockGetKnownUserIds = jest.fn();
-const mockGetUserEmail = jest.fn();
 const mockSetItemSync = jest.fn();
 jest.mock('../../services/storage', () => ({
   getActiveUserId: (...args: unknown[]) => mockGetActiveUserId(...args),
   getKnownUserIds: (...args: unknown[]) => mockGetKnownUserIds(...args),
-  getUserEmail: (...args: unknown[]) => mockGetUserEmail(...args),
   kvStorage: { setItemSync: (...args: unknown[]) => mockSetItemSync(...args) },
   KV_KEYS: { KNOWN_USER_IDS: 'known_user_ids' },
   switchActiveUser: (...args: unknown[]) => mockSwitchActiveUser(...args),
@@ -49,6 +47,45 @@ jest.mock('../../utils/logger', () => ({
   logger: { create: () => ({ info: jest.fn(), error: jest.fn() }) },
 }));
 
+const mockUseDeviceAccounts = jest.fn();
+jest.mock('../../hooks/useDeviceAccounts', () => ({
+  useDeviceAccounts: (...args: unknown[]) => mockUseDeviceAccounts(...args),
+}));
+
+const activeAccount = {
+  userId: 'active-1',
+  displayName: 'Active User',
+  email: 'active@example.com',
+  initials: 'AU',
+  isActive: true,
+};
+
+const otherAccount = {
+  userId: 'other-2',
+  displayName: 'Other User',
+  email: 'other@example.com',
+  initials: 'OU',
+  isActive: false,
+};
+
+function setDeviceAccountsResult(
+  overrides: Partial<{
+    accounts: (typeof activeAccount)[];
+    hasAccountLimit: boolean;
+    loading: boolean;
+  }> = {},
+) {
+  const accounts = overrides.accounts ?? [activeAccount, otherAccount];
+  mockUseDeviceAccounts.mockReturnValue({
+    accounts,
+    accountCount: accounts.length,
+    activeUserId: 'active-1',
+    hasAccountLimit: overrides.hasAccountLimit ?? false,
+    loading: overrides.loading ?? false,
+    reload: jest.fn(),
+  });
+}
+
 describe('UserSettingsMenu', () => {
   const onClose = jest.fn();
   const onUserSwitched = jest.fn();
@@ -63,15 +100,13 @@ describe('UserSettingsMenu', () => {
 
     mockGetActiveUserId.mockReturnValue('active-1');
     mockGetKnownUserIds.mockReturnValue(['active-1', 'other-2']);
-    mockGetUserEmail.mockImplementation((id: string) =>
-      id === 'active-1' ? 'active@example.com' : 'other@example.com',
-    );
     mockSignOutApi.mockResolvedValue(undefined);
+    setDeviceAccountsResult();
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
 
   function renderMenu() {
-    const utils = render(
+    return render(
       <UserSettingsMenu
         visible
         onClose={onClose}
@@ -80,33 +115,77 @@ describe('UserSettingsMenu', () => {
         onUserSwitched={onUserSwitched}
       />,
     );
+  }
 
-    // The real Modal fires onShow natively; RN's test-environment Modal
-    // mock doesn't simulate that, so the component's onShow-triggered
-    // loadKnownUsers() never runs unless we fire it ourselves.
-    act(() => {
-      utils.UNSAFE_getByType(Modal).props.onShow();
+  it('groups accounts under Accounts with Add User below the list', () => {
+    const { getByText, getByTestId, queryByText } = renderMenu();
+
+    expect(getByText('Accounts')).toBeTruthy();
+    expect(getByText('Active User')).toBeTruthy();
+    expect(getByText('Other User')).toBeTruthy();
+    expect(getByTestId('settings-menu-add-user')).toBeTruthy();
+    expect(getByText('Add User')).toBeTruthy();
+    expect(queryByText('Switch User')).toBeNull();
+  });
+
+  it('keeps Add User out of the top group (after Privacy / Terms)', () => {
+    const { getByText, getByTestId } = renderMenu();
+    const privacy = getByTestId('settings-menu-privacy-policy');
+    const terms = getByTestId('settings-menu-terms-of-use');
+    const addUser = getByTestId('settings-menu-add-user');
+    const accountsLabel = getByText('Accounts');
+
+    expect(privacy).toBeTruthy();
+    expect(terms).toBeTruthy();
+    expect(accountsLabel).toBeTruthy();
+    expect(addUser).toBeTruthy();
+  });
+
+  it('shows the 3-account limit message instead of Add User when capped', () => {
+    setDeviceAccountsResult({
+      accounts: [
+        activeAccount,
+        otherAccount,
+        {
+          userId: 'third-3',
+          displayName: 'Third User',
+          email: 'third@example.com',
+          initials: 'TU',
+          isActive: false,
+        },
+      ],
+      hasAccountLimit: true,
     });
 
-    return utils;
-  }
+    const { getByTestId, queryByTestId } = renderMenu();
+
+    expect(getByTestId('settings-menu-account-limit')).toBeTruthy();
+    expect(queryByTestId('settings-menu-add-user')).toBeNull();
+  });
+
+  it('navigates to AddUser when Add User is pressed', () => {
+    const { getByTestId } = renderMenu();
+    fireEvent.press(getByTestId('settings-menu-add-user'));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('AddUser');
+  });
 
   it('does nothing when tapping the already-active user', async () => {
     const { getByText } = renderMenu();
-    await waitFor(() => getByText('active@example.com'));
 
-    fireEvent.press(getByText('active@example.com'));
+    fireEvent.press(getByText('Active User'));
 
     expect(mockGetCredentials).not.toHaveBeenCalled();
     expect(mockSwitchActiveUser).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 
   it('switches successfully when the target user has a valid session', async () => {
     mockGetCredentials.mockResolvedValueOnce({ token: 'valid-token' });
     const { getByText } = renderMenu();
-    await waitFor(() => getByText('other@example.com'));
 
-    fireEvent.press(getByText('other@example.com'));
+    fireEvent.press(getByText('Other User'));
 
     await waitFor(() => {
       expect(mockAuthTokenSet).toHaveBeenCalledWith('valid-token');
@@ -119,9 +198,8 @@ describe('UserSettingsMenu', () => {
   it('shows an alert and does not switch when credentials are missing', async () => {
     mockGetCredentials.mockResolvedValueOnce(null);
     const { getByText } = renderMenu();
-    await waitFor(() => getByText('other@example.com'));
 
-    fireEvent.press(getByText('other@example.com'));
+    fireEvent.press(getByText('Other User'));
 
     await waitFor(() => {
       expect(Alert.alert).toHaveBeenCalledWith(
@@ -136,9 +214,8 @@ describe('UserSettingsMenu', () => {
   it('shows an alert when the stored session has no token', async () => {
     mockGetCredentials.mockResolvedValueOnce({ token: '' });
     const { getByText } = renderMenu();
-    await waitFor(() => getByText('other@example.com'));
 
-    fireEvent.press(getByText('other@example.com'));
+    fireEvent.press(getByText('Other User'));
 
     await waitFor(() => {
       expect(Alert.alert).toHaveBeenCalled();
@@ -151,7 +228,6 @@ describe('UserSettingsMenu', () => {
     mockGetCredentials.mockResolvedValueOnce({ token: 'next-token' });
 
     const { getByText } = renderMenu();
-    await waitFor(() => getByText('Sign Out'));
     fireEvent.press(getByText('Sign Out'));
 
     await waitFor(() => {
@@ -164,9 +240,9 @@ describe('UserSettingsMenu', () => {
 
   it('fully signs out when no accounts remain', async () => {
     mockGetKnownUserIds.mockReturnValue(['active-1']);
+    setDeviceAccountsResult({ accounts: [activeAccount] });
 
     const { getByText } = renderMenu();
-    await waitFor(() => getByText('Sign Out'));
     fireEvent.press(getByText('Sign Out'));
 
     await waitFor(() => {

--- a/src/components/ui/UserSettingsMenu.test.tsx
+++ b/src/components/ui/UserSettingsMenu.test.tsx
@@ -128,6 +128,13 @@ describe('UserSettingsMenu', () => {
     expect(queryByText('Switch User')).toBeNull();
   });
 
+  it('uses leading checkmark for active and person icon for inactive (design mock)', () => {
+    const { getByTestId } = renderMenu();
+
+    expect(getByTestId('settings-menu-active-active-1')).toBeTruthy();
+    expect(getByTestId('settings-menu-inactive-other-2')).toBeTruthy();
+  });
+
   it('keeps Add User out of the top group (after Privacy / Terms)', () => {
     const { getByText, getByTestId } = renderMenu();
     const privacy = getByTestId('settings-menu-privacy-policy');

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -12,6 +12,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { UserPlus } from 'lucide-react-native';
 import { appStyles } from '../../app/appStyles';
 import { RootStackParamList } from '../../types/navigation/types';
 import {
@@ -27,6 +28,9 @@ import { signOut } from '../../services/authSession';
 import { authToken } from '../../services/authToken';
 import { useDeviceAccounts } from '../../hooks/useDeviceAccounts';
 import { logger } from '../../utils/logger';
+
+const MENU_ICON_COLOR = '#333';
+const MENU_ICON_ACTIVE = '#1a6ef5';
 
 const log = logger.create('UserSettingsMenu');
 
@@ -146,11 +150,14 @@ export function UserSettingsMenu({
             activeOpacity={0.7}
             accessibilityRole="button"
           >
-            <Ionicons name="settings-outline" size={18} color="#333" />
+            <Ionicons
+              name="settings-outline"
+              size={18}
+              color={MENU_ICON_COLOR}
+            />
             <Text style={appStyles.menuItemText}>More Settings</Text>
           </TouchableOpacity>
 
-          <View style={appStyles.menuDivider} />
           <TouchableOpacity
             style={appStyles.menuItem}
             onPress={handleOpenPrivacy}
@@ -158,7 +165,11 @@ export function UserSettingsMenu({
             accessibilityRole="button"
             testID="settings-menu-privacy-policy"
           >
-            <Ionicons name="document-text-outline" size={18} color="#333" />
+            <Ionicons
+              name="document-text-outline"
+              size={18}
+              color={MENU_ICON_COLOR}
+            />
             <Text style={appStyles.menuItemText}>Privacy Policy</Text>
           </TouchableOpacity>
 
@@ -169,7 +180,11 @@ export function UserSettingsMenu({
             accessibilityRole="button"
             testID="settings-menu-terms-of-use"
           >
-            <Ionicons name="reader-outline" size={18} color="#333" />
+            <Ionicons
+              name="shield-checkmark-outline"
+              size={18}
+              color={MENU_ICON_COLOR}
+            />
             <Text style={appStyles.menuItemText}>Terms of Use</Text>
           </TouchableOpacity>
 
@@ -181,7 +196,7 @@ export function UserSettingsMenu({
               style={styles.loadingRow}
               testID="settings-menu-accounts-loading"
             >
-              <ActivityIndicator size="small" color="#1a6ef5" />
+              <ActivityIndicator size="small" color={MENU_ICON_ACTIVE} />
             </View>
           ) : (
             accounts.map(account => (
@@ -198,9 +213,18 @@ export function UserSettingsMenu({
                 disabled={switchingUserId !== null}
                 testID={`settings-menu-account-${account.userId}`}
               >
-                <View style={styles.avatar}>
-                  <Text style={styles.avatarText}>{account.initials}</Text>
-                </View>
+                <Ionicons
+                  name={
+                    account.isActive ? 'checkmark-circle' : 'person-outline'
+                  }
+                  size={18}
+                  color={account.isActive ? MENU_ICON_ACTIVE : MENU_ICON_COLOR}
+                  testID={
+                    account.isActive
+                      ? `settings-menu-active-${account.userId}`
+                      : `settings-menu-inactive-${account.userId}`
+                  }
+                />
                 <Text
                   style={[
                     appStyles.menuItemText,
@@ -210,14 +234,6 @@ export function UserSettingsMenu({
                 >
                   {account.displayName}
                 </Text>
-                {account.isActive ? (
-                  <Ionicons
-                    name="checkmark-circle"
-                    size={18}
-                    color="#1a6ef5"
-                    testID={`settings-menu-active-${account.userId}`}
-                  />
-                ) : null}
               </TouchableOpacity>
             ))
           )}
@@ -235,7 +251,7 @@ export function UserSettingsMenu({
               accessibilityLabel="Add User"
               testID="settings-menu-add-user"
             >
-              <Ionicons name="person-add-outline" size={18} color="#333" />
+              <UserPlus size={18} color={MENU_ICON_COLOR} />
               <Text style={appStyles.menuItemText}>Add User</Text>
             </TouchableOpacity>
           )}
@@ -266,19 +282,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingVertical: 8,
-  },
-  avatar: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: '#1a6ef5',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarText: {
-    color: '#fff',
-    fontSize: 10,
-    fontWeight: '700',
   },
   limitText: {
     paddingHorizontal: 16,

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -15,17 +15,11 @@ import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { UserPlus } from 'lucide-react-native';
 import { appStyles } from '../../app/appStyles';
 import { RootStackParamList } from '../../types/navigation/types';
+import { getActiveUserId } from '../../services/storage';
 import {
-  getActiveUserId,
-  getKnownUserIds,
-  kvStorage,
-  KV_KEYS,
-  switchActiveUser,
-} from '../../services/storage';
-import { clearCredentials, getCredentials } from '../../services/keychain';
-import { FluentAPI } from '../../services/api';
-import { signOut } from '../../services/authSession';
-import { authToken } from '../../services/authToken';
+  signOutCurrentDeviceAccount,
+  switchToDeviceAccount,
+} from '../../services/accountSession';
 import { useDeviceAccounts } from '../../hooks/useDeviceAccounts';
 import { logger } from '../../utils/logger';
 
@@ -84,13 +78,7 @@ export function UserSettingsMenu({
 
     setSwitchingUserId(userId);
     try {
-      const creds = await getCredentials(userId);
-      if (!creds?.token) {
-        throw new Error('No usable stored session for this account');
-      }
-
-      authToken.set(creds.token);
-      switchActiveUser(userId);
+      await switchToDeviceAccount(userId);
       onClose();
       onUserSwitched?.();
     } catch (error) {
@@ -107,30 +95,12 @@ export function UserSettingsMenu({
 
   const handleSignOut = async () => {
     onClose();
-    const currentUserId = getActiveUserId();
-
-    try {
-      await FluentAPI.signOut();
-    } catch (e) {
-      log.error('Server sign out failed', { error: e });
-    }
-
-    await clearCredentials(currentUserId);
-
-    const remaining = getKnownUserIds().filter(id => id !== currentUserId);
-    kvStorage.setItemSync(KV_KEYS.KNOWN_USER_IDS, remaining.join(','));
-    log.info('User signed out', { userId: currentUserId });
-
-    if (remaining.length > 0) {
-      const nextUserId = remaining[0];
-      const creds = await getCredentials(nextUserId);
-      authToken.set(creds?.token ?? null);
-      switchActiveUser(nextUserId);
+    const result = await signOutCurrentDeviceAccount();
+    if (result.kind === 'switched') {
       onUserSwitched?.();
-    } else {
-      signOut();
-      onSignOut?.();
+      return;
     }
+    onSignOut?.();
   };
 
   return (

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -6,6 +6,8 @@ import {
   Modal,
   Pressable,
   Alert,
+  StyleSheet,
+  ActivityIndicator,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -15,16 +17,15 @@ import { RootStackParamList } from '../../types/navigation/types';
 import {
   getActiveUserId,
   getKnownUserIds,
-  getUserEmail,
   kvStorage,
   KV_KEYS,
   switchActiveUser,
-  MAX_DEVICE_ACCOUNTS,
 } from '../../services/storage';
 import { clearCredentials, getCredentials } from '../../services/keychain';
 import { FluentAPI } from '../../services/api';
 import { signOut } from '../../services/authSession';
 import { authToken } from '../../services/authToken';
+import { useDeviceAccounts } from '../../hooks/useDeviceAccounts';
 import { logger } from '../../utils/logger';
 
 const log = logger.create('UserSettingsMenu');
@@ -47,21 +48,8 @@ export function UserSettingsMenu({
   onUserSwitched,
 }: UserSettingsMenuProps) {
   const navigation = useNavigation<Nav>();
-  const [knownUsers, setKnownUsers] = useState<
-    Array<{ id: string; email: string }>
-  >([]);
+  const { accounts, hasAccountLimit, loading } = useDeviceAccounts(visible);
   const [switchingUserId, setSwitchingUserId] = useState<string | null>(null);
-
-  const loadKnownUsers = useCallback(() => {
-    const ids = getKnownUserIds();
-    setKnownUsers(ids.map(id => ({ id, email: getUserEmail(id) })));
-  }, []);
-
-  const atAccountLimit = knownUsers.length >= MAX_DEVICE_ACCOUNTS;
-
-  const handleOpen = () => {
-    loadKnownUsers();
-  };
 
   const handleOpenSettings = () => {
     onClose();
@@ -69,7 +57,7 @@ export function UserSettingsMenu({
   };
 
   const handleAddUser = () => {
-    if (atAccountLimit) return;
+    if (hasAccountLimit) return;
     onClose();
     navigation.navigate('AddUser');
   };
@@ -141,15 +129,12 @@ export function UserSettingsMenu({
     }
   };
 
-  const activeUserId = getActiveUserId();
-
   return (
     <Modal
       transparent
       visible={visible}
       animationType="fade"
       onRequestClose={onClose}
-      onShow={handleOpen}
     >
       <Pressable style={appStyles.modalOverlay} onPress={onClose}>
         <View
@@ -163,36 +148,6 @@ export function UserSettingsMenu({
           >
             <Ionicons name="settings-outline" size={18} color="#333" />
             <Text style={appStyles.menuItemText}>More Settings</Text>
-          </TouchableOpacity>
-
-          <View style={appStyles.menuDivider} />
-          <TouchableOpacity
-            style={[
-              appStyles.menuItem,
-              atAccountLimit && appStyles.menuItemDisabled,
-            ]}
-            onPress={handleAddUser}
-            activeOpacity={atAccountLimit ? 1 : 0.7}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: atAccountLimit }}
-            disabled={atAccountLimit}
-            testID="settings-menu-add-user"
-          >
-            <Ionicons
-              name="person-add-outline"
-              size={18}
-              color={atAccountLimit ? '#999' : '#333'}
-            />
-            <Text
-              style={[
-                appStyles.menuItemText,
-                atAccountLimit && appStyles.menuItemTextDisabled,
-              ]}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {atAccountLimit ? '3-account limit reached' : 'Add User'}
-            </Text>
           </TouchableOpacity>
 
           <View style={appStyles.menuDivider} />
@@ -218,46 +173,79 @@ export function UserSettingsMenu({
             <Text style={appStyles.menuItemText}>Terms of Use</Text>
           </TouchableOpacity>
 
-          {knownUsers.length > 1 && (
-            <>
-              <View style={appStyles.menuDivider} />
-              <Text style={appStyles.menuSectionLabel}>Switch User</Text>
-              {knownUsers.map(user => (
-                <TouchableOpacity
-                  key={user.id}
-                  style={appStyles.menuItem}
-                  onPress={() => handleSwitchUser(user.id)}
-                  activeOpacity={0.7}
-                  accessibilityRole="button"
-                  disabled={switchingUserId !== null}
+          <View style={appStyles.menuDivider} />
+          <Text style={appStyles.menuSectionLabel}>Accounts</Text>
+
+          {loading ? (
+            <View
+              style={styles.loadingRow}
+              testID="settings-menu-accounts-loading"
+            >
+              <ActivityIndicator size="small" color="#1a6ef5" />
+            </View>
+          ) : (
+            accounts.map(account => (
+              <TouchableOpacity
+                key={account.userId}
+                style={appStyles.menuItem}
+                onPress={() => {
+                  void handleSwitchUser(account.userId);
+                }}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={`Switch to ${account.displayName}`}
+                accessibilityState={{ selected: account.isActive }}
+                disabled={switchingUserId !== null}
+                testID={`settings-menu-account-${account.userId}`}
+              >
+                <View style={styles.avatar}>
+                  <Text style={styles.avatarText}>{account.initials}</Text>
+                </View>
+                <Text
+                  style={[
+                    appStyles.menuItemText,
+                    account.isActive && appStyles.menuItemActive,
+                  ]}
+                  numberOfLines={1}
                 >
+                  {account.displayName}
+                </Text>
+                {account.isActive ? (
                   <Ionicons
-                    name={
-                      user.id === activeUserId
-                        ? 'checkmark-circle'
-                        : 'person-outline'
-                    }
+                    name="checkmark-circle"
                     size={18}
-                    color={user.id === activeUserId ? '#1a6ef5' : '#333'}
+                    color="#1a6ef5"
+                    testID={`settings-menu-active-${account.userId}`}
                   />
-                  <Text
-                    style={[
-                      appStyles.menuItemText,
-                      user.id === activeUserId && appStyles.menuItemActive,
-                    ]}
-                    numberOfLines={1}
-                  >
-                    {user.email || `User ${user.id}`}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </>
+                ) : null}
+              </TouchableOpacity>
+            ))
+          )}
+
+          {hasAccountLimit ? (
+            <Text style={styles.limitText} testID="settings-menu-account-limit">
+              You&apos;ve reached the 3-account limit.
+            </Text>
+          ) : (
+            <TouchableOpacity
+              style={appStyles.menuItem}
+              onPress={handleAddUser}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Add User"
+              testID="settings-menu-add-user"
+            >
+              <Ionicons name="person-add-outline" size={18} color="#333" />
+              <Text style={appStyles.menuItemText}>Add User</Text>
+            </TouchableOpacity>
           )}
 
           <View style={appStyles.menuDivider} />
           <TouchableOpacity
             style={appStyles.menuItem}
-            onPress={handleSignOut}
+            onPress={() => {
+              void handleSignOut();
+            }}
             activeOpacity={0.7}
             accessibilityRole="button"
           >
@@ -271,3 +259,32 @@ export function UserSettingsMenu({
     </Modal>
   );
 }
+
+const styles = StyleSheet.create({
+  loadingRow: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 8,
+  },
+  avatar: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#1a6ef5',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  limitText: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 13,
+    color: '#999',
+    textAlign: 'center',
+  },
+});

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -199,43 +199,49 @@ export function UserSettingsMenu({
               <ActivityIndicator size="small" color={MENU_ICON_ACTIVE} />
             </View>
           ) : (
-            accounts.map(account => (
-              <TouchableOpacity
-                key={account.userId}
-                style={appStyles.menuItem}
-                onPress={() => {
-                  void handleSwitchUser(account.userId);
-                }}
-                activeOpacity={0.7}
-                accessibilityRole="button"
-                accessibilityLabel={`Switch to ${account.displayName}`}
-                accessibilityState={{ selected: account.isActive }}
-                disabled={switchingUserId !== null}
-                testID={`settings-menu-account-${account.userId}`}
-              >
-                <Ionicons
-                  name={
-                    account.isActive ? 'checkmark-circle' : 'person-outline'
-                  }
-                  size={18}
-                  color={account.isActive ? MENU_ICON_ACTIVE : MENU_ICON_COLOR}
-                  testID={
-                    account.isActive
-                      ? `settings-menu-active-${account.userId}`
-                      : `settings-menu-inactive-${account.userId}`
-                  }
-                />
-                <Text
-                  style={[
-                    appStyles.menuItemText,
-                    account.isActive && appStyles.menuItemActive,
-                  ]}
-                  numberOfLines={1}
+            accounts.map(account => {
+              // Mockup (#193) labels accounts by email; fall back to displayName.
+              const accountLabel = account.email || account.displayName;
+              return (
+                <TouchableOpacity
+                  key={account.userId}
+                  style={appStyles.menuItem}
+                  onPress={() => {
+                    void handleSwitchUser(account.userId);
+                  }}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Switch to ${accountLabel}`}
+                  accessibilityState={{ selected: account.isActive }}
+                  disabled={switchingUserId !== null}
+                  testID={`settings-menu-account-${account.userId}`}
                 >
-                  {account.displayName}
-                </Text>
-              </TouchableOpacity>
-            ))
+                  <Ionicons
+                    name={
+                      account.isActive ? 'checkmark-circle' : 'person-outline'
+                    }
+                    size={18}
+                    color={
+                      account.isActive ? MENU_ICON_ACTIVE : MENU_ICON_COLOR
+                    }
+                    testID={
+                      account.isActive
+                        ? `settings-menu-active-${account.userId}`
+                        : `settings-menu-inactive-${account.userId}`
+                    }
+                  />
+                  <Text
+                    style={[
+                      appStyles.menuItemText,
+                      account.isActive && appStyles.menuItemActive,
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {accountLabel}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })
           )}
 
           {hasAccountLimit ? (


### PR DESCRIPTION
### TLDR

Reorganizes the settings overflow menu so account management is one section: rename Switch User → Accounts, keep the account list with the active checkmark, and move Add User under that list (hidden at the 3-account cap with the existing limit message). Visual layout and icons match the #193 design mock (top group without internal dividers; person / blue checkmark leading icons; shield Terms; Lucide UserPlus for Add User).

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #193

Groups account actions in `UserSettingsMenu` so Add User sits with the multi-account list instead of above Privacy / Terms. Uses existing `useDeviceAccounts` for the list and cap. Updated to match the ticket mockup after a design pass.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/components/ui/UserSettingsMenu.tsx`** — Accounts section; Add User (or 3-account limit copy) under the list; More Settings / Privacy / Terms as one undivided top group; leading `person-outline` / blue `checkmark-circle` (not initials avatars); Terms `shield-checkmark-outline`; Add User Lucide `UserPlus`
- **`src/components/ui/UserSettingsMenu.test.tsx`** — Layout, limit, switch/sign-out, and leading-icon coverage

#### Testing

`npm run lint`, `npm run typecheck`, `npm test -- --ci --testPathPattern=UserSettingsMenu` (11 passed).

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. On Android: open the user settings menu — compare to the #193 mock: top group (More Settings, Privacy, Terms), Accounts list with person vs blue checkmark + blue active email, Add User with user-plus, red Sign Out
3. With 3 accounts — Add User hidden; “You've reached the 3-account limit” shown

**Expected:** Menu structure and icons match the ticket design; switch/add/sign-out behavior unchanged aside from layout.

### Follow-ups

- None for this issue. Related foundation work is in separate PRs (#205 accountSession, etc.).
