### PR TITLE
[#110]: Add versioned SQLite migration framework

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -49,7 +49,7 @@ alwaysApply: true
 ## Database cautions
 
 - `getDatabase()` throws if called before `initializeDatabase()`.
-- No migration framework yet — schema edits affect existing DB files on devices.
+- Schema changes go through versioned migrations in `db/migrations.ts` (`PRAGMA user_version`); do not ship ad-hoc ignore-errors `ALTER` arrays.
 - Foreign keys enabled in init; use transactions in repository.
 
 ## Navigation stack

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -197,7 +197,7 @@ When adding features: mock `op-sqlite`, navigation, and sync in screen tests fol
 
 | Area | Risk |
 |------|------|
-| `src/db/schema.ts` | No migrations yet — schema changes affect existing installs |
+| `src/db/schema.ts` + `migrations.ts` | Baseline DDL + versioned `user_version` migrations |
 | `sync.ts` module-level `getDatabase()` | Dead import at line 24; calling `getDatabase()` before init throws |
 | `fluent-api.test.ts` | Skipped in CI; opt-in live network via `RUN_LIVE_API_TESTS=1` |
 | `format` vs `format:check` | Different glob scopes — CI only checks `src/**` |

--- a/src/db/AGENTS.md
+++ b/src/db/AGENTS.md
@@ -4,8 +4,9 @@ Agents: UI reads here after sync; writes happen only in the repository. See [`.c
 
 | File | Role |
 | ---- | ---- |
-| `schema.ts` | `CREATE TABLE` statements |
-| `index.ts` | Open DB, pragmas, create tables |
+| `schema.ts` | `CREATE TABLE` statements (baseline for migration v1) |
+| `migrations.ts` | Versioned `PRAGMA user_version` runner + table-rebuild helper |
+| `index.ts` | Open DB, pragmas, `runMigrations` |
 | `db.ts` | `getDatabase()` / `setDatabase()` singleton |
 | `repository.ts` | Inserts/upserts in transactions |
 | `queries.ts` | SELECTs for UI |
@@ -13,14 +14,20 @@ Agents: UI reads here after sync; writes happen only in the repository. See [`.c
 ## Rules
 
 - Call `getDatabase()` only **after** `initializeDatabase()` (throws otherwise).
-- **No migration framework yet** — schema edits affect existing device DB files; change carefully.
+- Schema changes go through **versioned migrations** in `migrations.ts` — do not reintroduce ignore-errors `ALTER` arrays.
 - Foreign keys are enabled in init; use transactions in `repository.ts`.
 - Screens must not write SQL — use `queries.ts` / `repository.ts`.
 
 ## Adding a synced entity
 
-1. Table in `schema.ts`
+1. Table in `schema.ts` **and** a new migration version that applies it for existing installs
 2. Types in `src/types/db/types.ts`
 3. API + sync step (`services/`)
 4. Inserts in `repository.ts`
 5. Reads in `queries.ts` if UI needs them
+
+## Migrations
+
+- `runMigrations(db)` applies steps with `version > PRAGMA user_version`, once each, in a transaction.
+- Use `rebuildTable()` for SQLite FK/default/type changes (#99 / #103).
+- Current schema version: see `CURRENT_SCHEMA_VERSION` in `migrations.ts`.

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,42 +1,10 @@
 import { open, DB } from '@op-engineering/op-sqlite';
-import { chapterAssignmentMigrations, createTableQueries } from './schema';
+import { runMigrations } from './migrations';
 import { logger } from '../utils/logger';
 import { setDatabase, getDatabase } from './db';
 
 const log = logger.create('Database');
 const DB_NAME = 'fluent.db';
-
-function shouldIgnoreInitError(
-  message: string,
-  kind: 'table' | 'column',
-): boolean {
-  const lower = message.toLowerCase();
-  return kind === 'table'
-    ? lower.includes('already exists')
-    : lower.includes('duplicate column');
-}
-
-async function runStatements(
-  db: DB,
-  statements: string[],
-  kind: 'table' | 'column',
-): Promise<void> {
-  for (const query of statements) {
-    try {
-      await db.execute(query);
-    } catch (error: unknown) {
-      if (
-        error instanceof Error &&
-        shouldIgnoreInitError(error.message, kind)
-      ) {
-        continue;
-      }
-      log.error(kind === 'table' ? 'SQL Error:' : 'Migration error:', {
-        error,
-      });
-    }
-  }
-}
 
 export async function initializeDatabase(): Promise<void> {
   try {
@@ -64,10 +32,9 @@ export async function initializeDatabase(): Promise<void> {
     await db.execute('PRAGMA synchronous = NORMAL;');
     await db.execute('PRAGMA busy_timeout = 5000;');
 
-    await runStatements(db, createTableQueries, 'table');
-    await runStatements(db, chapterAssignmentMigrations, 'column');
+    await runMigrations(db);
 
-    log.info('All tables created successfully');
+    log.info('Database ready');
   } catch (error: unknown) {
     log.error('Failed to initialize database:', { error });
     throw error;

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,0 +1,359 @@
+import type { DB, QueryResult, Transaction } from '@op-engineering/op-sqlite';
+import {
+  addColumnIfMissing,
+  columnExists,
+  getUserVersion,
+  Migration,
+  rebuildTable,
+  runMigrations,
+  setUserVersion,
+} from './migrations';
+
+type Row = Record<string, string | number | null>;
+
+type FakeTable = {
+  columns: Set<string>;
+  rows: Row[];
+};
+
+function emptyResult(rows: Row[] = []): QueryResult {
+  return {
+    rowsAffected: 0,
+    rows: rows as QueryResult['rows'],
+  };
+}
+
+/**
+ * Minimal SQLite stand-in for migration unit tests (no native op-sqlite).
+ * Supports: PRAGMA user_version, PRAGMA table_info, CREATE TABLE IF NOT EXISTS,
+ * ALTER TABLE ADD COLUMN, INSERT, SELECT, DROP, RENAME, and no-op indexes.
+ */
+function createFakeDb(initialVersion = 0) {
+  let userVersion = initialVersion;
+  const tables = new Map<string, FakeTable>();
+
+  const ensureChapterAssignmentsOldShape = () => {
+    if (tables.has('chapter_assignments')) {
+      return;
+    }
+    tables.set('chapter_assignments', {
+      columns: new Set([
+        'id',
+        'project_unit_id',
+        'bible_id',
+        'book_id',
+        'chapter_number',
+        'assigned_user_id',
+        'status',
+        'submitted_time',
+        'updated_at',
+      ]),
+      rows: [
+        {
+          id: 1,
+          project_unit_id: 10,
+          bible_id: 1,
+          book_id: 1,
+          chapter_number: 1,
+          assigned_user_id: 5,
+          status: 'in_progress',
+          submitted_time: null,
+          updated_at: '2024-01-01',
+        },
+      ],
+    });
+  };
+
+  const parseCreateTable = (sql: string): void => {
+    const match = sql.match(
+      /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+(\w+)\s*\(([\s\S]*)\)/i,
+    );
+    if (!match) {
+      return;
+    }
+    const [, name, body] = match;
+    if (tables.has(name)) {
+      return;
+    }
+    const columns = new Set<string>();
+    for (const part of body.split(',')) {
+      const col = part.trim().split(/\s+/)[0];
+      if (
+        col &&
+        !/^(PRIMARY|UNIQUE|FOREIGN|CONSTRAINT|CHECK)$/i.test(col) &&
+        col !== ')'
+      ) {
+        columns.add(col.replace(/[^a-zA-Z0-9_]/g, ''));
+      }
+    }
+    tables.set(name, { columns, rows: [] });
+  };
+
+  const executor = {
+    execute: async (query: string): Promise<QueryResult> => {
+      const sql = query.trim();
+
+      if (/^PRAGMA\s+user_version\s*$/i.test(sql)) {
+        return emptyResult([{ user_version: userVersion }]);
+      }
+
+      const setVersion = sql.match(/^PRAGMA\s+user_version\s*=\s*(\d+)/i);
+      if (setVersion) {
+        userVersion = Number(setVersion[1]);
+        return emptyResult();
+      }
+
+      const tableInfo = sql.match(/^PRAGMA\s+table_info\((\w+)\)/i);
+      if (tableInfo) {
+        const table = tables.get(tableInfo[1]);
+        if (!table) {
+          return emptyResult();
+        }
+        return emptyResult(
+          [...table.columns].map((name, index) => ({
+            cid: index,
+            name,
+            type: 'TEXT',
+            notnull: 0,
+            dflt_value: null,
+            pk: 0,
+          })),
+        );
+      }
+
+      if (/^CREATE\s+TABLE/i.test(sql)) {
+        parseCreateTable(sql);
+        return emptyResult();
+      }
+
+      if (/^CREATE\s+INDEX/i.test(sql)) {
+        return emptyResult();
+      }
+
+      const alter = sql.match(
+        /^ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)\s+(.+)$/i,
+      );
+      if (alter) {
+        const [, tableName, columnName] = alter;
+        const table = tables.get(tableName);
+        if (!table) {
+          throw new Error(`no such table: ${tableName}`);
+        }
+        if (table.columns.has(columnName)) {
+          throw new Error(`duplicate column name: ${columnName}`);
+        }
+        table.columns.add(columnName);
+        for (const row of table.rows) {
+          row[columnName] = 0;
+        }
+        return emptyResult();
+      }
+
+      const insertSelect = sql.match(
+        /^INSERT\s+INTO\s+(\w+)\s*\(([^)]+)\)\s*SELECT\s+(.+)\s+FROM\s+(\w+)/i,
+      );
+      if (insertSelect) {
+        const [, dest, destCols, , src] = insertSelect;
+        const source = tables.get(src);
+        const target = tables.get(dest);
+        if (!source || !target) {
+          throw new Error('missing table for copy');
+        }
+        const cols = destCols.split(',').map(c => c.trim());
+        target.rows = source.rows.map(row => {
+          const next: Row = {};
+          for (const col of cols) {
+            next[col] = (row[col] as string | number | null) ?? 0;
+          }
+          return next;
+        });
+        return emptyResult();
+      }
+
+      const drop = sql.match(/^DROP\s+TABLE\s+(\w+)/i);
+      if (drop) {
+        tables.delete(drop[1]);
+        return emptyResult();
+      }
+
+      const rename = sql.match(/^ALTER\s+TABLE\s+(\w+)\s+RENAME\s+TO\s+(\w+)/i);
+      if (rename) {
+        const [, from, to] = rename;
+        const table = tables.get(from);
+        if (!table) {
+          throw new Error(`no such table: ${from}`);
+        }
+        tables.delete(from);
+        tables.set(to, table);
+        return emptyResult();
+      }
+
+      if (/^SELECT\s+\*\s+FROM\s+chapter_assignments/i.test(sql)) {
+        ensureChapterAssignmentsOldShape();
+        return emptyResult(tables.get('chapter_assignments')!.rows);
+      }
+
+      // Baseline CREATE statements may include whitespace quirks; ignore unknown DDL in fake.
+      if (/^CREATE\s+/i.test(sql) || sql.length === 0) {
+        return emptyResult();
+      }
+
+      return emptyResult();
+    },
+  };
+
+  const db = {
+    execute: executor.execute,
+    transaction: async (fn: (tx: Transaction) => Promise<void>) => {
+      await fn(executor as unknown as Transaction);
+    },
+    _tables: tables,
+    _seedOldChapterAssignments: ensureChapterAssignmentsOldShape,
+  };
+
+  return db as unknown as DB & {
+    _tables: Map<string, FakeTable>;
+    _seedOldChapterAssignments: () => void;
+  };
+}
+
+describe('migrations framework', () => {
+  it('applies all migrations from version 0 and sets user_version', async () => {
+    const db = createFakeDb(0);
+    await runMigrations(db);
+    await expect(getUserVersion(db)).resolves.toBe(2);
+  });
+
+  it('is idempotent on a second run', async () => {
+    const db = createFakeDb(0);
+    await runMigrations(db);
+    const versionAfterFirst = await getUserVersion(db);
+
+    const applied: number[] = [];
+    const spySteps: Migration[] = [
+      {
+        version: 1,
+        name: 'one',
+        up: async () => {
+          applied.push(1);
+        },
+      },
+      {
+        version: 2,
+        name: 'two',
+        up: async () => {
+          applied.push(2);
+        },
+      },
+    ];
+    await runMigrations(db, spySteps);
+    expect(applied).toEqual([]);
+    await expect(getUserVersion(db)).resolves.toBe(versionAfterFirst);
+  });
+
+  it('runs only migrations newer than the current user_version', async () => {
+    const applied: number[] = [];
+    const db = createFakeDb(1);
+    await runMigrations(db, [
+      {
+        version: 1,
+        name: 'one',
+        up: async () => {
+          applied.push(1);
+        },
+      },
+      {
+        version: 2,
+        name: 'two',
+        up: async () => {
+          applied.push(2);
+        },
+      },
+    ]);
+    expect(applied).toEqual([2]);
+    await expect(getUserVersion(db)).resolves.toBe(2);
+  });
+
+  it('upgrades an old-shape chapter_assignments table without losing rows', async () => {
+    const db = createFakeDb(0);
+    db._seedOldChapterAssignments();
+
+    const before = await db.execute('SELECT * FROM chapter_assignments');
+    expect(before.rows).toHaveLength(1);
+    expect(before.rows[0].id).toBe(1);
+    expect(await columnExists(db, 'chapter_assignments', 'total_verses')).toBe(
+      false,
+    );
+
+    await runMigrations(db);
+
+    expect(await columnExists(db, 'chapter_assignments', 'total_verses')).toBe(
+      true,
+    );
+    expect(
+      await columnExists(db, 'chapter_assignments', 'completed_verses'),
+    ).toBe(true);
+    expect(
+      await columnExists(db, 'chapter_assignments', 'peer_checker_id'),
+    ).toBe(true);
+
+    const after = await db.execute('SELECT * FROM chapter_assignments');
+    expect(after.rows).toHaveLength(1);
+    expect(after.rows[0].id).toBe(1);
+    expect(after.rows[0].status).toBe('in_progress');
+    await expect(getUserVersion(db)).resolves.toBe(2);
+  });
+
+  it('addColumnIfMissing is a no-op when the column already exists', async () => {
+    const db = createFakeDb(0);
+    db._seedOldChapterAssignments();
+    await addColumnIfMissing(
+      db,
+      'chapter_assignments',
+      'total_verses',
+      'INTEGER NOT NULL DEFAULT 0',
+    );
+    await addColumnIfMissing(
+      db,
+      'chapter_assignments',
+      'total_verses',
+      'INTEGER NOT NULL DEFAULT 0',
+    );
+    expect(await columnExists(db, 'chapter_assignments', 'total_verses')).toBe(
+      true,
+    );
+  });
+
+  it('rebuildTable copies rows through create → copy → drop → rename', async () => {
+    const db = createFakeDb(0);
+    db._seedOldChapterAssignments();
+
+    await rebuildTable(db, {
+      tableName: 'chapter_assignments',
+      createSql: `CREATE TABLE IF NOT EXISTS chapter_assignments_new (
+        id INTEGER PRIMARY KEY,
+        status TEXT NOT NULL,
+        total_verses INTEGER NOT NULL DEFAULT 0
+      )`,
+      copySql: `INSERT INTO chapter_assignments_new (id, status, total_verses)
+        SELECT id, status, 0 FROM chapter_assignments`,
+      indexes: [
+        'CREATE INDEX IF NOT EXISTS idx_ca_status ON chapter_assignments(status)',
+      ],
+    });
+
+    const table = db._tables.get('chapter_assignments');
+    expect(table).toBeDefined();
+    expect(table!.columns.has('total_verses')).toBe(true);
+    expect(table!.rows).toHaveLength(1);
+    expect(table!.rows[0].id).toBe(1);
+    expect(table!.rows[0].status).toBe('in_progress');
+    expect(db._tables.has('chapter_assignments_new')).toBe(false);
+  });
+
+  it('setUserVersion and getUserVersion round-trip', async () => {
+    const db = createFakeDb(0);
+    await setUserVersion(db, 7);
+    await expect(getUserVersion(db)).resolves.toBe(7);
+  });
+});

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,0 +1,166 @@
+import type {
+  DB,
+  QueryResult,
+  Scalar,
+  Transaction,
+} from '@op-engineering/op-sqlite';
+import { createTableQueries } from './schema';
+import { logger } from '../utils/logger';
+
+const log = logger.create('Migrations');
+
+/** Anything that can run SQL (DB or in-transaction handle). */
+export type SqlExecutor = {
+  execute: (query: string, params?: Scalar[]) => Promise<QueryResult>;
+};
+
+export type Migration = {
+  version: number;
+  name: string;
+  up: (db: SqlExecutor) => Promise<void>;
+};
+
+export const CURRENT_SCHEMA_VERSION = 2;
+
+export async function getUserVersion(db: SqlExecutor): Promise<number> {
+  const result = await db.execute('PRAGMA user_version');
+  const row = result.rows[0] as { user_version?: number } | undefined;
+  return row?.user_version ?? 0;
+}
+
+export async function setUserVersion(
+  db: SqlExecutor,
+  version: number,
+): Promise<void> {
+  await db.execute(`PRAGMA user_version = ${version}`);
+}
+
+export async function columnExists(
+  db: SqlExecutor,
+  tableName: string,
+  columnName: string,
+): Promise<boolean> {
+  const result = await db.execute(`PRAGMA table_info(${tableName})`);
+  return result.rows.some(row => row.name === columnName);
+}
+
+export async function addColumnIfMissing(
+  db: SqlExecutor,
+  tableName: string,
+  columnName: string,
+  columnSql: string,
+): Promise<void> {
+  if (await columnExists(db, tableName, columnName)) {
+    return;
+  }
+  await db.execute(
+    `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnSql}`,
+  );
+}
+
+export type RebuildTableOptions = {
+  tableName: string;
+  /** CREATE TABLE for the temporary `_new` table (must use `${tableName}_new`). */
+  createSql: string;
+  /** INSERT INTO … SELECT … FROM old table. */
+  copySql: string;
+  /** Indexes to recreate after rename. */
+  indexes?: string[];
+};
+
+/**
+ * SQLite table rebuild for FK / default / column-type changes.
+ * Pattern: create `_new` → copy → drop old → rename → indexes.
+ * Used by follow-ups #99 / #103 (not invoked by baseline migrations).
+ */
+export async function rebuildTable(
+  db: SqlExecutor,
+  options: RebuildTableOptions,
+): Promise<void> {
+  const { tableName, createSql, copySql, indexes = [] } = options;
+  const tempName = `${tableName}_new`;
+
+  await db.execute(createSql);
+  await db.execute(copySql);
+  await db.execute(`DROP TABLE ${tableName}`);
+  await db.execute(`ALTER TABLE ${tempName} RENAME TO ${tableName}`);
+
+  for (const indexSql of indexes) {
+    await db.execute(indexSql);
+  }
+}
+
+async function applyBaselineSchema(db: SqlExecutor): Promise<void> {
+  for (const query of createTableQueries) {
+    await db.execute(query);
+  }
+}
+
+async function applyVerseProgressColumns(db: SqlExecutor): Promise<void> {
+  await addColumnIfMissing(
+    db,
+    'chapter_assignments',
+    'peer_checker_id',
+    'INTEGER',
+  );
+  await addColumnIfMissing(
+    db,
+    'chapter_assignments',
+    'total_verses',
+    'INTEGER NOT NULL DEFAULT 0',
+  );
+  await addColumnIfMissing(
+    db,
+    'chapter_assignments',
+    'completed_verses',
+    'INTEGER NOT NULL DEFAULT 0',
+  );
+}
+
+/** Ordered schema migrations. Version 1 = current CREATE IF NOT EXISTS baseline. */
+export const migrations: Migration[] = [
+  {
+    version: 1,
+    name: 'baseline_schema',
+    up: applyBaselineSchema,
+  },
+  {
+    version: 2,
+    name: 'chapter_assignment_verse_progress',
+    up: applyVerseProgressColumns,
+  },
+];
+
+/**
+ * Apply migrations with `version > PRAGMA user_version`, each once, in order.
+ * Each step runs inside a DB transaction; `user_version` advances on success.
+ */
+export async function runMigrations(
+  db: DB,
+  steps: Migration[] = migrations,
+): Promise<void> {
+  const current = await getUserVersion(db);
+  const pending = [...steps]
+    .filter(step => step.version > current)
+    .sort((a, b) => a.version - b.version);
+
+  if (pending.length === 0) {
+    log.info('Schema up to date', { userVersion: current });
+    return;
+  }
+
+  for (const step of pending) {
+    log.info('Applying migration', {
+      version: step.version,
+      name: step.name,
+    });
+
+    await db.transaction(async (tx: Transaction) => {
+      await step.up(tx);
+      await setUserVersion(tx, step.version);
+    });
+  }
+
+  const next = await getUserVersion(db);
+  log.info('Migrations complete', { userVersion: next });
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -103,10 +103,3 @@ export const createTableQueries: string[] = [
 
   `CREATE INDEX IF NOT EXISTS idx_up_user ON user_projects(user_id);`,
 ];
-
-/** For DBs created before verse progress columns were added. */
-export const chapterAssignmentMigrations: string[] = [
-  `ALTER TABLE chapter_assignments ADD COLUMN peer_checker_id INTEGER`,
-  `ALTER TABLE chapter_assignments ADD COLUMN total_verses INTEGER NOT NULL DEFAULT 0`,
-  `ALTER TABLE chapter_assignments ADD COLUMN completed_verses INTEGER NOT NULL DEFAULT 0`,
-];


### PR DESCRIPTION
### TLDR

Replaces ignore-errors `ALTER` loops with a `PRAGMA user_version` migration runner. Baseline schema is v1; verse-progress / `peer_checker_id` column adds are v2 via `addColumnIfMissing`. Adds `rebuildTable()` for upcoming FK rebuild tickets. Removes `chapterAssignmentMigrations`. Unblocks #99 / #103 / #105 without applying those schema changes here.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #110

`initializeDatabase` still sets pragmas, then calls `runMigrations(db)`. Each pending migration runs once, in order, inside a transaction; `user_version` advances on success. Fresh DBs and already-upgraded devices both converge to version 2.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Maintenance / refactor

#### Technical changes

- **`src/db/migrations.ts`** — `runMigrations`, `addColumnIfMissing`, `rebuildTable`, migrations v1–v2
- **`src/db/migrations.test.ts`** — Fresh apply, idempotency, old-shape upgrade with row preserved, rebuild helper
- **`src/db/index.ts`** — Drop ad-hoc statement runner; call `runMigrations`
- **`src/db/schema.ts`** — Remove `chapterAssignmentMigrations`
- **`src/db/AGENTS.md`**, **`.cursor/rules/architecture.mdc`**, **`docs/AGENT_ONBOARDING.md`** — Document versioned migrations

#### Testing

Ran: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test -- --ci` (243 passed at PR time).

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Read `src/db/migrations.ts` — confirm v1 baseline + v2 column adds; no ignore-errors ALTER array left
3. Optional Android cold start on an existing install — app opens; data still present (framework only; no intentional schema rebuild yet)

**Expected:** Versioned migrations on init; tests prove fresh apply, second-run no-op, and old-shape upgrade without losing sample rows. No #99/#103/#105 schema rebuilds in this PR.

### Follow-ups

- [ ] #99 — chapter_assignments FK rebuild (use `rebuildTable`)
- [ ] #103 — user_projects FK rebuild
- [ ] #105 — attribution column migration
