### PR TITLE
[#217]: Document Project 4 Fluent Mobile Board as canonical tracker

### DIFF
--- a/.cursor/commands/create-pr-branch.md
+++ b/.cursor/commands/create-pr-branch.md
@@ -12,7 +12,7 @@ Creates a new git branch using the team naming convention:
 
 Run with `/create-pr-branch` in Cursor chat.
 
-**Tracker:** GitHub Issues for this repo right now — see [docs/issue-tracking.md](../../docs/issue-tracking.md).
+**Tracker:** Project 4 Fluent Mobile Board — see [docs/issue-tracking.md](../../docs/issue-tracking.md).
 
 ## Branch name format
 

--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -6,7 +6,7 @@ Automated PR creation for **fluent-mobile** when you run `/create-pr`. Creates a
 
 Complements team PR conventions (title `[#NNN]: Description`, verification gates). Does not merge PRs.
 
-**Tracker:** GitHub Issues — [docs/issue-tracking.md](../../docs/issue-tracking.md).
+**Tracker:** Project 4 Fluent Mobile Board — [docs/issue-tracking.md](../../docs/issue-tracking.md).
 
 ## What happens
 

--- a/.cursor/commands/generate-pr-description.md
+++ b/.cursor/commands/generate-pr-description.md
@@ -30,7 +30,7 @@ Every run **must** output a suggested title before the description block. Do not
 | GitHub issue in branch (`…/173-…` or `38-…`) | `#173` | `[#173]: Adopt Phase 1 agent/process docs` |
 | No ticket | descriptive prefix | `Chore: Add Cursor AI rules` |
 
-**Tracker:** GitHub Issues ([docs/issue-tracking.md](../../docs/issue-tracking.md)).
+**Tracker:** Project 4 Fluent Mobile Board ([docs/issue-tracking.md](../../docs/issue-tracking.md)).
 
 ### Title synthesis (apply in order)
 

--- a/.cursor/commands/onboard.md
+++ b/.cursor/commands/onboard.md
@@ -58,7 +58,7 @@ npm run doctor          # after native-impacting / dependency changes
 ## Step 4 — Point at docs
 
 - [docs/AGENT_ONBOARDING.md](../../docs/AGENT_ONBOARDING.md) — architecture map
-- [docs/issue-tracking.md](../../docs/issue-tracking.md) — GitHub Issues + PR linking
+- [docs/issue-tracking.md](../../docs/issue-tracking.md) — Project 4 Fluent Mobile Board + PR linking
 - [docs/ci.md](../../docs/ci.md) — CI inventory
 - [README.md](../../README.md) — human setup
 

--- a/.cursor/rules/commands.mdc
+++ b/.cursor/rules/commands.mdc
@@ -39,7 +39,7 @@ Report what ran and the outcome. If a step was skipped, say why.
 
 ## PR workflow
 
-Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-description`, `/create-pr`, `/onboard`, `/dep-bump`, `/handle-dependabot`. Align with team PR title format: `[#NNN]: Description` (GitHub Issues — [docs/issue-tracking.md](../../docs/issue-tracking.md)). CI map: [docs/ci.md](../../docs/ci.md).
+Slash commands in `.cursor/commands/`: `/create-pr-branch`, `/generate-pr-description`, `/create-pr`, `/onboard`, `/dep-bump`, `/handle-dependabot`. Align with team PR title format: `[#NNN]: Description` (Project 4 Fluent Mobile Board — [docs/issue-tracking.md](../../docs/issue-tracking.md)). CI map: [docs/ci.md](../../docs/ci.md).
 
 ## Do not run without user request
 

--- a/.cursor/rules/delivery.mdc
+++ b/.cursor/rules/delivery.mdc
@@ -11,9 +11,9 @@ alwaysApply: true
 
 Every change — including infra, CI, docs, Dependabot follow-ups, and `expo install --fix` — goes through:
 
-1. **GitHub issue** — required; ask if missing (`#NNN`). See [docs/issue-tracking.md](../../docs/issue-tracking.md). (Linear is not the tracker for this repo right now.)
+1. **Ticket on Project 4** — GitHub Issue `#NNN` **on** the [Fluent Mobile Board](https://github.com/orgs/eten-tech-foundation/projects/4/views/9) (org project #4, view 9). Ask if missing. See [docs/issue-tracking.md](../../docs/issue-tracking.md). The repo Issues list is not the triage board. (Not Linear.)
 2. **Feature branch** — `{author}/{type}/{issue-number}-{slug}` (see `/create-pr-branch`)
-3. **Pull request** — title `[#NNN]: Description`; body `Closes #NNN` under Details when the PR completes the issue
+3. **Pull request** — title `[#NNN]: Description`; body `Closes #NNN` under Details when the PR completes the issue; set Project 4 Status to **In PR Review**
 4. **Human merge** — agents open PRs and push **feature branches only**; never merge on GitHub unless the user explicitly asks for a Dependabot squash merge in that session
 
 Allowed on `main` locally: `git checkout main`, `git pull`, read-only validation after merges. **Not allowed:** `git push origin main`, commits on `main`, or opening PRs with `main` as the head branch.

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -15,7 +15,7 @@ alwaysApply: false
 
 ## Issue tracking & CI
 
-- [docs/issue-tracking.md](../../docs/issue-tracking.md) — GitHub Issues, branch naming, PR linking (`Closes #NNN`)
+- [docs/issue-tracking.md](../../docs/issue-tracking.md) — Project 4 Fluent Mobile Board, branch naming, PR linking (`Closes #NNN`)
 - [docs/ci.md](../../docs/ci.md) — workflow inventory + future required-check guardrail
 
 Update these when tracker policy or CI workflows change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ On feature PRs with heavy agent co-authorship, reviewers should prioritize **sco
 ## Related
 
 - Delivery / branch / PR process: [`.cursor/rules/delivery.mdc`](.cursor/rules/delivery.mdc)
-- Issue tracking (GitHub Issues): [docs/issue-tracking.md](docs/issue-tracking.md)
+- Issue tracking (Project 4 Fluent Mobile Board): [docs/issue-tracking.md](docs/issue-tracking.md)
 - CI command order: [`.cursor/rules/commands.mdc`](.cursor/rules/commands.mdc)
 - CI inventory: [docs/ci.md](docs/ci.md)
 - PR body template: [`.cursor/templates/pr-template.md`](.cursor/templates/pr-template.md)

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -215,7 +215,7 @@ When adding features: mock `op-sqlite`, navigation, and sync in screen tests fol
 
 - Human setup: [README.md](../README.md)
 - Agent delivery guardrails: [`AGENTS.md`](../AGENTS.md)
-- Issue tracking (GitHub Issues): [issue-tracking.md](issue-tracking.md)
+- Issue tracking (Project 4 Fluent Mobile Board): [issue-tracking.md](issue-tracking.md)
 - CI inventory: [ci.md](ci.md)
 - Cursor rules: [`.cursor/rules/`](../.cursor/rules/) — **Android-only:** [android-only.mdc](../.cursor/rules/android-only.mdc)
 - Dependabot: [guides/dependabot-process.md](guides/dependabot-process.md) — use with `.cursor/rules/dependabot-workflow.mdc`

--- a/docs/issue-tracking.md
+++ b/docs/issue-tracking.md
@@ -1,14 +1,36 @@
 # Issue tracking (fluent-mobile)
 
+## Canonical board (source of truth)
+
+**Fluent Mobile Board** — [org Project 4, view 9](https://github.com/orgs/eten-tech-foundation/projects/4/views/9)
+
+| | |
+| --- | --- |
+| Org project | [Fluent](https://github.com/orgs/eten-tech-foundation/projects/4) (project **#4**) |
+| Mobile triage view | **View 9 — Fluent Mobile Board** |
+| Status / columns | Set on **Project 4** only (not by scanning the repo Issues list) |
+
+The [repo Issues list](https://github.com/eten-tech-foundation/fluent-mobile/issues) is **not** the triage board. Cards are still GitHub Issues (`#NNN`) linked into Project 4; agents must treat **Project 4 → Fluent Mobile Board** as canonical for backlog, in-progress, review, and done.
+
+### Project 4 Status options (as of 2026-07)
+
+`Backlog` · `In Progress (Product)` · `Product Ready` · `Sprint Shaping` · `Dev Ready` · `In Progress (Dev)` · `In PR Review` · `In QA` · `Passed QA` · `To Deploy` · `Done`
+
+For open PRs awaiting review, prefer **`In PR Review`**. For merged/completed work, set **`Done`**.
+
+Do **not** use org Project 7 (“Fluent Mobile App”) as the primary tracker unless the team explicitly migrates.
+
 ## Where to file work
 
-**GitHub Issues:** https://github.com/eten-tech-foundation/fluent-mobile/issues
+1. Create a **GitHub Issue** in `eten-tech-foundation/fluent-mobile` (needed for `#NNN`, branch names, and `Closes #NNN`).
+2. **Add the issue to Project 4** and set Status on the Fluent Mobile Board (view 9).
+3. Assign the owner on the issue.
 
-For now, **GitHub Issues** are the ticket tracker for this repo (not Linear). Prefer a GitHub issue for every non-trivial change before opening a PR.
+Prefer a ticketed card for every non-trivial change before opening a PR. **Not Linear.**
 
 ## Labels
 
-Use existing repo labels when they fit (`documentation`, `bug`, Dependabot labels, etc.). Do not invent a large label taxonomy in docs — keep labels light until the team agrees on a board.
+Use existing repo labels when they fit (`documentation`, `bug`, Dependabot labels, etc.). Keep labels light; column status lives on Project 4.
 
 ## Branch naming
 
@@ -38,18 +60,20 @@ See [`.cursor/commands/create-pr-branch.md`](../.cursor/commands/create-pr-branc
 - **Body:** link the issue under Details:
   - `Closes #NNN` when the PR **completes** the issue (auto-closes on merge to `main`)
   - For related work that must stay open, say “Part of #NNN” in prose, or link manually in the PR sidebar — do not use a closing keyword
+- After opening a PR, set Project 4 Status to **`In PR Review`** (if not already)
 - **Template:** [`.cursor/templates/pr-template.md`](../.cursor/templates/pr-template.md) — generate with `/generate-pr-description` or `/create-pr`
 
 ### Closing keywords
 
 Use [GitHub closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) (`Closes`, `Fixes`, `Resolves`) when the PR finishes the issue.
 
-`Refs #NNN` is **not** a GitHub closing keyword — it will not auto-close. Prefer `Closes #NNN` for completed work.
+`Refs #NNN` is **not** a GitHub closing keyword — it will not auto-close. Prefer `Closes #NNN` for completed work. After merge, confirm Project 4 Status is **`Done`**.
 
 ## Agents / delivery
 
 - Never push commits to `main` — feature branch + PR only ([delivery.mdc](../.cursor/rules/delivery.mdc))
 - Done means acceptance criteria, not green CI alone ([AGENTS.md](../AGENTS.md))
+- Triage and column moves: Project 4 Fluent Mobile Board — not the bare Issues index
 - Dependabot PRs: follow [guides/dependabot-process.md](guides/dependabot-process.md)
 
 ## Related


### PR DESCRIPTION
### TLDR

Agents were treating the repo Issues list as the triage board. This docs/rules update makes org Project 4 view 9 (Fluent Mobile Board) the canonical place for status/columns, while keeping `#NNN` issue numbers for branches and `Closes`.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #217

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`docs/issue-tracking.md`** — Project 4 / view 9 as canonical; Status options; filing steps
- **`.cursor/rules/delivery.mdc`** — ticket + In PR Review on Project 4
- Pointers updated in `AGENTS.md`, `docs/AGENT_ONBOARDING.md`, `commands.mdc`, `docs.mdc`, and `/create-pr*` / `/onboard` commands

#### Testing

Docs/rules only — no runtime tests.

`npm run format:check` not required for markdown-only; skipped product lint/typecheck/test.

### How to verify

1. Open [Project 4 view 9](https://github.com/orgs/eten-tech-foundation/projects/4/views/9) and confirm it is named Fluent Mobile Board
2. Skim `docs/issue-tracking.md` — repo Issues list described as non-canonical
3. Confirm `delivery.mdc` step 1 points at Project 4 view 9

**Expected:** Agents triage and set columns on Project 4, not the bare Issues index.

### Follow-ups

- None