### PR TITLE
[#204]: Truth-up agent docs and theme conventions

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -7,9 +7,9 @@ alwaysApply: true
 
 ## Data flow
 
-1. **Launch:** `App.tsx` → `initializeDatabase()` → `syncAllData(email)`
+1. **Launch:** `App.tsx` → `initializeDatabase()` → `restoreSession()` → navigator. Sync runs **post-login** / via sync hooks (`syncAllData` / `syncAllUsers`), not as a required cold-start step.
 2. **Sync:** `sync.ts` calls `FluentAPI`, writes via `repository.ts`, updates KV in `storage.ts`
-3. **UI:** screens call `queries.ts` only for reads
+3. **UI:** screens/hooks call `queries.ts` for reads (prefer hooks over importing queries in screens)
 
 ## Layer boundaries
 
@@ -42,19 +42,19 @@ alwaysApply: true
 
 ## Adding a screen
 
-1. Component in `src/app/tabs/`
+1. Prefer a component in `src/app/screens/` for stack routes (or `src/app/tabs/` for nested drafting/list surfaces)
 2. Route in `AppNavigator.tsx`
 3. Params in `src/types/navigation/types.ts`
 
 ## Database cautions
 
 - `getDatabase()` throws if called before `initializeDatabase()`.
-- No migration framework yet — schema edits affect existing DB files on devices.
+- Prefer the versioned migration runner (`#110`) for schema changes — ad-hoc ALTER lists without `user_version` are fragile on existing devices.
 - Foreign keys enabled in init; use transactions in repository.
 
 ## Navigation stack
 
-`Projects` → `Chapters` (project) → `VerseDetail` (chapter). Pass IDs via route params; load detail in screen `useEffect`.
+Authenticated stack includes Home → project chapters (`ViewProject`) → drafting (`DraftingScreen` / VerseDetail). Pass IDs via route params; load detail in screen `useEffect` / hooks. Sync and Settings are stack destinations.
 
 ## Native (Expo CNG, Android-only)
 

--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -24,10 +24,12 @@ log.info('message', { context });
 ## Environment
 
 ```typescript
-import { API_BASE_URL } from '../config/apiBaseUrl';
+import { getApiBaseUrl } from '../config/apiBaseUrl';
+
+const baseUrl = getApiBaseUrl();
 ```
 
-`src/config/apiBaseUrl.ts` requires a non-empty `EXPO_PUBLIC_API_BASE_URL` (set in `.env`; see `.env.example`). Never commit `.env`.
+`src/config/apiBaseUrl.ts` requires a non-empty `EXPO_PUBLIC_API_BASE_URL` (set in `.env`; see `.env.example`). Never commit `.env`. There is **no** named `API_BASE_URL` export from this module.
 
 ## TypeScript
 
@@ -38,8 +40,9 @@ import { API_BASE_URL } from '../config/apiBaseUrl';
 ## React Native
 
 - Functional components + hooks.
-- Shared layout: `src/app/appStyles.ts`.
-- Icons: `@react-native-vector-icons/ionicons`.
+- **Styling:** use `theme` from `src/theme` for new UI (colors, spacing, radius, typography). Do **not** add new hardcoded hex values in new StyleSheets.
+- `src/app/appStyles.ts` is **legacy** shared styles — reuse existing keys if needed, but prefer tokens for anything new; migrate to `theme` when touching a file.
+- Icons: `@react-native-vector-icons/ionicons` and/or `lucide-react-native` (match neighbors).
 - SVG: default import as component (e.g. `FluentLogo`).
 
 ## Prettier (`.prettierrc.cjs`)

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -9,14 +9,16 @@ Offline-first **Expo SDK 56** (React Native **0.85**, React **19.2.3**) companio
 
 ## Key paths
 
-- Entry: `App.tsx` → `initializeDatabase()` → `syncAllData()` → `AppNavigator`
+- Entry: `App.tsx` → `initializeDatabase()` → `restoreSession()` → `AppNavigator` (sync post-login / via hooks)
 - App config: `app.config.ts` (EAS project ID, plugins, package id)
-- Screens: `src/app/tabs/` (`ProjectList`, `ViewProject`, `ViewChapter`)
+- Stack screens: `src/app/screens/` (Home, Settings, Sync, Drafting, PrepareForOffline)
+- Nested UI: `src/app/tabs/` (ProjectsTab, MyWorkTab, BibleTab, RecordTab, auth/legal)
+- Theme: `src/theme/` (canonical tokens for new UI)
 - API: `src/services/api.ts` (`FluentAPI`)
 - Sync: `src/services/sync.ts`
 - DB writes: `src/db/repository.ts` | reads: `src/db/queries.ts`
 - Types: `src/types/{api,db,navigation}/`
-- Env: `EXPO_PUBLIC_API_BASE_URL` in `.env` (validated in `src/config/apiBaseUrl.ts`)
+- Env: `EXPO_PUBLIC_API_BASE_URL` in `.env` (via `getApiBaseUrl()` in `src/config/apiBaseUrl.ts`)
 - Native (generated): run `npm run prebuild` — regenerates `android/` only; do not commit `android/`
 - Releases: tag `v*` → `.github/workflows/eas-build.yml` + `.eas/workflows/create-production-builds.yml` (Android only)
 

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -6,7 +6,7 @@ Quick map for Cursor agents, other coding tools, and new contributors. Verified 
 
 ## What this project is
 
-**Fluent Mobile** is an offline-first React Native companion app for Bible translation recording workflows. **Android-only permanently** — no iOS app. On launch it initializes a local SQLite database, syncs data from the Fluent API, then lets users browse **projects → chapters → verses**. Recording UI exists as local state stubs; persistence to the `recordings` table is not wired yet.
+**Fluent Mobile** is an offline-first React Native companion app for Bible translation recording workflows. **Android-only permanently** — no iOS app. On launch it initializes a local SQLite database and restores the auth session, then shows the navigator. After login (or when the user triggers sync), it syncs Fluent API data into SQLite so translators can browse **projects → chapters → drafting** (Bible / Resources / Record). Recording UI is still largely stubbed; persistence to the `recordings` table is not fully wired yet.
 
 ## Tech stack
 
@@ -31,15 +31,18 @@ Quick map for Cursor agents, other coding tools, and new contributors. Verified 
 
 | Path | Purpose |
 |------|---------|
-| [`App.tsx`](../App.tsx) | Root: DB init + initial `syncAllData`, then navigator |
-| [`src/app/tabs/`](../src/app/tabs/) | Screens: `ProjectList`, `ViewProject`, `ViewChapter` |
+| [`App.tsx`](../App.tsx) | Root: DB init + session restore, then navigator; sync runs post-login |
+| [`src/app/screens/`](../src/app/screens/) | Stack screens: Home, Settings, Sync, Drafting, PrepareForOffline |
+| [`src/app/tabs/`](../src/app/tabs/) | Nested surfaces: ProjectsTab, MyWorkTab, BibleTab, RecordTab, auth/legal |
+| [`src/components/`](../src/components/) | Shared `layout/` + `ui/` |
+| [`src/theme/`](../src/theme/) | Canonical design tokens (`theme` object) for new UI |
 | [`src/navigation/`](../src/navigation/) | Stack navigator |
 | [`src/services/api.ts`](../src/services/api.ts) | HTTP client (`FluentAPI`) — see [api-client-standard.md](guides/api-client-standard.md) |
 | [`src/services/sync.ts`](../src/services/sync.ts) | Sync orchestration, retries, KV counts |
 | [`src/services/storage.ts`](../src/services/storage.ts) | KV sync state (`op-sqlite` Storage) |
 | [`src/db/`](../src/db/) | Schema, init, `repository` (writes), `queries` (reads), singleton |
 | [`src/types/`](../src/types/) | API, DB, navigation, env types |
-| [`src/components/ui/`](../src/components/ui/) | Shared UI (`SyncButton`) |
+| [`src/hooks/`](../src/hooks/) | Screen data/sync/auth hooks (SQLite-first lists) |
 | [`src/utils/logger.ts`](../src/utils/logger.ts) | Tagged logging |
 | [`app.config.ts`](../app.config.ts) | Expo config, EAS project ID, config plugins |
 | [`eas.json`](../eas.json) | EAS build/submit profiles (Android only) |
@@ -120,8 +123,13 @@ flowchart TD
   subgraph launch [App launch]
     App[App.tsx]
     InitDB[initializeDatabase]
-    SyncAll[syncAllData email]
-    App --> InitDB --> SyncAll
+    Restore[restoreSession]
+    Nav[AppNavigator]
+    App --> InitDB --> Restore --> Nav
+  end
+
+  subgraph postLogin [Post-login / manual sync]
+    SyncAll[syncAllData / syncAllUsers]
   end
 
   subgraph remote [Remote]
@@ -144,18 +152,19 @@ flowchart TD
   end
 
   subgraph ui [UI]
-    Screens[app/tabs screens]
+    Screens[screens + tabs via hooks]
     Queries --> Screens
-    SyncBtn[SyncButton] --> SyncSvc
   end
 ```
 
+**Launch (actual):** `App.tsx` → `initializeDatabase()` → `restoreSession()` → set auth + `dbReady` → `AppNavigator`. **Sync is not automatic on every cold start**; it runs after successful login (`syncAllData`) and when the user/manual sync hooks call `syncAllUsers`.
+
 **Layer rules (do not bypass):**
 
-- **HTTP only in** `src/services/api.ts`
+- **HTTP only in** `src/services/api.ts` (via `httpClient`)
 - **Sync orchestration only in** `src/services/sync.ts`
 - **Writes** → `src/db/repository.ts` (transactions)
-- **Reads** → `src/db/queries.ts`
+- **Reads** → `src/db/queries.ts` (prefer hooks in UI; avoid importing queries from screens when a hook exists)
 - **DB handle** → `setDatabase` / `getDatabase` in `src/db/db.ts` — must run after `initializeDatabase()`
 
 Sync order in `syncAllData`: user → master data (languages, books, bibles) → projects → chapter assignments → bible texts.
@@ -165,10 +174,10 @@ Auth: email/password via `FluentAPI.signIn`; authenticated API calls use `Author
 ## Coding conventions
 
 - **Logging:** `const log = logger.create('ComponentName')` — no raw `console` (ESLint); exception: `src/utils/logger.ts`, tests.
-- **Env:** `EXPO_PUBLIC_API_BASE_URL` in `.env`; validated in `src/config/apiBaseUrl.ts` — never commit `.env`. ESLint blocks direct `process.env` reads and legacy imports (`@env`, `react-native-fs`, `react-native-keychain`, Simform waveform) outside the config layer.
+- **Env:** `EXPO_PUBLIC_API_BASE_URL` in `.env`; read via `getApiBaseUrl()` from `src/config/apiBaseUrl.ts` — never commit `.env`. ESLint blocks direct `process.env` reads and legacy imports (`@env`, `react-native-fs`, `react-native-keychain`, Simform waveform) outside the config layer.
 - **Types:** API shapes in `src/types/api/`, DB in `src/types/db/`, navigation in `src/types/navigation/`.
 - **Prettier:** single quotes, trailing commas, `arrowParens: 'avoid'`.
-- **Styles:** shared patterns in `src/app/appStyles.ts`; screen-local `StyleSheet` where needed.
+- **Styles:** **`src/theme` (`theme` object) is canonical for new UI.** Do not add new hardcoded hex colors in new StyleSheets. [`src/app/appStyles.ts`](../src/app/appStyles.ts) is legacy shared styles — migrate callers to tokens when you touch them; do not expand it with new hex.
 - **SVG:** import as React components (Metro SVG transformer).
 
 Keep changes **small and scoped** — avoid drive-by refactors.
@@ -180,6 +189,7 @@ Keep changes **small and scoped** — avoid drive-by refactors.
 - **Colocated:** `src/utils/logger.test.ts`, `src/services/fluent-api.test.ts`.
 - **Live API test:** `fluent-api.test.ts` is **skipped by default**; opt in with `RUN_LIVE_API_TESTS=1 npm test -- fluent-api.test.ts`.
 - **No E2E** in this repo yet.
+- **Gap:** `src/db/` currently has little/no unit coverage — prefer adding tests when changing queries/repository.
 
 When adding features: mock `op-sqlite`, navigation, and sync in screen tests following existing patterns. Reset shared Expo mocks in `beforeEach` when mutating secure-store/file-system state.
 
@@ -187,21 +197,23 @@ When adding features: mock `op-sqlite`, navigation, and sync in screen tests fol
 
 | Task | Start here |
 |------|------------|
-| New screen | `src/app/tabs/`, register in `AppNavigator.tsx`, extend `RootStackParamList` |
+| New stack screen | Prefer `src/app/screens/`, register in `AppNavigator.tsx`, extend `RootStackParamList` |
+| Nested drafting/list UI | `src/app/tabs/` or `src/components/` |
 | New API endpoint | `FluentAPI` in `api.ts`, then `sync.ts` step + `repository.ts` |
-| New table / column | `schema.ts` → repository inserts → queries → types |
-| Manual re-sync | `SyncButton` → `syncAllData` |
+| New table / column | `schema.ts` → prefer versioned migrations (`#110`) → repository inserts → queries → types |
+| Manual re-sync | Sync page / header sync → `useSync` / `syncAllUsers` |
 | PR workflow | `/create-pr-branch`, `/generate-pr-description`, `/create-pr` (see `.cursor/commands/`) |
 
 ## Risk areas (change carefully)
 
 | Area | Risk |
 |------|------|
-| `src/db/schema.ts` | No migrations yet — schema changes affect existing installs |
-| `sync.ts` module-level `getDatabase()` | Dead import at line 24; calling `getDatabase()` before init throws |
+| `src/db/schema.ts` | Prefer versioned migrations (`#110`); ad-hoc ALTER-on-launch is fragile for existing installs |
+| `getDatabase()` before init | Calling `getDatabase()` before `initializeDatabase()` throws |
 | `fluent-api.test.ts` | Skipped in CI; opt-in live network via `RUN_LIVE_API_TESTS=1` |
 | `format` vs `format:check` | Different glob scopes — CI only checks `src/**` |
 | Native folders | `android/` is gitignored CNG output — customize via `app.config.ts` + plugins. No iOS project. |
+| Dual styles | `src/theme` vs legacy `appStyles.ts` hex — new UI must use tokens |
 
 ## Open questions / TODOs
 


### PR DESCRIPTION
### TLDR

Truth-up agent onboarding docs and Cursor rules to match current main: real launch/session path, current screens map, `getApiBaseUrl()`, and `src/theme` as canonical for new UI (no new hardcoded hex; `appStyles` legacy). Docs/rules only — no runtime behavior change.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #204

Agents were still pointed at cold-start-only `syncAllData`, outdated screen paths, a non-existent `API_BASE_URL` export, and hex-first styling. This PR aligns rules/docs with the code on main.

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Maintenance / refactor

#### Technical changes

- **`docs/AGENT_ONBOARDING.md`** — Launch path, screen map, theme note
- **`.cursor/rules/architecture.mdc`** — Launch / navigation wording aligned with code
- **`.cursor/rules/project-overview.mdc`** — Entry + screen paths
- **`.cursor/rules/code-style.mdc`** — `getApiBaseUrl()`; theme tokens over new hex

#### Testing

Docs/rules only. Ran `npm run format:check` / lint / typecheck as applicable at PR time; no product test changes required.

### How to verify

1. Skim the four files above against `App.tsx` / `src/app/screens/` / `src/theme/`
2. Confirm no claim of a named `API_BASE_URL` export remains in `code-style.mdc`
3. Confirm new-UI guidance prefers `src/theme` tokens

**Expected:** An agent reading onboarding + rules gets an accurate map of launch, screens, API config, and theme without code changes.

### Follow-ups

- None required for AC. Broader `appStyles` → theme migration is separate product work if desired.
