### PR TITLE
[#214]: Log Dependabot triage for 2026-07-20 batch

### DIFF
--- a/docs/guides/dependabot-resolution-log.md
+++ b/docs/guides/dependabot-resolution-log.md
@@ -4,23 +4,23 @@ Records how open Dependabot PRs were resolved in a given branch so the team can 
 
 ## Batch: `main` (2026-07-20)
 
-Resolved: 2026-07-20 (finish pass same day)
+Resolved: 2026-07-20 (finish pass + close pass same day)
 
 | PR | Title / scope | Change applied |
 |----|---------------|----------------|
 | #194 | actions/setup-node 4 → 7 | **Merged** — safe GitHub Actions only; CI green; `main` Lint/Test/Quality Gates green after squash |
-| #195 | react group (`react` / `react-test-renderer` 19.2.3 → 19.2.7) | **Deferred** — risky; CI red after rebase; needs Android smoke |
-| #196 | navigation group (`@react-navigation/native` / `stack`) | **Deferred** — risky; CI green after rebase but Android smoke required (not run) |
-| #197 | testing group (Jest 29→30, RTL 13→14, `@types/jest` 29→30) | **Deferred** — major tooling; CI red after rebase |
+| #195 | react group (`react` / `react-test-renderer` 19.2.3 → 19.2.7) | **Closed** — Expo SDK 56 / RN 0.85 React pin; CI red (tests/doctor/install-check); needs dedicated ticket + Android smoke |
+| #196 | navigation group (`@react-navigation/native` 7.3.8→7.3.12 / `stack` 7.10.11→7.10.15) | **Closed** — risky navigation; CI green but Android smoke required; dedicated ticket |
+| #197 | testing group (Jest 29→30, RTL 13→14, `@types/jest` 29→30) | **Closed** — major tooling; CI red; needs migration ticket |
 | #198 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7) | **Closed by Dependabot** — superseded after rebase; see #216 |
 | #199 | expo group (`expo` ~56 → ~57) | **Closed** — SDK upgrade; use dedicated SDK 57 ticket |
-| #216 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7 + related) | **Deferred** — replacement for #198; stacked majors; CI red |
+| #216 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7 + related) | **Closed** — stacked majors (replacement for #198); CI red; dedicated tooling ticket |
 
-**Action:** Merged #194 squash. Closed #199 (Expo). #198 superseded/closed by Dependabot; deferred replacement #216. Deferred #195–#197 (risky/majors). Finish pass: no additional safe merges — remaining open bots are risky or majors with red CI. Re-triage comments posted after rebase.
+**Action:** Merged #194 squash. Closed #199 (Expo). #198 superseded/closed by Dependabot. Close pass: closed #195, #196, #197, #216 with technical comments (unsafe / majors / smoke required per dependabot-workflow). No remaining open Dependabot bots from this batch.
 
-**Left open (Dependabot):** #195, #196, #197, #216.
+**Left open (Dependabot):** none from this batch.
 
-**Verification run:** GitHub CI on #194 green before merge. `main` CI (Lint Check, Test Check, Quality Gates) success for #194 squash. Finish pass used CI-first triage only; no Android smoke (required before merging #195/#196).
+**Verification run:** GitHub CI on #194 green before merge. `main` CI (Lint Check, Test Check, Quality Gates) success for #194 squash. Close pass: verified PRs still open, then `gh pr close` with rationale comments; no merges; no Android smoke (N/A for closes).
 
 ---
 

--- a/docs/guides/dependabot-resolution-log.md
+++ b/docs/guides/dependabot-resolution-log.md
@@ -4,20 +4,23 @@ Records how open Dependabot PRs were resolved in a given branch so the team can 
 
 ## Batch: `main` (2026-07-20)
 
-Resolved: 2026-07-20
+Resolved: 2026-07-20 (finish pass same day)
 
 | PR | Title / scope | Change applied |
 |----|---------------|----------------|
-| #194 | actions/setup-node 4 → 7 | **Merged** — safe GitHub Actions only; CI green |
-| #195 | react group (`react` / `react-test-renderer` 19.2.3 → 19.2.7) | **Deferred** — risky; CI red; needs Android smoke |
-| #196 | navigation group (`@react-navigation/*`) | **Deferred** — risky; CI green but Android smoke required |
-| #197 | testing group (Jest 29→30, RTL 13→14, `@types/jest` 29→30) | **Deferred** — major tooling; CI red |
-| #198 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7) | **Deferred** — stacked majors; CI red |
+| #194 | actions/setup-node 4 → 7 | **Merged** — safe GitHub Actions only; CI green; `main` Lint/Test/Quality Gates green after squash |
+| #195 | react group (`react` / `react-test-renderer` 19.2.3 → 19.2.7) | **Deferred** — risky; CI red after rebase; needs Android smoke |
+| #196 | navigation group (`@react-navigation/native` / `stack`) | **Deferred** — risky; CI green after rebase but Android smoke required (not run) |
+| #197 | testing group (Jest 29→30, RTL 13→14, `@types/jest` 29→30) | **Deferred** — major tooling; CI red after rebase |
+| #198 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7) | **Closed by Dependabot** — superseded after rebase; see #216 |
 | #199 | expo group (`expo` ~56 → ~57) | **Closed** — SDK upgrade; use dedicated SDK 57 ticket |
+| #216 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7 + related) | **Deferred** — replacement for #198; stacked majors; CI red |
 
-**Action:** Merged #194 squash. Closed #199. Deferred #195–#198 with comments. `@dependabot rebase` on remaining open bots after #194.
+**Action:** Merged #194 squash. Closed #199 (Expo). #198 superseded/closed by Dependabot; deferred replacement #216. Deferred #195–#197 (risky/majors). Finish pass: no additional safe merges — remaining open bots are risky or majors with red CI. Re-triage comments posted after rebase.
 
-**Verification run:** GitHub CI on #194 (Lint, Test, Quality Gates) green before merge. `main` CI for #194 merge watched after squash.
+**Left open (Dependabot):** #195, #196, #197, #216.
+
+**Verification run:** GitHub CI on #194 green before merge. `main` CI (Lint Check, Test Check, Quality Gates) success for #194 squash. Finish pass used CI-first triage only; no Android smoke (required before merging #195/#196).
 
 ---
 

--- a/docs/guides/dependabot-resolution-log.md
+++ b/docs/guides/dependabot-resolution-log.md
@@ -2,6 +2,25 @@
 
 Records how open Dependabot PRs were resolved in a given branch so the team can close or merge PRs consistently.
 
+## Batch: `main` (2026-07-20)
+
+Resolved: 2026-07-20
+
+| PR | Title / scope | Change applied |
+|----|---------------|----------------|
+| #194 | actions/setup-node 4 → 7 | **Merged** — safe GitHub Actions only; CI green |
+| #195 | react group (`react` / `react-test-renderer` 19.2.3 → 19.2.7) | **Deferred** — risky; CI red; needs Android smoke |
+| #196 | navigation group (`@react-navigation/*`) | **Deferred** — risky; CI green but Android smoke required |
+| #197 | testing group (Jest 29→30, RTL 13→14, `@types/jest` 29→30) | **Deferred** — major tooling; CI red |
+| #198 | dev-tools group (Babel 8, ESLint 10, Prettier 3, TS 7) | **Deferred** — stacked majors; CI red |
+| #199 | expo group (`expo` ~56 → ~57) | **Closed** — SDK upgrade; use dedicated SDK 57 ticket |
+
+**Action:** Merged #194 squash. Closed #199. Deferred #195–#198 with comments. `@dependabot rebase` on remaining open bots after #194.
+
+**Verification run:** GitHub CI on #194 (Lint, Test, Quality Gates) green before merge. `main` CI for #194 merge watched after squash.
+
+---
+
 ## Batch: `main` (2026-06-10)
 
 Resolved: 2026-06-10


### PR DESCRIPTION
### TLDR

Updates the 2026-07-20 Dependabot resolution log for the close pass: #194 merged earlier; #199 closed (Expo SDK jump); #198 superseded by Dependabot; **#195, #196, #197, and #216 closed** with technical comments (Expo SDK 56 / RN pins, risky navigation smoke, major tooling, stacked Babel/ESLint/Prettier/TS majors). No Dependabot bots left open from this batch.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #214

Docs-only update to `docs/guides/dependabot-resolution-log.md` after Dependabot close pass.

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`docs/guides/dependabot-resolution-log.md`** — 2026-07-20 batch: #195–#197 and #216 marked **Closed** (was Deferred); action / left-open / verification notes refreshed for close pass

#### Testing

Docs only — no app code gates required beyond diff review. PR CI (Lint / Test / Quality Gates) should stay green.

### How to verify

1. Skim the batch entry against Dependabot PR states on GitHub
2. Confirm #194 merged; #195, #196, #197, #198, #199, #216 closed
3. Confirm left open from this batch: none

**Expected:** Log matches the 2026-07-20 finish + close pass.

### Follow-ups

- [ ] Dedicated ticket + Android smoke before any future React (`react` / `react-test-renderer`) bump on SDK 56
- [ ] Dedicated ticket + Android smoke for `@react-navigation/*` bumps
- [ ] Dedicated tickets for Jest 30 / RNTL 14 and Babel 8 / ESLint 10 / Prettier 3 / TS 7 when scheduled