### PR TITLE
[#150]: Implement upload trigger and sync engine

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,10 @@ import { syncAllData } from './src/services/sync';
 import { restoreSession, signOut } from './src/services/authSession';
 import AppNavigator from './src/navigation/AppNavigator';
 import { onAuthSessionExpired } from './src/services/syncEvents';
+import {
+  startUploadOrchestrator,
+  stopUploadOrchestrator,
+} from './src/services/uploadOrchestrator';
 import { queryClient } from './src/services/queryClient';
 import { appStyles } from './src/app/appStyles';
 import { theme } from './src/theme';
@@ -24,6 +28,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
 
   const handleSignOut = () => {
+    stopUploadOrchestrator();
     signOut();
     setIsAuthenticated(false);
   };
@@ -31,6 +36,7 @@ function App() {
   useEffect(() => {
     return onAuthSessionExpired(() => {
       log.info('Session expired — returning to login');
+      stopUploadOrchestrator();
       signOut();
       setIsAuthenticated(false);
     });
@@ -52,6 +58,18 @@ function App() {
 
     initApp();
   }, []);
+
+  useEffect(() => {
+    if (!dbReady || !isAuthenticated) {
+      stopUploadOrchestrator();
+      return;
+    }
+
+    startUploadOrchestrator();
+    return () => {
+      stopUploadOrchestrator();
+    };
+  }, [dbReady, isAuthenticated]);
 
   useEffect(() => {
     if (!dbReady) {

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import React from 'react';
-import App from '../App';
 import { render, waitFor } from '@testing-library/react-native';
 import BootSplash from 'react-native-bootsplash';
 
@@ -72,12 +71,19 @@ jest.mock('../src/services/authSession', () => ({
   signOut: jest.fn(),
 }));
 
+jest.mock('../src/services/uploadOrchestrator', () => ({
+  startUploadOrchestrator: jest.fn(),
+  stopUploadOrchestrator: jest.fn(),
+}));
+
 // Keychain
 jest.mock('../src/services/keychain', () => ({
   hasCredentials: jest.fn(() => Promise.resolve(false)),
   getCredentials: jest.fn(() => Promise.resolve(null)),
   getAllStoredUserIds: jest.fn(() => Promise.resolve([])),
 }));
+
+import App from '../App';
 
 describe('App', () => {
   it('renders navigator after initialization', async () => {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -425,6 +425,38 @@ export async function getPendingUploadCount(): Promise<number> {
   }
 }
 
+export type PendingUploadChapter = {
+  bookId: number;
+  chapterNumber: number;
+};
+
+/**
+ * Distinct chapters with at least one latest non-uploaded recording.
+ * Upload engine (#150) processes work per chapter, not per verse.
+ */
+export async function getPendingUploadChapters(): Promise<
+  PendingUploadChapter[]
+> {
+  const db = getDatabase();
+  try {
+    const result = await db.execute(
+      `SELECT DISTINCT bt.book_id AS book_id, bt.chapter_number AS chapter_number
+       FROM recordings r
+       JOIN bible_texts bt ON bt.id = r.bible_text_id
+       WHERE r.is_latest = 1 AND r.sync_status != 'uploaded'
+       ORDER BY bt.book_id, bt.chapter_number`,
+    );
+    const rows = result.rows ?? [];
+    return rows.map(row => ({
+      bookId: Number(row.book_id),
+      chapterNumber: Number(row.chapter_number),
+    }));
+  } catch (error) {
+    log.error('Error fetching pending upload chapters', { error });
+    return [];
+  }
+}
+
 export async function getBibleTexts(
   bibleId: number,
   bookId: number,

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -8,6 +8,7 @@ Agents: keep this layer thin. Full contract: [docs/guides/api-client-standard.md
 - **SQLite-first reads** — UI loads from `src/db/queries.ts` after sync; do not add react-query list hooks for projects/chapters/verses.
 - **Auth** — bearer via `authToken` / `authedRequest`; `publicRequest` has no bearer. Mobile headers on auth calls only (`signIn`, `forgotPassword`, `signOut`).
 - **Sync** — orchestration + retries live in `sync.ts`; persist through `src/db/repository.ts`; KV timestamps/counts in `storage.ts`.
+- **Recording uploads** — trigger/pause/cancel/cellular gate live in `uploadOrchestrator.ts` (+ `uploadOrchestratorCore.ts`). Register the real chapter worker via `setChapterUploadWorker` from #100. Do not conflate with metadata `syncAllData`.
 - **Errors** — `ApiError` / `AuthError`; no raw response bodies in logs.
 
 ## Adding an endpoint

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -23,6 +23,8 @@ export const KV_KEYS = {
   SYNC_ERROR_CHAPTER_ASSIGNMENTS: 'sync_error_chapter_assignments',
   SYNC_ERROR_PROJECT_UNITS: 'sync_error_project_units',
   SYNC_ERROR_BIBLE_TEXTS: 'sync_error_bible_texts',
+  /** ISO timestamp; empty / missing = not paused. */
+  SYNC_PAUSED_UNTIL: 'sync_paused_until',
 } as const;
 
 export function clearUserSession() {
@@ -175,4 +177,26 @@ export function getUserLastSyncedAt(userId: string): string {
 export function setUserLastSyncedAt(userId: string, timestamp: string) {
   kvStorage.setItemSync(`${userId}:last_synced_at`, timestamp);
   log.info('Per-user last synced timestamp updated', { userId, timestamp });
+}
+
+/** End of user pause window (ms since epoch), or null if not paused. */
+export function getSyncPausedUntilMs(): number | null {
+  const raw = kvStorage.getItemSync(KV_KEYS.SYNC_PAUSED_UNTIL);
+  if (!raw) {
+    return null;
+  }
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function setSyncPausedUntilMs(ms: number | null): void {
+  if (ms === null) {
+    kvStorage.removeItemSync(KV_KEYS.SYNC_PAUSED_UNTIL);
+    return;
+  }
+  kvStorage.setItemSync(KV_KEYS.SYNC_PAUSED_UNTIL, new Date(ms).toISOString());
+}
+
+export function clearSyncPausedUntil(): void {
+  setSyncPausedUntilMs(null);
 }

--- a/src/services/syncEvents.ts
+++ b/src/services/syncEvents.ts
@@ -40,3 +40,29 @@ export function onAuthSessionExpired(fn: SyncListener): () => void {
 export function emitAuthSessionExpired(): void {
   [...authSessionExpiredListeners].forEach(fn => fn());
 }
+
+/** Recording-upload session events (distinct from metadata sync). */
+export type UploadSessionEvent =
+  | { type: 'start'; totalChapters: number }
+  | { type: 'progress'; completedChapters: number; totalChapters: number }
+  | { type: 'paused'; reason: 'user' | 'connectivity' }
+  | { type: 'cancelled' }
+  | { type: 'complete' }
+  | { type: 'waiting_wifi' }
+  | { type: 'idle' };
+
+type UploadSessionListener = (event: UploadSessionEvent) => void;
+
+const uploadSessionListeners: UploadSessionListener[] = [];
+
+export function onUploadSessionEvent(fn: UploadSessionListener): () => void {
+  uploadSessionListeners.push(fn);
+  return () => {
+    const idx = uploadSessionListeners.indexOf(fn);
+    if (idx > -1) uploadSessionListeners.splice(idx, 1);
+  };
+}
+
+export function emitUploadSessionEvent(event: UploadSessionEvent): void {
+  [...uploadSessionListeners].forEach(fn => fn(event));
+}

--- a/src/services/uploadOrchestrator.test.ts
+++ b/src/services/uploadOrchestrator.test.ts
@@ -1,0 +1,285 @@
+import {
+  createUploadOrchestrator,
+  PAUSE_WINDOW_MS,
+  type ChapterUploadWorker,
+  type UploadOrchestratorDeps,
+} from './uploadOrchestratorCore';
+import type { UploadSessionEvent } from './syncEvents';
+import type { PendingUploadChapter } from '../db/queries';
+
+jest.mock('../utils/logger', () => ({
+  logger: {
+    create: () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }),
+  },
+}));
+
+type ConnListener = (isOnline: boolean, isWifi: boolean) => void;
+
+function createHarness(options?: {
+  chapters?: PendingUploadChapter[];
+  uploadOverCellular?: boolean;
+  workerDelayMs?: number;
+}) {
+  let connListener: ConnListener | null = null;
+  let prefListener: ((value: boolean) => void) | null = null;
+  let uploadOverCellular = options?.uploadOverCellular ?? false;
+  let pausedUntilMs: number | null = null;
+  let nowMs = 1_000_000;
+  const events: UploadSessionEvent[] = [];
+  const uploaded: PendingUploadChapter[] = [];
+  let chapters = options?.chapters ?? [
+    { bookId: 1, chapterNumber: 1 },
+    { bookId: 1, chapterNumber: 2 },
+  ];
+
+  const worker: ChapterUploadWorker = {
+    uploadChapter: async (chapter, signal) => {
+      if (options?.workerDelayMs) {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, options.workerDelayMs);
+          const onAbort = () => {
+            clearTimeout(timer);
+            reject(new Error('aborted'));
+          };
+          if (signal.aborted) {
+            onAbort();
+            return;
+          }
+          signal.addEventListener('abort', onAbort, { once: true });
+        });
+      }
+      if (signal.aborted) {
+        throw new Error('aborted');
+      }
+      uploaded.push(chapter);
+    },
+  };
+
+  const deps: UploadOrchestratorDeps = {
+    subscribeToConnectivity: onChange => {
+      connListener = onChange;
+      return () => {
+        connListener = null;
+      };
+    },
+    getUploadOverCellular: () => uploadOverCellular,
+    subscribeToUploadOverCellular: listener => {
+      prefListener = listener;
+      return () => {
+        prefListener = null;
+      };
+    },
+    getPendingUploadChapters: async () => chapters,
+    getPausedUntilMs: () => pausedUntilMs,
+    setPausedUntilMs: ms => {
+      pausedUntilMs = ms;
+    },
+    now: () => nowMs,
+    pauseWindowMs: PAUSE_WINDOW_MS,
+    worker,
+    emit: event => {
+      events.push(event);
+    },
+  };
+
+  const orchestrator = createUploadOrchestrator(deps);
+  orchestrator.start();
+
+  return {
+    orchestrator,
+    events,
+    uploaded,
+    setChapters: (next: PendingUploadChapter[]) => {
+      chapters = next;
+    },
+    setNow: (ms: number) => {
+      nowMs = ms;
+    },
+    setCellularPref: (value: boolean) => {
+      uploadOverCellular = value;
+      prefListener?.(value);
+    },
+    emitConnectivity: (isOnline: boolean, isWifi: boolean) => {
+      connListener?.(isOnline, isWifi);
+    },
+    getPausedUntilMs: () => pausedUntilMs,
+    flush: async () => {
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 0);
+      });
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 0);
+      });
+    },
+    waitFor: async (
+      predicate: () => boolean,
+      timeoutMs = 500,
+    ): Promise<void> => {
+      const start = Date.now();
+      while (!predicate()) {
+        if (Date.now() - start > timeoutMs) {
+          throw new Error('waitFor timed out');
+        }
+        await new Promise<void>(resolve => {
+          setTimeout(resolve, 10);
+        });
+      }
+    },
+  };
+}
+
+describe('uploadOrchestrator', () => {
+  it('auto-uploads on Wi‑Fi when pending chapters exist (online = server reachable)', async () => {
+    const h = createHarness();
+    h.emitConnectivity(true, true);
+    await h.flush();
+    await h.flush();
+
+    expect(h.uploaded).toEqual([
+      { bookId: 1, chapterNumber: 1 },
+      { bookId: 1, chapterNumber: 2 },
+    ]);
+    expect(h.events.some(e => e.type === 'start')).toBe(true);
+    expect(h.events.some(e => e.type === 'complete')).toBe(true);
+    expect(h.orchestrator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('does not auto-upload on cellular when uploadOverCellular is false', async () => {
+    const h = createHarness({ uploadOverCellular: false });
+    h.emitConnectivity(true, false);
+    await h.flush();
+
+    expect(h.uploaded).toEqual([]);
+    expect(h.orchestrator.getSnapshot().phase).toBe('waiting_wifi');
+    expect(h.events.some(e => e.type === 'waiting_wifi')).toBe(true);
+  });
+
+  it('auto-uploads on cellular when uploadOverCellular is true', async () => {
+    const h = createHarness({ uploadOverCellular: true });
+    h.emitConnectivity(true, false);
+    await h.flush();
+    await h.flush();
+
+    expect(h.uploaded).toHaveLength(2);
+    expect(h.events.some(e => e.type === 'complete')).toBe(true);
+  });
+
+  it('silently pauses mid-upload when server becomes unreachable and resumes on restore', async () => {
+    const h = createHarness({ workerDelayMs: 40 });
+    h.emitConnectivity(true, true);
+    await h.waitFor(() => h.orchestrator.getSnapshot().phase === 'syncing');
+
+    h.emitConnectivity(false, true);
+    await h.waitFor(() => h.orchestrator.getSnapshot().phase === 'offline');
+    expect(
+      h.events.some(e => e.type === 'paused' && e.reason === 'connectivity'),
+    ).toBe(true);
+
+    h.setChapters([{ bookId: 1, chapterNumber: 9 }]);
+    h.emitConnectivity(true, true);
+    await h.waitFor(() => h.uploaded.some(c => c.chapterNumber === 9));
+    await h.waitFor(() => h.events.some(e => e.type === 'complete'));
+  });
+
+  it('cancel stops upload and does not auto-retry until a new online edge', async () => {
+    const h = createHarness({ workerDelayMs: 40 });
+    h.emitConnectivity(true, true);
+    await h.waitFor(() => h.orchestrator.getSnapshot().phase === 'syncing');
+    await h.orchestrator.cancel();
+    await h.waitFor(() => h.events.some(e => e.type === 'cancelled'));
+
+    const countAfterCancel = h.uploaded.length;
+
+    // Still online — no new online edge → no auto retry
+    h.emitConnectivity(true, true);
+    await h.flush();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 50);
+    });
+    expect(h.uploaded.length).toBe(countAfterCancel);
+
+    // Offline then online → auto-upload re-fires
+    h.emitConnectivity(false, true);
+    await h.waitFor(() => h.orchestrator.getSnapshot().phase === 'offline');
+    h.setChapters([{ bookId: 2, chapterNumber: 1 }]);
+    h.emitConnectivity(true, true);
+    await h.waitFor(() => h.uploaded.some(c => c.bookId === 2));
+  });
+
+  it('pause blocks auto-upload for 24h; Sync Now clears the window', async () => {
+    const h = createHarness();
+    h.emitConnectivity(true, true);
+    await h.flush();
+    await h.flush();
+
+    h.setChapters([{ bookId: 3, chapterNumber: 1 }]);
+    await h.orchestrator.pause();
+
+    expect(h.getPausedUntilMs()).toBe(1_000_000 + PAUSE_WINDOW_MS);
+    expect(h.orchestrator.getSnapshot().phase).toBe('paused');
+
+    h.emitConnectivity(true, true);
+    await h.flush();
+    expect(h.uploaded.some(c => c.bookId === 3)).toBe(false);
+
+    await h.orchestrator.syncNow();
+    await h.flush();
+
+    expect(h.getPausedUntilMs()).toBeNull();
+    expect(h.uploaded.some(c => c.bookId === 3)).toBe(true);
+  });
+
+  it('pausing again after Sync Now starts a fresh 24h window', async () => {
+    const h = createHarness();
+    h.emitConnectivity(true, true);
+    await h.flush();
+    await h.flush();
+
+    await h.orchestrator.pause();
+    const firstUntil = h.getPausedUntilMs();
+
+    h.setNow(1_000_000 + 60_000);
+    await h.orchestrator.syncNow();
+    await h.flush();
+
+    h.setChapters([{ bookId: 4, chapterNumber: 1 }]);
+    await h.orchestrator.pause();
+    const secondUntil = h.getPausedUntilMs();
+
+    expect(secondUntil).not.toBe(firstUntil);
+    expect(secondUntil).toBe(1_000_000 + 60_000 + PAUSE_WINDOW_MS);
+  });
+
+  it('skips sessions when no worker is registered', async () => {
+    let connListener: ConnListener | null = null;
+    const events: UploadSessionEvent[] = [];
+    const orchestrator = createUploadOrchestrator({
+      subscribeToConnectivity: onChange => {
+        connListener = onChange;
+        return () => {
+          connListener = null;
+        };
+      },
+      getUploadOverCellular: () => false,
+      subscribeToUploadOverCellular: () => () => undefined,
+      getPendingUploadChapters: async () => [{ bookId: 1, chapterNumber: 1 }],
+      getPausedUntilMs: () => null,
+      setPausedUntilMs: () => undefined,
+      now: () => 0,
+      pauseWindowMs: PAUSE_WINDOW_MS,
+      worker: null,
+      emit: e => events.push(e),
+    });
+    orchestrator.start();
+    connListener!(true, true);
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(events.some(e => e.type === 'idle')).toBe(true);
+    expect(orchestrator.getSnapshot().phase).toBe('idle');
+  });
+});

--- a/src/services/uploadOrchestrator.ts
+++ b/src/services/uploadOrchestrator.ts
@@ -1,0 +1,103 @@
+import { getPendingUploadChapters } from '../db/queries';
+import { subscribeToConnectivity } from './connectivity';
+import { emitUploadSessionEvent } from './syncEvents';
+import { getSyncPausedUntilMs, setSyncPausedUntilMs } from './storage';
+import {
+  getUploadOverCellular,
+  subscribeToPreference,
+} from './userPreferences';
+import {
+  createUploadOrchestrator,
+  PAUSE_WINDOW_MS,
+  type ChapterUploadWorker,
+  type UploadOrchestrator,
+  type UploadOrchestratorDeps,
+  type UploadOrchestratorSnapshot,
+} from './uploadOrchestratorCore';
+
+export {
+  createUploadOrchestrator,
+  PAUSE_WINDOW_MS,
+  type ChapterUploadWorker,
+  type UploadOrchestrator,
+  type UploadOrchestratorDeps,
+  type UploadOrchestratorSnapshot,
+  type UploadPhase,
+} from './uploadOrchestratorCore';
+
+/** Production singleton — worker registered by #100 via setChapterUploadWorker. */
+let chapterUploadWorker: ChapterUploadWorker | null = null;
+let singleton: UploadOrchestrator | null = null;
+
+export function setChapterUploadWorker(
+  worker: ChapterUploadWorker | null,
+): void {
+  chapterUploadWorker = worker;
+}
+
+export function getChapterUploadWorker(): ChapterUploadWorker | null {
+  return chapterUploadWorker;
+}
+
+export function getUploadOrchestrator(): UploadOrchestrator {
+  if (!singleton) {
+    throw new Error(
+      'Upload orchestrator not started — call startUploadOrchestrator first',
+    );
+  }
+  return singleton;
+}
+
+export function startUploadOrchestrator(
+  overrides?: Partial<UploadOrchestratorDeps>,
+): UploadOrchestrator {
+  if (singleton) {
+    singleton.stop();
+  }
+
+  const { worker: workerOverride, ...restOverrides } = overrides ?? {};
+
+  const deps: UploadOrchestratorDeps = {
+    subscribeToConnectivity,
+    getUploadOverCellular,
+    subscribeToUploadOverCellular: listener =>
+      subscribeToPreference('uploadOverCellular', listener),
+    getPendingUploadChapters,
+    getPausedUntilMs: getSyncPausedUntilMs,
+    setPausedUntilMs: setSyncPausedUntilMs,
+    now: () => Date.now(),
+    pauseWindowMs: PAUSE_WINDOW_MS,
+    emit: emitUploadSessionEvent,
+    worker:
+      overrides && 'worker' in overrides
+        ? workerOverride ?? null
+        : chapterUploadWorker,
+    ...restOverrides,
+  };
+
+  singleton = createUploadOrchestrator(deps);
+  singleton.start();
+  return singleton;
+}
+
+export function stopUploadOrchestrator(): void {
+  singleton?.stop();
+  singleton = null;
+}
+
+/** Imperative APIs for Sync page controls (#151). */
+export async function pauseUploadSession(): Promise<void> {
+  await getUploadOrchestrator().pause();
+}
+
+export async function cancelUploadSession(): Promise<void> {
+  await getUploadOrchestrator().cancel();
+}
+
+export async function syncNowUploads(): Promise<void> {
+  await getUploadOrchestrator().syncNow();
+}
+
+export function getUploadSessionSnapshot(): UploadOrchestratorSnapshot {
+  return getUploadOrchestrator().getSnapshot();
+}

--- a/src/services/uploadOrchestratorCore.ts
+++ b/src/services/uploadOrchestratorCore.ts
@@ -1,0 +1,336 @@
+import type { PendingUploadChapter } from '../db/queries';
+import { logger } from '../utils/logger';
+import type { UploadSessionEvent } from './syncEvents';
+
+const log = logger.create('UploadOrchestrator');
+
+export const PAUSE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export type UploadPhase =
+  | 'idle'
+  | 'syncing'
+  | 'paused'
+  | 'waiting_wifi'
+  | 'offline';
+
+export type ChapterUploadWorker = {
+  uploadChapter: (
+    chapter: PendingUploadChapter,
+    signal: AbortSignal,
+  ) => Promise<void>;
+};
+
+export type UploadOrchestratorDeps = {
+  subscribeToConnectivity: (
+    onChange: (isOnline: boolean, isWifi: boolean) => void,
+  ) => () => void;
+  getUploadOverCellular: () => boolean;
+  subscribeToUploadOverCellular: (
+    listener: (value: boolean) => void,
+  ) => () => void;
+  getPendingUploadChapters: () => Promise<PendingUploadChapter[]>;
+  getPausedUntilMs: () => number | null;
+  setPausedUntilMs: (ms: number | null) => void;
+  now: () => number;
+  pauseWindowMs: number;
+  worker: ChapterUploadWorker | null;
+  emit: (event: UploadSessionEvent) => void;
+};
+
+export type UploadOrchestratorSnapshot = {
+  phase: UploadPhase;
+  completedChapters: number;
+  totalChapters: number;
+  pausedUntilMs: number | null;
+};
+
+export type UploadOrchestrator = {
+  start: () => void;
+  stop: () => void;
+  pause: () => Promise<void>;
+  cancel: () => Promise<void>;
+  syncNow: () => Promise<void>;
+  getSnapshot: () => UploadOrchestratorSnapshot;
+};
+
+function transportAllowsUpload(
+  isOnline: boolean,
+  isWifi: boolean,
+  uploadOverCellular: boolean,
+): 'ok' | 'offline' | 'waiting_wifi' {
+  if (!isOnline) {
+    return 'offline';
+  }
+  if (!isWifi && !uploadOverCellular) {
+    return 'waiting_wifi';
+  }
+  return 'ok';
+}
+
+/** Pure upload session orchestrator (injectable deps for unit tests). */
+export function createUploadOrchestrator(
+  deps: UploadOrchestratorDeps,
+): UploadOrchestrator {
+  let phase: UploadPhase = 'idle';
+  let completedChapters = 0;
+  let totalChapters = 0;
+  let isOnline = false;
+  let isWifi = false;
+  let started = false;
+  let unsubConnectivity: (() => void) | null = null;
+  let unsubPrefs: (() => void) | null = null;
+  let sessionAbort: AbortController | null = null;
+  let sessionPromise: Promise<void> | null = null;
+  /** After cancel, suppress auto-start until the next reachability→online edge. */
+  let suppressAutoUntilOnlineEdge = false;
+  let wasOnline = false;
+  let evaluateChain: Promise<void> = Promise.resolve();
+
+  const snapshot = (): UploadOrchestratorSnapshot => ({
+    phase,
+    completedChapters,
+    totalChapters,
+    pausedUntilMs: deps.getPausedUntilMs(),
+  });
+
+  const isUserPaused = (): boolean => {
+    const until = deps.getPausedUntilMs();
+    return until !== null && deps.now() < until;
+  };
+
+  const abortActiveSession = async (): Promise<void> => {
+    if (sessionAbort) {
+      sessionAbort.abort();
+    }
+    if (sessionPromise) {
+      try {
+        await sessionPromise;
+      } catch {
+        // aborted / failed sessions are expected
+      }
+    }
+    sessionAbort = null;
+    sessionPromise = null;
+  };
+
+  const runSession = async (reason: 'auto' | 'sync_now'): Promise<void> => {
+    if (sessionPromise) {
+      return;
+    }
+    if (!deps.worker) {
+      log.info('No chapter upload worker registered; skipping session', {
+        reason,
+      });
+      phase = isUserPaused() ? 'paused' : 'idle';
+      deps.emit({ type: 'idle' });
+      return;
+    }
+
+    const gate = transportAllowsUpload(
+      isOnline,
+      isWifi,
+      deps.getUploadOverCellular(),
+    );
+    if (gate === 'offline') {
+      phase = 'offline';
+      return;
+    }
+    if (gate === 'waiting_wifi') {
+      phase = 'waiting_wifi';
+      deps.emit({ type: 'waiting_wifi' });
+      return;
+    }
+    if (reason === 'auto' && isUserPaused()) {
+      phase = 'paused';
+      deps.emit({ type: 'paused', reason: 'user' });
+      return;
+    }
+    if (reason === 'auto' && suppressAutoUntilOnlineEdge) {
+      return;
+    }
+
+    const chapters = await deps.getPendingUploadChapters();
+    if (chapters.length === 0) {
+      phase = 'idle';
+      deps.emit({ type: 'idle' });
+      return;
+    }
+
+    const abort = new AbortController();
+    sessionAbort = abort;
+    completedChapters = 0;
+    totalChapters = chapters.length;
+    phase = 'syncing';
+    deps.emit({ type: 'start', totalChapters: chapters.length });
+    log.info('Upload session started', {
+      reason,
+      totalChapters: chapters.length,
+    });
+
+    const work = (async () => {
+      try {
+        for (const chapter of chapters) {
+          if (abort.signal.aborted) {
+            return;
+          }
+          await deps.worker!.uploadChapter(chapter, abort.signal);
+          if (abort.signal.aborted) {
+            return;
+          }
+          completedChapters += 1;
+          deps.emit({
+            type: 'progress',
+            completedChapters,
+            totalChapters,
+          });
+        }
+        if (!abort.signal.aborted) {
+          phase = 'idle';
+          deps.emit({ type: 'complete' });
+          log.info('Upload session complete', { totalChapters });
+        }
+      } catch (error) {
+        if (abort.signal.aborted) {
+          return;
+        }
+        log.error('Upload session failed', { error });
+        phase = 'idle';
+        deps.emit({ type: 'idle' });
+      }
+    })();
+
+    sessionPromise = work.finally(() => {
+      if (sessionAbort === abort) {
+        sessionAbort = null;
+        sessionPromise = null;
+      }
+    });
+
+    await sessionPromise;
+  };
+
+  const evaluateAuto = (): void => {
+    evaluateChain = evaluateChain
+      .then(async () => {
+        const gate = transportAllowsUpload(
+          isOnline,
+          isWifi,
+          deps.getUploadOverCellular(),
+        );
+
+        if (gate === 'offline') {
+          // Offline transitions are handled immediately in onConnectivity.
+          if (phase !== 'paused') {
+            phase = 'offline';
+          }
+          return;
+        }
+
+        if (sessionPromise && phase === 'syncing') {
+          return;
+        }
+
+        if (isUserPaused()) {
+          phase = 'paused';
+          return;
+        }
+
+        if (gate === 'waiting_wifi') {
+          phase = 'waiting_wifi';
+          deps.emit({ type: 'waiting_wifi' });
+          return;
+        }
+
+        // Do not await — keeps the evaluate chain free for later triggers.
+        void runSession('auto');
+      })
+      .catch(error => {
+        log.error('Upload orchestrator evaluate failed', { error });
+      });
+  };
+
+  const onConnectivity = (online: boolean, wifi: boolean) => {
+    const becameOnline = online && !wasOnline;
+    wasOnline = online;
+    isOnline = online;
+    isWifi = wifi;
+
+    if (!online) {
+      // Interrupt mid-upload immediately — do not wait on the evaluate chain.
+      void (async () => {
+        if (sessionPromise) {
+          await abortActiveSession();
+          phase = 'offline';
+          deps.emit({ type: 'paused', reason: 'connectivity' });
+          log.info('Upload paused silently (server unreachable)');
+        } else if (phase !== 'paused') {
+          phase = 'offline';
+        }
+      })();
+      return;
+    }
+
+    if (becameOnline) {
+      suppressAutoUntilOnlineEdge = false;
+    }
+
+    evaluateAuto();
+  };
+
+  return {
+    start() {
+      if (started) {
+        return;
+      }
+      started = true;
+      unsubConnectivity = deps.subscribeToConnectivity(onConnectivity);
+      unsubPrefs = deps.subscribeToUploadOverCellular(() => {
+        evaluateAuto();
+      });
+      log.info('Upload orchestrator started');
+    },
+
+    stop() {
+      if (!started) {
+        return;
+      }
+      started = false;
+      unsubConnectivity?.();
+      unsubPrefs?.();
+      unsubConnectivity = null;
+      unsubPrefs = null;
+      void abortActiveSession();
+      phase = 'idle';
+      log.info('Upload orchestrator stopped');
+    },
+
+    async pause() {
+      const until = deps.now() + deps.pauseWindowMs;
+      deps.setPausedUntilMs(until);
+      await abortActiveSession();
+      phase = 'paused';
+      deps.emit({ type: 'paused', reason: 'user' });
+      log.info('Upload paused by user', {
+        until: new Date(until).toISOString(),
+      });
+    },
+
+    async cancel() {
+      deps.setPausedUntilMs(null);
+      suppressAutoUntilOnlineEdge = true;
+      await abortActiveSession();
+      phase = 'idle';
+      deps.emit({ type: 'cancelled' });
+      log.info('Upload cancelled by user');
+    },
+
+    async syncNow() {
+      deps.setPausedUntilMs(null);
+      suppressAutoUntilOnlineEdge = false;
+      await abortActiveSession();
+      await runSession('sync_now');
+    },
+
+    getSnapshot: snapshot,
+  };
+}


### PR DESCRIPTION
### TLDR

Implements the recording **upload orchestrator** for #150: online means Fluent `/health` reachable, auto-upload on Wi‑Fi (cellular only if `uploadOverCellular`), silent mid-drop pause/resume, cancel until the next online edge, and a 24h user pause cleared by Sync Now. Real HTTP/multipart upload is intentionally behind `setChapterUploadWorker` (#100 / #102). No Sync page UI in this PR.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #150

**Ticket-level waivers (also post on #150):**

| Capability | This PR | Follow-up |
|------------|---------|-----------|
| Real chapter upload / status writers / multipart | Injectable `ChapterUploadWorker` seam only | #100 |
| `POST /recordings/sync` / R2 contract | Dependency documented | #102 |
| Sync page Pause/Resume/Cancel/Sync Now UI | Out of scope (product: no UI) | #151 / PR #203 |

Orchestrator starts when authenticated (`App.tsx`) and exposes `pauseUploadSession` / `cancelUploadSession` / `syncNowUploads` / `getUploadSessionSnapshot` for #151 to wire.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/services/uploadOrchestratorCore.ts`** — Pure session engine (injectable deps)
- **`src/services/uploadOrchestrator.ts`** — Production singleton, worker registry, Sync-control APIs
- **`src/services/uploadOrchestrator.test.ts`** — Wi‑Fi/cellular/pref matrix, mid-drop, cancel, 24h pause + Sync Now
- **`src/db/queries.ts`** — `getPendingUploadChapters()` (chapter-level queue)
- **`src/services/storage.ts`** — `sync_paused_until` KV helpers
- **`src/services/syncEvents.ts`** — `onUploadSessionEvent` / `emitUploadSessionEvent`
- **`App.tsx`** — start/stop orchestrator with auth lifecycle
- **`src/services/AGENTS.md`** — upload vs metadata sync note

#### Testing

`npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test -- --ci` (244 passed).

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Read `uploadOrchestratorCore.ts` + tests — confirm AC matrices without Sync UI
3. Confirm no real upload HTTP client is introduced (worker null until #100)

**Expected:** Orchestrator lifecycle + unit coverage land; uploads no-op until a worker is registered; Sync controls remain on #151.

### Follow-ups

- [ ] #100 — Register real `ChapterUploadWorker` (`recordingSync.ts`)
- [ ] #102 — API `/recordings/sync` contract
- [ ] #151 — Wire SyncActionControls to `pauseUploadSession` / `cancelUploadSession` / `syncNowUploads`
- [ ] Device QA when real uploads run (native network) — not required for this orchestrator-only PR
