### PR TITLE
[#211]: Require filled PR template in delivery rules

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -57,7 +57,9 @@ See [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) for full command 
 
 ## Template
 
-Load [`.cursor/templates/pr-template.md`](../templates/pr-template.md) and pre-fill:
+**Always** load [`.cursor/templates/pr-template.md`](../templates/pr-template.md) and pre-fill — this is mandatory for **every** agent-opened PR in this repo ([delivery.mdc](../rules/delivery.mdc)), not only when this slash command is used. Do not substitute a short Summary/Test plan body.
+
+Pre-fill:
 
 **From GitHub issue:**
 

--- a/.cursor/commands/generate-pr-description.md
+++ b/.cursor/commands/generate-pr-description.md
@@ -128,7 +128,8 @@ Fluent Mobile is **Android-only** for now. Generated PR descriptions must not in
 
 ## Template source
 
-Always read the current [`.cursor/templates/pr-template.md`](../templates/pr-template.md) — do not duplicate template content in this command file.
+**Always** read the current [`.cursor/templates/pr-template.md`](../templates/pr-template.md) — do not duplicate template content in this command file. Filling this template is mandatory for agent-opened PRs ([delivery.mdc](../rules/delivery.mdc)), including when generating a body for manual paste.
+
 
 ## Usage
 

--- a/.cursor/rules/agent-guardrails.mdc
+++ b/.cursor/rules/agent-guardrails.mdc
@@ -14,5 +14,6 @@ Quick checklist:
 3. **Abstraction** — no generic adapter/framework without a second caller or ticket ask
 4. **Human QA** — native / mic / camera / filesystem / permissions need Android device results before ready-for-review
 5. **Agent-authored features** — review scope, abstraction, and AC-vs-CI first
+6. **PR body** — filled from [`.cursor/templates/pr-template.md`](../templates/pr-template.md) on every agent-opened PR ([delivery.mdc](./delivery.mdc)) — not a short Summary/Test plan substitute
 
 See also [delivery.mdc](./delivery.mdc) and [commands.mdc](./commands.mdc).

--- a/.cursor/rules/commands.mdc
+++ b/.cursor/rules/commands.mdc
@@ -39,7 +39,7 @@ Report what ran and the outcome. If a step was skipped, say why.
 
 ## PR workflow
 
-Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-description`, `/create-pr`, `/onboard`, `/dep-bump`, `/handle-dependabot`. Align with team PR title format: `[#NNN]: Description` (GitHub Issues — [docs/issue-tracking.md](../../docs/issue-tracking.md)). CI map: [docs/ci.md](../../docs/ci.md).
+Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-description`, `/create-pr`, `/onboard`, `/dep-bump`, `/handle-dependabot`. Align with team PR title format: `[#NNN]: Description` (GitHub Issues — [docs/issue-tracking.md](../../docs/issue-tracking.md)). **PR body must be filled from** [`.cursor/templates/pr-template.md`](../templates/pr-template.md) on every agent-opened PR — see [delivery.mdc](./delivery.mdc) (not optional; not only when `/create-pr` is typed). CI map: [docs/ci.md](../../docs/ci.md).
 
 ## Do not run without user request
 

--- a/.cursor/rules/delivery.mdc
+++ b/.cursor/rules/delivery.mdc
@@ -13,10 +13,30 @@ Every change — including infra, CI, docs, Dependabot follow-ups, and `expo ins
 
 1. **GitHub issue** — required; ask if missing (`#NNN`). See [docs/issue-tracking.md](../../docs/issue-tracking.md). (Linear is not the tracker for this repo right now.)
 2. **Feature branch** — `{author}/{type}/{issue-number}-{slug}` (see `/create-pr-branch`)
-3. **Pull request** — title `[#NNN]: Description`; body `Closes #NNN` under Details when the PR completes the issue
+3. **Pull request** — title `[#NNN]: Description`; body filled from the PR template (below)
 4. **Human merge** — agents open PRs and push **feature branches only**; never merge on GitHub unless the user explicitly asks for a Dependabot squash merge in that session
 
 Allowed on `main` locally: `git checkout main`, `git pull`, read-only validation after merges. **Not allowed:** `git push origin main`, commits on `main`, or opening PRs with `main` as the head branch.
+
+## PR body (mandatory)
+
+**Every** agent-opened PR body — whether via `/create-pr`, `gh pr create`, or any other path — **must** be filled from [`.cursor/templates/pr-template.md`](../templates/pr-template.md).
+
+Do **not** substitute a short “Summary / Test plan” or ad-hoc bullet list. Load the template and pre-fill:
+
+| Section | Required content |
+| ------- | ---------------- |
+| **TLDR** | 2–4 sentences: what / why / impact |
+| **Reviewer checklist** | Leave items unchecked unless verified |
+| **Details** | `Closes #NNN` on its own line when the PR completes the issue; short summary; type-of-change checkboxes |
+| **Technical changes** | Key files as `` `path` `` bullets |
+| **Testing** | What gates ran (`format:check`, `lint`, `typecheck`, `npm test -- --ci`) or waiver |
+| **How to verify** | Numbered steps + **Expected** |
+| **Follow-ups** | Deferred AC → linked issues (ticket-level waiver); otherwise say none |
+
+Prefer `/create-pr` or `/generate-pr-description` so the template is not skipped. Keep under ~400 lines; no nested fenced code blocks inside the PR body.
+
+This repo’s template **wins** over generic personal or org-wide PR body shapes when they conflict.
 
 ## Dependabot exception (merge only)
 
@@ -26,4 +46,4 @@ Agent-authored fixes (expo doctor CI, lockfile repair, conflict resolution) stil
 
 ## Before delivery
 
-Run gates from [commands.mdc](./commands.mdc). Also apply delivery judgment from root [`AGENTS.md`](../../AGENTS.md) (AC, scope, abstraction, human QA) — Cursor pointer: [agent-guardrails.mdc](./agent-guardrails.mdc). Use `/create-pr` when the user wants a PR opened.
+Run gates from [commands.mdc](./commands.mdc). Also apply delivery judgment from root [`AGENTS.md`](../../AGENTS.md) (AC, scope, abstraction, human QA) — Cursor pointer: [agent-guardrails.mdc](./agent-guardrails.mdc). Use `/create-pr` when the user wants a PR opened (template still required if opening the PR another way).

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -34,7 +34,7 @@ Keep `.cursor/rules/*.mdc` in sync with onboarding — short pointers only; avoi
 
 ## PR template
 
-[.cursor/templates/pr-template.md](../templates/pr-template.md) — update if required PR sections or verification steps change.
+[.cursor/templates/pr-template.md](../templates/pr-template.md) — update if required PR sections or verification steps change. Agents must fill this template on every PR ([delivery.mdc](./delivery.mdc)).
 
 ## Nested hot-path notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ On feature PRs with heavy agent co-authorship, reviewers should prioritize **sco
 
 ## Related
 
-- Delivery / branch / PR process: [`.cursor/rules/delivery.mdc`](.cursor/rules/delivery.mdc)
+- Delivery / branch / PR process: [`.cursor/rules/delivery.mdc`](.cursor/rules/delivery.mdc) — **PR bodies must use** [`.cursor/templates/pr-template.md`](.cursor/templates/pr-template.md)
 - Issue tracking (GitHub Issues): [docs/issue-tracking.md](docs/issue-tracking.md)
 - CI command order: [`.cursor/rules/commands.mdc`](.cursor/rules/commands.mdc)
 - CI inventory: [docs/ci.md](docs/ci.md)

--- a/docs/issue-tracking.md
+++ b/docs/issue-tracking.md
@@ -35,10 +35,10 @@ See [`.cursor/commands/create-pr-branch.md`](../.cursor/commands/create-pr-branc
 
 - **Base branch:** `main`
 - **Title:** `[#NNN]: Short description` (or `#NNN: Short description`) — match existing PR style in this repo
-- **Body:** link the issue under Details:
-  - `Closes #NNN` when the PR **completes** the issue (auto-closes on merge to `main`)
+- **Body:** **required** — fill [`.cursor/templates/pr-template.md`](../.cursor/templates/pr-template.md) (TLDR, Reviewer checklist, Details, Technical changes, Testing, How to verify, Follow-ups). Prefer `/generate-pr-description` or `/create-pr`. Do not ship a short Summary/Test plan substitute.
+  - Under Details: `Closes #NNN` when the PR **completes** the issue (auto-closes on merge to `main`)
   - For related work that must stay open, say “Part of #NNN” in prose, or link manually in the PR sidebar — do not use a closing keyword
-- **Template:** [`.cursor/templates/pr-template.md`](../.cursor/templates/pr-template.md) — generate with `/generate-pr-description` or `/create-pr`
+- **Template source of truth:** [`.cursor/templates/pr-template.md`](../.cursor/templates/pr-template.md) — also required by [delivery.mdc](../.cursor/rules/delivery.mdc)
 
 ### Closing keywords
 


### PR DESCRIPTION
### TLDR

Closes the process gap where agents could open thin PR bodies while still satisfying `delivery.mdc` (title + `Closes #NNN` only). Always-on rules now require filling `.cursor/templates/pr-template.md` for every agent-opened PR — slash command or not — and say this repo’s template wins over generic Summary/Test plan shapes.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #211

Docs/rules only. No runtime behavior change. Existing open product PRs already had their bodies rewritten to the template in-session; this PR makes that requirement structural for future agent work.

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Maintenance / refactor

#### Technical changes

- **`.cursor/rules/delivery.mdc`** — new **PR body (mandatory)** section; template table; wins over generic body shapes
- **`.cursor/rules/agent-guardrails.mdc`** — checklist item 6 for PR template
- **`.cursor/rules/commands.mdc`** — PR workflow points at mandatory template
- **`.cursor/rules/docs.mdc`** — PR template section links delivery requirement
- **`.cursor/commands/create-pr.md`** / **`generate-pr-description.md`** — template required for every agent-opened PR, not only slash invocation
- **`docs/issue-tracking.md`** / **`AGENTS.md`** — body/template language strengthened

#### Testing

Docs/rules only. Ran `npm run format:check`, `npm run lint`, `npm run typecheck`. No product tests required.

### How to verify

1. Read `.cursor/rules/delivery.mdc` — confirm **PR body (mandatory)** section and template path
2. Confirm `agent-guardrails.mdc` item 6 and `commands.mdc` PR workflow mention the same requirement
3. Skim `docs/issue-tracking.md` — body is required via the template, not optional

**Expected:** An agent with only always-on rules loaded still sees that thin Summary/Test plan PR bodies are non-compliant for fluent-mobile.

### Follow-ups

- None for AC. Optional later: Cursor user-rule note that fluent-mobile template overrides personal PR formats (out of repo).
