### PR TITLE
[#151]: Build Sync page action controls

### DIFF
--- a/src/app/screens/SyncScreen.tsx
+++ b/src/app/screens/SyncScreen.tsx
@@ -1,11 +1,9 @@
 import { theme } from '../../theme';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSync } from '../../hooks/useSync';
-import { Pause, Play, X } from 'lucide-react-native';
 import { SyncPageStatus } from '../../types/sync/types';
 import { useNavigation } from '@react-navigation/native';
 import { getPendingUploadCount } from '../../db/queries';
-import { listIconStrokeWidth } from '../../theme/iconSpecs';
 import { usePreferences } from '../../hooks/usePreferences';
 import { useConnectivity } from '../../hooks/useConnectivity';
 import { usePendingUploads } from '../../hooks/usePendingUploads';
@@ -15,16 +13,11 @@ import { UploadProgressBar } from '../../components/ui/UploadProgressBar';
 import { StackScreenHeader } from '../../components/layout/StackScreenHeader';
 import { SyncStatusIndicator } from '../../components/ui/SyncStatusIndicator';
 import { CloudSyncStatusIcon } from '../../components/ui/CloudSyncStatusIcon';
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { SyncActionControls } from '../../components/ui/SyncActionControls';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 // TODO(#150): status/uploadedChapters/totalChapters/nextRetryAt are mock
-// state for the UI-only #149 ticket. Replace with real derivation once
+// state until the upload orchestrator owns them.
 export default function SyncScreen() {
   const navigation = useNavigation();
 
@@ -40,6 +33,7 @@ export default function SyncScreen() {
   const { uploadOverCellular, setUploadOverCellular } = usePreferences();
   const { hasPendingUploads } = usePendingUploads(refreshKey);
   const effectivelyOnline = isOnline && (isWifi || uploadOverCellular);
+  const cellularBlocked = isOnline && !isWifi && !uploadOverCellular;
 
   // Once the real sync finishes, re-check the pending count directly
   // (rather than relying on hasPendingUploads above, which only refetches
@@ -51,7 +45,7 @@ export default function SyncScreen() {
   // "no downloads pending" too, and there's no download-queue signal to
   // check yet (that section is still a TODO). It'll stay dead code until
   // that integration exists.
-  const { triggerSync } = useSync({
+  const { triggerSync, isSyncing } = useSync({
     onSyncComplete: async () => {
       setRefreshKey(key => key + 1);
       const count = await getPendingUploadCount();
@@ -63,18 +57,34 @@ export default function SyncScreen() {
   });
 
   useEffect(() => {
-    if (status === 'syncing' && isOnline && !isWifi && !uploadOverCellular) {
+    if (status === 'syncing' && cellularBlocked) {
       setStatus('paused');
     }
-  }, [status, isOnline, isWifi, uploadOverCellular]);
+  }, [status, cellularBlocked]);
 
-  const handleSyncNow = () => {
-    if (isOnline && !isWifi && !uploadOverCellular) {
+  const runSyncNow = useCallback(() => {
+    if (cellularBlocked) {
       return;
     }
+    // TODO(#150): invoke upload-engine Sync Now (clears pause window).
     triggerSync();
     setStatus('syncing');
-  };
+  }, [cellularBlocked, triggerSync]);
+
+  // TODO(#150): invoke upload-engine pause.
+  const handlePause = useCallback(() => {
+    setStatus('paused');
+  }, []);
+
+  // TODO(#150): invoke upload-engine resume (distinct from Sync Now pause-window clear).
+  const handleResume = useCallback(() => {
+    runSyncNow();
+  }, [runSyncNow]);
+
+  // TODO(#150): invoke upload-engine cancel / clear pause window.
+  const handleCancel = useCallback(() => {
+    setStatus('pending');
+  }, []);
 
   return (
     <ScreenContainer edges={['bottom']}>
@@ -98,14 +108,16 @@ export default function SyncScreen() {
             nextRetryAt,
           )}
         </View>
-        {/*
-          PREVIEW ONLY, not #151. These buttons just flip local mock
-          `status` so we can visually confirm the icon/label changes per
-          state render correctly. #151 replaces this block entirely with
-          real Pause/Resume/Cancel/Sync Now wired to #150's engine.
-        */}
         <View style={styles.controlsSection}>
-          {renderMockControls(status, setStatus, handleSyncNow)}
+          <SyncActionControls
+            status={status}
+            onPause={handlePause}
+            onResume={handleResume}
+            onCancel={handleCancel}
+            onSyncNow={runSyncNow}
+            syncNowDisabled={cellularBlocked}
+            busy={isSyncing}
+          />
         </View>
         {/*
           TODO: render the already-drafted downloads queue section here
@@ -252,120 +264,6 @@ function renderSecondaryContent(
   }
 }
 
-// PREVIEW ONLY — see note above. Cancel is assumed to drop the page into
-// 'pending' (uploads still queued, nothing actively running); that mapping
-// isn't spec'd anywhere, just a reasonable guess for demo purposes.
-//
-// Only "Sync Now" (pending state) calls the gated sync handler, so
-// there's at least one working manual-sync path until #151 wires up the
-// real thing. Pause, Resume, and Cancel remain visual-only — there's no
-// real pause/resume/cancel behavior to call yet (that's #150).
-function renderMockControls(
-  status: SyncPageStatus,
-  setStatus: (status: SyncPageStatus) => void,
-  onSyncNow: () => void,
-) {
-  switch (status) {
-    case 'syncing':
-      return (
-        <View style={styles.controlsRow}>
-          <MockActionButton
-            label="Pause"
-            Icon={Pause}
-            variant="secondary"
-            onPress={() => setStatus('paused')}
-          />
-          <MockActionButton
-            label="Cancel"
-            Icon={X}
-            variant="secondary"
-            onPress={() => setStatus('pending')}
-          />
-        </View>
-      );
-
-    case 'paused':
-      return (
-        <View style={styles.controlsRow}>
-          <MockActionButton
-            label="Resume"
-            Icon={Play}
-            variant="secondary"
-            onPress={() => setStatus('syncing')}
-          />
-          <MockActionButton
-            label="Cancel"
-            Icon={X}
-            variant="secondary"
-            onPress={() => setStatus('pending')}
-          />
-        </View>
-      );
-
-    case 'pending':
-      return (
-        <MockActionButton
-          label="Sync Now"
-          Icon={Play}
-          variant="primary"
-          fullWidth
-          onPress={onSyncNow}
-        />
-      );
-
-    case 'uploadComplete':
-    case 'allComplete':
-    default:
-      return null;
-  }
-}
-
-interface MockActionButtonProps {
-  label: string;
-  Icon: typeof Pause;
-  variant: 'primary' | 'secondary';
-  fullWidth?: boolean;
-  onPress: () => void;
-}
-
-function MockActionButton({
-  label,
-  Icon,
-  variant,
-  fullWidth,
-  onPress,
-}: MockActionButtonProps) {
-  const isPrimary = variant === 'primary';
-
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      accessibilityRole="button"
-      style={[
-        styles.controlButton,
-        isPrimary && styles.controlButtonPrimary,
-        fullWidth && styles.controlButtonFullWidth,
-      ]}
-    >
-      <Icon
-        size={18}
-        color={
-          isPrimary ? theme.colors.primaryForeground : theme.colors.foreground
-        }
-        strokeWidth={listIconStrokeWidth}
-      />
-      <Text
-        style={[
-          styles.controlButtonLabel,
-          isPrimary && styles.controlButtonLabelPrimary,
-        ]}
-      >
-        {label}
-      </Text>
-    </TouchableOpacity>
-  );
-}
-
 function formatRetryText(nextRetryAt?: Date): string {
   if (!nextRetryAt) {
     return '';
@@ -464,37 +362,5 @@ const styles = StyleSheet.create({
     color: theme.colors.foreground,
     textAlign: 'center',
     paddingVertical: theme.spacing.lg,
-  },
-  controlsRow: {
-    flexDirection: 'row',
-    width: '100%',
-    gap: theme.spacing.sm,
-  },
-  controlButton: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: theme.spacing.xs,
-    paddingVertical: theme.spacing.sm,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: theme.radius.lg,
-    backgroundColor: theme.colors.cardBackground,
-  },
-  controlButtonPrimary: {
-    backgroundColor: theme.colors.primary,
-    borderColor: theme.colors.primary,
-  },
-  controlButtonFullWidth: {
-    width: '100%',
-  },
-  controlButtonLabel: {
-    fontSize: theme.typography.sizes.md,
-    fontWeight: theme.typography.weights.medium,
-    color: theme.colors.foreground,
-  },
-  controlButtonLabelPrimary: {
-    color: theme.colors.primaryForeground,
   },
 });

--- a/src/components/ui/SyncActionControls.test.tsx
+++ b/src/components/ui/SyncActionControls.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import {
+  SYNC_NOW_CELLULAR_DISABLED_MESSAGE,
+  SyncActionControls,
+} from './SyncActionControls';
+
+describe('SyncActionControls', () => {
+  const onPause = jest.fn();
+  const onResume = jest.fn();
+  const onCancel = jest.fn();
+  const onSyncNow = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function renderControls(
+    overrides: Partial<React.ComponentProps<typeof SyncActionControls>> = {},
+  ) {
+    return render(
+      <SyncActionControls
+        status="pending"
+        onPause={onPause}
+        onResume={onResume}
+        onCancel={onCancel}
+        onSyncNow={onSyncNow}
+        {...overrides}
+      />,
+    );
+  }
+
+  it('shows Pause and Cancel while syncing', () => {
+    const { getByTestId, queryByTestId } = renderControls({
+      status: 'syncing',
+    });
+
+    expect(getByTestId('sync-action-pause')).toBeTruthy();
+    expect(getByTestId('sync-action-cancel')).toBeTruthy();
+    expect(queryByTestId('sync-action-sync-now')).toBeNull();
+  });
+
+  it('shows Resume, Sync Now, and Cancel while paused', () => {
+    const { getByTestId } = renderControls({ status: 'paused' });
+
+    expect(getByTestId('sync-action-resume')).toBeTruthy();
+    expect(getByTestId('sync-action-sync-now')).toBeTruthy();
+    expect(getByTestId('sync-action-cancel')).toBeTruthy();
+  });
+
+  it('shows Sync Now while pending', () => {
+    const { getByTestId, queryByTestId } = renderControls({
+      status: 'pending',
+    });
+
+    expect(getByTestId('sync-action-sync-now')).toBeTruthy();
+    expect(queryByTestId('sync-action-pause')).toBeNull();
+  });
+
+  it('hides controls for uploadComplete and allComplete', () => {
+    const uploadComplete = renderControls({ status: 'uploadComplete' });
+    expect(uploadComplete.toJSON()).toBeNull();
+
+    const allComplete = renderControls({ status: 'allComplete' });
+    expect(allComplete.toJSON()).toBeNull();
+  });
+
+  it('disables Sync Now and shows explanation when syncNowDisabled', () => {
+    const { getByTestId, getByText } = renderControls({
+      status: 'pending',
+      syncNowDisabled: true,
+    });
+
+    expect(
+      getByTestId('sync-action-sync-now').props.accessibilityState,
+    ).toEqual(expect.objectContaining({ disabled: true }));
+    expect(getByText(SYNC_NOW_CELLULAR_DISABLED_MESSAGE)).toBeTruthy();
+  });
+
+  it('invokes callbacks for syncing controls', () => {
+    const { getByTestId } = renderControls({ status: 'syncing' });
+
+    fireEvent.press(getByTestId('sync-action-pause'));
+    fireEvent.press(getByTestId('sync-action-cancel'));
+
+    expect(onPause).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes callbacks for paused controls', () => {
+    const { getByTestId } = renderControls({ status: 'paused' });
+
+    fireEvent.press(getByTestId('sync-action-resume'));
+    fireEvent.press(getByTestId('sync-action-sync-now'));
+    fireEvent.press(getByTestId('sync-action-cancel'));
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onSyncNow).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onSyncNow when Sync Now is disabled', () => {
+    const { getByTestId } = renderControls({
+      status: 'pending',
+      syncNowDisabled: true,
+    });
+
+    fireEvent.press(getByTestId('sync-action-sync-now'));
+    expect(onSyncNow).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/SyncActionControls.tsx
+++ b/src/components/ui/SyncActionControls.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { Pause, Play, X, type LucideIcon } from 'lucide-react-native';
+import { SyncPageStatus } from '../../types/sync/types';
+import { theme, listIconStrokeWidth } from '../../theme';
+
+export const SYNC_NOW_CELLULAR_DISABLED_MESSAGE =
+  'Connect to WiFi to sync, or enable cellular uploads in Settings.';
+
+export interface SyncActionControlsProps {
+  status: SyncPageStatus;
+  onPause: () => void;
+  onResume: () => void;
+  onCancel: () => void;
+  onSyncNow: () => void;
+  syncNowDisabled?: boolean;
+  busy?: boolean;
+}
+
+export function SyncActionControls({
+  status,
+  onPause,
+  onResume,
+  onCancel,
+  onSyncNow,
+  syncNowDisabled = false,
+  busy = false,
+}: SyncActionControlsProps) {
+  const disabled = busy;
+
+  switch (status) {
+    case 'syncing':
+      return (
+        <View style={styles.controlsRow} testID="sync-action-controls-syncing">
+          <SyncActionButton
+            label="Pause"
+            Icon={Pause}
+            variant="secondary"
+            disabled={disabled}
+            onPress={onPause}
+            testID="sync-action-pause"
+          />
+          <SyncActionButton
+            label="Cancel"
+            Icon={X}
+            variant="secondary"
+            disabled={disabled}
+            onPress={onCancel}
+            testID="sync-action-cancel"
+          />
+        </View>
+      );
+
+    case 'paused':
+      return (
+        <View
+          style={styles.controlsColumn}
+          testID="sync-action-controls-paused"
+        >
+          <View style={styles.controlsRow}>
+            <SyncActionButton
+              label="Resume"
+              Icon={Play}
+              variant="secondary"
+              disabled={disabled || syncNowDisabled}
+              onPress={onResume}
+              testID="sync-action-resume"
+            />
+            <SyncActionButton
+              label="Cancel"
+              Icon={X}
+              variant="secondary"
+              disabled={disabled}
+              onPress={onCancel}
+              testID="sync-action-cancel"
+            />
+          </View>
+          <SyncActionButton
+            label="Sync Now"
+            Icon={Play}
+            variant="primary"
+            fullWidth
+            disabled={disabled || syncNowDisabled}
+            onPress={onSyncNow}
+            testID="sync-action-sync-now"
+          />
+          {syncNowDisabled ? (
+            <Text
+              style={styles.disabledHint}
+              testID="sync-action-sync-now-disabled-hint"
+            >
+              {SYNC_NOW_CELLULAR_DISABLED_MESSAGE}
+            </Text>
+          ) : null}
+        </View>
+      );
+
+    case 'pending':
+      return (
+        <View
+          style={styles.controlsColumn}
+          testID="sync-action-controls-pending"
+        >
+          <SyncActionButton
+            label="Sync Now"
+            Icon={Play}
+            variant="primary"
+            fullWidth
+            disabled={disabled || syncNowDisabled}
+            onPress={onSyncNow}
+            testID="sync-action-sync-now"
+          />
+          {syncNowDisabled ? (
+            <Text
+              style={styles.disabledHint}
+              testID="sync-action-sync-now-disabled-hint"
+            >
+              {SYNC_NOW_CELLULAR_DISABLED_MESSAGE}
+            </Text>
+          ) : null}
+        </View>
+      );
+
+    case 'uploadComplete':
+    case 'allComplete':
+    default:
+      return null;
+  }
+}
+
+interface SyncActionButtonProps {
+  label: string;
+  Icon: LucideIcon;
+  variant: 'primary' | 'secondary';
+  fullWidth?: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+  testID?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+function SyncActionButton({
+  label,
+  Icon,
+  variant,
+  fullWidth,
+  disabled,
+  onPress,
+  testID,
+}: SyncActionButtonProps) {
+  const isPrimary = variant === 'primary';
+  const iconColor = disabled
+    ? theme.colors.mutedForeground
+    : isPrimary
+    ? theme.colors.primaryForeground
+    : theme.colors.foreground;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: !!disabled }}
+      testID={testID}
+      style={[
+        styles.controlButton,
+        isPrimary && styles.controlButtonPrimary,
+        fullWidth && styles.controlButtonFullWidth,
+        disabled && styles.controlButtonDisabled,
+      ]}
+    >
+      <Icon size={18} color={iconColor} strokeWidth={listIconStrokeWidth} />
+      <Text
+        style={[
+          styles.controlButtonLabel,
+          isPrimary && styles.controlButtonLabelPrimary,
+          disabled && styles.controlButtonLabelDisabled,
+        ]}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  controlsRow: {
+    flexDirection: 'row',
+    width: '100%',
+    gap: theme.spacing.sm,
+  },
+  controlsColumn: {
+    width: '100%',
+    gap: theme.spacing.sm,
+  },
+  controlButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing.xs,
+    paddingVertical: theme.spacing.sm,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.lg,
+    backgroundColor: theme.colors.cardBackground,
+  },
+  controlButtonPrimary: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  controlButtonFullWidth: {
+    width: '100%',
+    flex: 0,
+  },
+  controlButtonDisabled: {
+    opacity: 0.5,
+  },
+  controlButtonLabel: {
+    fontSize: theme.typography.sizes.md,
+    fontWeight: theme.typography.weights.medium,
+    color: theme.colors.foreground,
+  },
+  controlButtonLabelPrimary: {
+    color: theme.colors.primaryForeground,
+  },
+  controlButtonLabelDisabled: {
+    color: theme.colors.mutedForeground,
+  },
+  disabledHint: {
+    fontSize: theme.typography.sizes.sm,
+    color: theme.colors.mutedForeground,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
### TLDR

Adds Sync page action controls (Pause / Resume / Cancel / Sync Now) as a dedicated `SyncActionControls` component wired from `SyncScreen`, with the per-status visibility matrix from #151. Engine-side Pause/Resume/Cancel/Sync Now behavior remains waived until #150; UI invokes handlers that are ready for that wiring.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #151

Fills the control area under the upload progress bar. Control set depends on sync page status; Upload Complete / All Complete show no actions. Sync Now disabled on cellular when the preference blocks it, with the documented hint copy.

**Ticket-level waiver (on #151):** upload-engine behaviors for these buttons are deferred to #150 — see issue comment. This PR ships UI matrix + handler hooks only.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/components/ui/SyncActionControls.tsx`** — Status → control matrix; busy disables in-flight; Sync Now cellular disabled hint (`SYNC_NOW_CELLULAR_DISABLED_MESSAGE`)
- **`src/components/ui/SyncActionControls.test.tsx`** — Matrix + disabled/hint coverage
- **`src/app/screens/SyncScreen.tsx`** — Wires controls; removes mock preview scaffolding

#### Testing

Ran locally before open: format / lint / typecheck / `npm test -- --ci` including `SyncActionControls` tests.

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. On Android Sync screen: walk statuses (syncing → pause/cancel; paused → resume/cancel; pending/offline → Sync Now; complete states → no controls)
3. With cellular sync preference off on cellular: Sync Now disabled + hint visible

**Expected:** Correct controls per status; busy disables presses; no controls on complete states. Full engine effect of Pause/Resume/Cancel/Sync Now waits on #150.

### Follow-ups

- [ ] #150 — Wire real upload-engine Pause / Resume / Cancel / Sync Now (ticket-level waiver on #151)
