### PR TITLE
[#219]: Add nightly binary Android preview CI

### DIFF
--- a/.eas/README.md
+++ b/.eas/README.md
@@ -57,9 +57,26 @@ Add the **`preview-build`** label to a pull request. GitHub Actions (`.github/wo
 
 Uses the latest git tag for runtime version when available; otherwise falls back to `app.config.ts` / `package.json` version (no tag required for first preview). Requires `EXPO_TOKEN` in GitHub Actions secrets.
 
+## Nightly builds (binary only)
+
+GitHub Actions [`.github/workflows/nightly-preview.yml`](../.github/workflows/nightly-preview.yml) builds a fresh Android **internal APK** with the EAS **`nightly`** profile each night (or on `workflow_dispatch`).
+
+- Bakes `EXPO_PUBLIC_API_BASE_URL=https://dev.api.fluent.bible`
+- **No Updates channel** and **no `eas update`** — what you install is what you run
+- Does **not** require the Expo GitHub App (uses `EXPO_TOKEN`, same as PR preview)
+- Distinct from PR `preview` (which may OTA to channel `preview`)
+
+See [`.github/README.md`](../.github/README.md) for secrets and skip / force behavior.
+
 ## Manual build (without tag)
 
 ```bash
 npx eas build --profile production --platform android
 npx eas submit --profile production --platform android
+```
+
+Nightly-equivalent local build:
+
+```bash
+npx eas build --profile nightly --platform android
 ```

--- a/.github/README.md
+++ b/.github/README.md
@@ -11,6 +11,7 @@ Workflows for Fluent Mobile (**Android-only**).
 | `quality-gates.yml` | push, PR | TypeScript, `expo-doctor`, `expo install --check` |
 | `eas-build.yml` | push tag `v*` | Sync `APP_VERSION_FALLBACK` in `app.config.ts` with tag; hand off to EAS |
 | `preview-build.yml` | PR label `preview-build` | Android preview OTA or native APK for QA |
+| `nightly-preview.yml` | cron (06:00 UTC) + `workflow_dispatch` | Nightly **binary-only** Android internal APK (dev API) |
 
 Native Android compile is **not** run on every PR. Use the **`preview-build`** label for EAS preview APKs (native/config changes) and tag releases for production builds.
 
@@ -35,3 +36,21 @@ See [`.eas/README.md`](../.eas/README.md) for Expo GitHub app and Play Store set
 **QA guide (non-technical):** [`docs/guides/qa-preview-testing.md`](../docs/guides/qa-preview-testing.md)
 
 Requires `EXPO_TOKEN` in repository secrets. For JS-only PRs, `.github/scripts/eas-resolve-android-build.sh` **reuses** a matching EAS preview APK (fingerprint) or starts one — avoiding duplicate compiles. `eas.json` enables **`EAS_USE_CACHE`** (ccache) on all profiles. Preview profile is internal distribution on channel `preview` (not `developmentClient`).
+
+## Nightly preview (internal APK)
+
+Scheduled (and manually dispatchable) workflow [`.github/workflows/nightly-preview.yml`](workflows/nightly-preview.yml):
+
+- Always starts a **new** EAS Android build with profile **`nightly`** (internal APK, baked `https://dev.api.fluent.bible`).
+- **No OTA** (`eas update` is not used). Expo Updates stay disabled for `nightly` so the APK cannot pull PR `preview` channel updates.
+- Skips when `main` HEAD matches the last successful nightly unless `force_build` is set.
+- Posts a GitHub Actions job summary and optional Slack notification.
+
+### Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `EXPO_TOKEN` | EAS CLI auth (same as PR preview) |
+| `SLACK_WEBHOOK_URL` | Incoming webhook for success / failure / skip notices |
+
+Does **not** require the Expo GitHub App — only `EXPO_TOKEN`. Manual run: **Actions → Nightly Preview → Run workflow**.

--- a/.github/README.md
+++ b/.github/README.md
@@ -53,4 +53,6 @@ Scheduled (and manually dispatchable) workflow [`.github/workflows/nightly-previ
 | `EXPO_TOKEN` | EAS CLI auth (same as PR preview) |
 | `SLACK_WEBHOOK_URL` | Incoming webhook for success / failure / skip notices |
 
-Does **not** require the Expo GitHub App — only `EXPO_TOKEN`. Manual run: **Actions → Nightly Preview → Run workflow**.
+Does **not** require the Expo GitHub App — only `EXPO_TOKEN`. Manual run: **Actions → Nightly Preview → Run workflow** (available after this workflow exists on `main`).
+
+To test from a PR before merge, add the **`nightly-preview`** label (forces a build + Slack notify).

--- a/.github/scripts/eas-build-android-nightly.sh
+++ b/.github/scripts/eas-build-android-nightly.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Always start a new Android EAS build (no fingerprint reuse).
+# Requires: eas CLI (expo-github-action) or npx eas-cli, jq, GITHUB_OUTPUT.
+#
+# Env:
+#   PROFILE — eas.json build profile (default: nightly)
+#   MESSAGE — eas build message (required)
+set -euo pipefail
+
+if command -v eas >/dev/null 2>&1; then
+  EAS=(eas)
+else
+  EAS=(npx --yes eas-cli@latest)
+fi
+
+PROFILE="${PROFILE:-nightly}"
+MESSAGE="${MESSAGE:?MESSAGE is required}"
+
+echo "Starting new EAS Android build (profile: ${PROFILE}) — binary only, no OTA..."
+
+BUILD_OUTPUT=$(
+  "${EAS[@]}" build \
+    --platform android \
+    --profile "${PROFILE}" \
+    --message "${MESSAGE}" \
+    --json \
+    --non-interactive \
+    --wait
+)
+
+BUILD_ID=$(echo "${BUILD_OUTPUT}" | jq -r '
+  if type == "array" then (.[-1].id // .[0].id // empty) else (.id // empty) end
+')
+
+if [ -z "${BUILD_ID}" ] || [ "${BUILD_ID}" = "null" ]; then
+  echo "❌ Could not parse EAS build id from output"
+  echo "${BUILD_OUTPUT}" | tail -n 40
+  exit 1
+fi
+
+BUILD_STATUS=$(echo "${BUILD_OUTPUT}" | jq -r '
+  if type == "array" then (.[-1].status // .[0].status // empty) else (.status // empty) end
+')
+
+APP_VERSION=$(echo "${BUILD_OUTPUT}" | jq -r '
+  if type == "array" then (.[-1].appVersion // .[0].appVersion // empty) else (.appVersion // empty) end
+')
+
+VERSION_CODE=$(echo "${BUILD_OUTPUT}" | jq -r '
+  if type == "array" then (.[-1].appBuildVersion // .[0].appBuildVersion // empty) else (.appBuildVersion // empty) end
+')
+
+if [ "${BUILD_STATUS}" = "ERRORED" ] || [ "${BUILD_STATUS}" = "CANCELED" ]; then
+  echo "❌ Build ${BUILD_ID} finished with status ${BUILD_STATUS}"
+  exit 1
+fi
+
+INSTALL_URL="https://expo.dev/builds/${BUILD_ID}"
+
+echo "✅ Nightly build ready: ${BUILD_ID} (${BUILD_STATUS})"
+echo "   Install: ${INSTALL_URL}"
+
+{
+  echo "build_id=${BUILD_ID}"
+  echo "build_status=${BUILD_STATUS}"
+  echo "install_url=${INSTALL_URL}"
+  echo "app_version=${APP_VERSION}"
+  echo "version_code=${VERSION_CODE}"
+} >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/nightly-changelog.sh
+++ b/.github/scripts/nightly-changelog.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Emit a short changelog between PREV_SHA (exclusive) and HEAD (inclusive).
+# Writes multiline output to GITHUB_OUTPUT key "changelog" when set.
+# Env:
+#   PREV_SHA — prior successful nightly head SHA (optional; empty = last N commits)
+#   MAX_LINES — max commit lines (default 15)
+set -euo pipefail
+
+MAX_LINES="${MAX_LINES:-15}"
+PREV_SHA="${PREV_SHA:-}"
+
+if [ -n "${PREV_SHA}" ] && git rev-parse --verify "${PREV_SHA}^{commit}" >/dev/null 2>&1; then
+  HEADER="Commits since last successful nightly (\`${PREV_SHA:0:7}\`):"
+  LOG=$(git log "${PREV_SHA}..HEAD" --pretty=format:'- %h %s (%an)' 2>/dev/null || true)
+else
+  HEADER="Recent commits (no prior successful nightly SHA):"
+  LOG=$(git log -n "${MAX_LINES}" --pretty=format:'- %h %s (%an)' 2>/dev/null || true)
+fi
+
+if [ -z "${LOG}" ]; then
+  LOG='_(no new commits)_'
+fi
+
+LINE_COUNT=$(printf '%s\n' "${LOG}" | wc -l | tr -d ' ')
+if [ "${LINE_COUNT}" -gt "${MAX_LINES}" ]; then
+  LOG=$(printf '%s\n' "${LOG}" | head -n "${MAX_LINES}")
+  LOG="${LOG}
+- … (${LINE_COUNT} total, truncated)"
+fi
+
+CHANGELOG="${HEADER}
+${LOG}"
+
+echo "${CHANGELOG}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "changelog<<EOF"
+    echo "${CHANGELOG}"
+    echo "EOF"
+  } >> "${GITHUB_OUTPUT}"
+fi

--- a/.github/scripts/notify-slack-nightly.sh
+++ b/.github/scripts/notify-slack-nightly.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Post a Slack Incoming Webhook message for nightly preview builds.
+# Env:
+#   SLACK_WEBHOOK_URL — required to send; if unset, skips with warning
+#   STATUS — success | failure | skipped
+#   TRIGGER — schedule | workflow_dispatch | …
+#   PLATFORM, PROFILE, BRANCH, SHA, AUTHOR, BUILD_DATE
+#   APP_VERSION, VERSION_CODE, INSTALL_URL, BUILD_ID
+#   CHANGELOG — multiline text
+#   RUN_URL — GitHub Actions run URL
+#   FAILED_STEP — optional (failure)
+#   FEEDBACK_URL — optional issue / feedback link
+#   API_BASE_URL — baked API URL (success)
+#   NOTIFY_SLACK — "true" to send (default true); "false" skips send
+set -euo pipefail
+
+NOTIFY_SLACK="${NOTIFY_SLACK:-true}"
+if [ "${NOTIFY_SLACK}" != "true" ]; then
+  echo "ℹ️ Slack notify disabled (NOTIFY_SLACK=${NOTIFY_SLACK})"
+  exit 0
+fi
+
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+  echo "⚠️ SLACK_WEBHOOK_URL not set — skipping Slack notification"
+  exit 0
+fi
+
+STATUS="${STATUS:?STATUS is required}"
+TRIGGER="${TRIGGER:-unknown}"
+PLATFORM="${PLATFORM:-android}"
+PROFILE="${PROFILE:-nightly}"
+BRANCH="${BRANCH:-}"
+SHA="${SHA:-}"
+AUTHOR="${AUTHOR:-}"
+BUILD_DATE="${BUILD_DATE:-}"
+APP_VERSION="${APP_VERSION:-}"
+VERSION_CODE="${VERSION_CODE:-}"
+INSTALL_URL="${INSTALL_URL:-}"
+BUILD_ID="${BUILD_ID:-}"
+CHANGELOG="${CHANGELOG:-}"
+RUN_URL="${RUN_URL:-}"
+FAILED_STEP="${FAILED_STEP:-}"
+API_BASE_URL="${API_BASE_URL:-https://dev.api.fluent.bible}"
+FEEDBACK_URL="${FEEDBACK_URL:-https://github.com/eten-tech-foundation/fluent-mobile/issues/new}"
+
+SHORT_SHA="${SHA:0:7}"
+QR_URL=""
+if [ -n "${INSTALL_URL}" ]; then
+  QR_URL="https://quickchart.io/qr?size=256&margin=2&text=$(printf '%s' "${INSTALL_URL}" | jq -sRr @uri)"
+fi
+
+case "${STATUS}" in
+  success)
+    TITLE=":white_check_mark: Fluent nightly Android build ready"
+    COLOR="#2eb886"
+    DETAIL_LINES=$(cat <<EOF
+*Status:* success (binary APK — no OTA)
+*Platform:* ${PLATFORM}
+*Environment:* development API (\`${API_BASE_URL}\`)
+*EAS profile:* \`${PROFILE}\`
+*Trigger:* ${TRIGGER}
+*Branch:* \`${BRANCH}\`
+*Commit:* \`${SHORT_SHA}\` (${AUTHOR})
+*Build date:* ${BUILD_DATE}
+*App version:* ${APP_VERSION}
+*Native build number:* ${VERSION_CODE:-n/a}
+*Install:* <${INSTALL_URL}|Download APK / open EAS build>
+*Build id:* \`${BUILD_ID}\`
+*Actions:* <${RUN_URL}|Workflow run>
+*Feedback:* <${FEEDBACK_URL}|Open an issue>
+
+*Changelog*
+${CHANGELOG}
+EOF
+)
+    if [ -n "${QR_URL}" ]; then
+      DETAIL_LINES="${DETAIL_LINES}
+
+QR (install page): ${QR_URL}"
+    fi
+    ;;
+  failure)
+    TITLE=":x: Fluent nightly Android build failed"
+    COLOR="#e01e5a"
+    DETAIL_LINES=$(cat <<EOF
+*Status:* failure
+*Failed step:* ${FAILED_STEP:-unknown}
+*Trigger:* ${TRIGGER}
+*Branch:* \`${BRANCH}\`
+*Commit:* \`${SHORT_SHA}\`
+*Actions:* <${RUN_URL}|View logs>
+*Owner:* Fluent Mobile maintainers — check EAS / Actions logs
+EOF
+)
+    ;;
+  skipped)
+    TITLE=":zzz: Fluent nightly skipped (no new commits)"
+    COLOR="#e8b339"
+    DETAIL_LINES=$(cat <<EOF
+*Status:* skipped
+*Trigger:* ${TRIGGER}
+*Branch:* \`${BRANCH}\`
+*Commit:* \`${SHORT_SHA}\` (same as last successful nightly)
+*Actions:* <${RUN_URL}|Workflow run>
+Use \`workflow_dispatch\` with \`force_build=true\` to build anyway.
+EOF
+)
+    ;;
+  *)
+    echo "❌ Unknown STATUS=${STATUS}"
+    exit 1
+    ;;
+esac
+
+PAYLOAD=$(jq -n \
+  --arg title "${TITLE}" \
+  --arg color "${COLOR}" \
+  --arg text "${DETAIL_LINES}" \
+  '{
+    text: $title,
+    attachments: [
+      {
+        color: $color,
+        mrkdwn_in: ["text"],
+        text: $text
+      }
+    ]
+  }')
+
+HTTP_CODE=$(curl -sS -o /tmp/slack-nightly-response.txt -w "%{http_code}" \
+  -X POST \
+  -H 'Content-type: application/json' \
+  --data "${PAYLOAD}" \
+  "${SLACK_WEBHOOK_URL}")
+
+if [ "${HTTP_CODE}" != "200" ]; then
+  echo "❌ Slack webhook returned HTTP ${HTTP_CODE}"
+  cat /tmp/slack-nightly-response.txt || true
+  exit 1
+fi
+
+echo "✅ Slack notification sent (${STATUS})"

--- a/.github/scripts/validate-nightly-api-url.sh
+++ b/.github/scripts/validate-nightly-api-url.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Fail if the nightly EAS profile would bake a non-dev / production-like API URL.
+# Requires: jq, eas.json at repo root.
+set -euo pipefail
+
+EXPECTED_URL="${EXPECTED_DEV_API_URL:-https://dev.api.fluent.bible}"
+EAS_JSON="${EAS_JSON_PATH:-eas.json}"
+
+if [ ! -f "${EAS_JSON}" ]; then
+  echo "❌ Missing ${EAS_JSON}"
+  exit 1
+fi
+
+URL=$(jq -r '.build.nightly.env.EXPO_PUBLIC_API_BASE_URL // empty' "${EAS_JSON}")
+
+if [ -z "${URL}" ]; then
+  echo "❌ eas.json build.nightly.env.EXPO_PUBLIC_API_BASE_URL is missing"
+  exit 1
+fi
+
+if [ "${URL}" != "${EXPECTED_URL}" ]; then
+  echo "❌ Nightly API URL must be exactly ${EXPECTED_URL}"
+  echo "   Found: ${URL}"
+  exit 1
+fi
+
+# Extra guard: reject hostnames that look like production (no "dev." subdomain).
+HOST=$(printf '%s' "${URL}" | sed -E 's|^https?://([^/]+).*|\1|')
+case "${HOST}" in
+  dev.api.fluent.bible) ;;
+  *api.fluent.bible*)
+    echo "❌ Nightly API host looks like production: ${HOST}"
+    exit 1
+    ;;
+esac
+
+echo "✅ Nightly API URL OK: ${URL}"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "api_base_url=${URL}" >> "${GITHUB_OUTPUT}"
+fi

--- a/.github/workflows/nightly-preview.yml
+++ b/.github/workflows/nightly-preview.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: boolean
         default: true
+  # Same-repo label trigger so the workflow can be tested from a PR before it
+  # exists on main (workflow_dispatch only registers after the file is on default).
+  pull_request:
+    types: [labeled]
 
 concurrency:
   group: nightly-preview
@@ -39,10 +43,14 @@ jobs:
     name: Nightly Android APK
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: >
+      github.event_name != 'pull_request' ||
+      contains(github.event.label.name, 'nightly-preview')
     env:
       # On schedule, inputs are empty → force false, notify true.
-      FORCE_BUILD: ${{ inputs.force_build || false }}
-      NOTIFY_SLACK: ${{ github.event_name == 'schedule' || inputs.notify_slack }}
+      # PR label runs always force a build (test / one-off).
+      FORCE_BUILD: ${{ inputs.force_build || github.event_name == 'pull_request' || false }}
+      NOTIFY_SLACK: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' || inputs.notify_slack }}
 
     steps:
       - name: 📋 Checkout repository

--- a/.github/workflows/nightly-preview.yml
+++ b/.github/workflows/nightly-preview.yml
@@ -1,0 +1,253 @@
+name: Nightly Preview
+
+# Binary-only Android internal APK for internal testers (dev API).
+# Does not use OTA / eas update. Does not require the Expo GitHub App —
+# only secrets.EXPO_TOKEN (same pattern as preview-build.yml).
+
+on:
+  schedule:
+    # 06:00 UTC daily
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Build even when HEAD matches the last successful nightly'
+        required: false
+        type: boolean
+        default: false
+      notify_slack:
+        description: 'Send Slack notifications'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: nightly-preview
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  EAS_PROJECT_ID: 'b0919574-f268-4768-b3bd-7cfa5172bbab'
+  EXPECTED_DEV_API_URL: https://dev.api.fluent.bible
+  EAS_PROFILE: nightly
+
+jobs:
+  nightly-preview:
+    name: Nightly Android APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      # On schedule, inputs are empty → force false, notify true.
+      FORCE_BUILD: ${{ inputs.force_build || false }}
+      NOTIFY_SLACK: ${{ github.event_name == 'schedule' || inputs.notify_slack }}
+
+    steps:
+      - name: 📋 Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 🏗️ Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Resolve trigger metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          TRIGGER="${{ github.event_name }}"
+          AUTHOR=$(git log -1 --pretty=format:'%an')
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          BASE_VERSION=$(grep -E "^const APP_VERSION_FALLBACK" app.config.ts | sed -E "s/.*'([^']+)'.*/\1/" || true)
+          if [ -z "${BASE_VERSION}" ]; then
+            BASE_VERSION=$(node -p "require('./package.json').version")
+          fi
+          {
+            echo "trigger=${TRIGGER}"
+            echo "author=${AUTHOR}"
+            echo "build_date=${BUILD_DATE}"
+            echo "base_version=${BASE_VERSION}"
+            echo "branch=${GITHUB_REF_NAME}"
+            echo "sha=${GITHUB_SHA}"
+            echo "short_sha=${GITHUB_SHA:0:7}"
+            echo "run_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Check for new commits since last success
+        id: skip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          FORCE="${FORCE_BUILD}"
+          PREV_SHA=""
+          # Latest successful run of this workflow on the default branch (main)
+          PREV_SHA=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/nightly-preview.yml/runs?branch=main&status=completed&per_page=20" \
+            --jq '[.workflow_runs[] | select(.conclusion == "success" and .head_sha != null)] | .[0].head_sha // empty' \
+            2>/dev/null || true)
+
+          echo "prev_sha=${PREV_SHA}" >> "${GITHUB_OUTPUT}"
+
+          SHOULD_SKIP=false
+          if [ "${FORCE}" = "true" ]; then
+            echo "🔁 force_build=true — will build"
+          elif [ -n "${PREV_SHA}" ] && [ "${PREV_SHA}" = "${GITHUB_SHA}" ]; then
+            SHOULD_SKIP=true
+            echo "⏭️ HEAD ${GITHUB_SHA:0:7} matches last successful nightly — skipping build"
+          else
+            echo "✅ New commits since last successful nightly (prev=${PREV_SHA:-none})"
+          fi
+          echo "should_skip=${SHOULD_SKIP}" >> "${GITHUB_OUTPUT}"
+
+      - name: Changelog
+        id: changelog
+        env:
+          PREV_SHA: ${{ steps.skip.outputs.prev_sha }}
+        run: bash .github/scripts/nightly-changelog.sh
+
+      - name: Write skip summary
+        if: steps.skip.outputs.should_skip == 'true'
+        run: |
+          {
+            echo "## Nightly preview — skipped"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Trigger | \`${{ steps.meta.outputs.trigger }}\` |"
+            echo "| Branch | \`${{ steps.meta.outputs.branch }}\` |"
+            echo "| Commit | \`${{ steps.meta.outputs.short_sha }}\` |"
+            echo "| Author | ${{ steps.meta.outputs.author }} |"
+            echo "| Reason | No new commits since last successful nightly |"
+            echo ""
+            echo "Re-run with **force_build** to build anyway."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Notify Slack (skipped)
+        if: steps.skip.outputs.should_skip == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STATUS: skipped
+          TRIGGER: ${{ steps.meta.outputs.trigger }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          SHA: ${{ steps.meta.outputs.sha }}
+          RUN_URL: ${{ steps.meta.outputs.run_url }}
+        run: bash .github/scripts/notify-slack-nightly.sh
+
+      - name: 📦 Install dependencies
+        if: steps.skip.outputs.should_skip != 'true'
+        run: npm ci
+
+      - name: Validate nightly API URL
+        if: steps.skip.outputs.should_skip != 'true'
+        id: api-url
+        run: bash .github/scripts/validate-nightly-api-url.sh
+
+      - name: Format check
+        if: steps.skip.outputs.should_skip != 'true'
+        run: npm run format:check
+
+      - name: Lint
+        if: steps.skip.outputs.should_skip != 'true'
+        run: npm run lint
+
+      - name: Typecheck
+        if: steps.skip.outputs.should_skip != 'true'
+        run: npm run typecheck
+
+      - name: Unit tests
+        if: steps.skip.outputs.should_skip != 'true'
+        env:
+          EXPO_PUBLIC_API_BASE_URL: http://localhost:9999
+        run: npm test -- --ci
+
+      - name: Expo doctor
+        if: steps.skip.outputs.should_skip != 'true'
+        env:
+          EXPO_PUBLIC_API_BASE_URL: http://localhost:9999
+        run: npm run doctor
+
+      - name: 🏗️ Setup EAS
+        if: steps.skip.outputs.should_skip != 'true'
+        uses: expo/expo-github-action@v9
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 🚀 EAS nightly Android build (binary only)
+        if: steps.skip.outputs.should_skip != 'true'
+        id: build
+        env:
+          PROFILE: ${{ env.EAS_PROFILE }}
+          MESSAGE: Nightly ${{ steps.meta.outputs.base_version }} ${{ steps.meta.outputs.short_sha }} (${{ steps.meta.outputs.trigger }})
+        run: bash .github/scripts/eas-build-android-nightly.sh
+
+      - name: Job summary (success)
+        if: steps.skip.outputs.should_skip != 'true' && steps.build.outputs.build_id != ''
+        env:
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+        run: |
+          {
+            echo "## Nightly preview — success"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Platform | Android |"
+            echo "| Environment | development API (\`${{ steps.api-url.outputs.api_base_url }}\`) |"
+            echo "| EAS profile | \`${{ env.EAS_PROFILE }}\` |"
+            echo "| Expo Updates | disabled (binary only — no OTA) |"
+            echo "| Trigger | \`${{ steps.meta.outputs.trigger }}\` |"
+            echo "| Branch | \`${{ steps.meta.outputs.branch }}\` |"
+            echo "| Commit | \`${{ steps.meta.outputs.sha }}\` |"
+            echo "| Author | ${{ steps.meta.outputs.author }} |"
+            echo "| Build date | ${{ steps.meta.outputs.build_date }} |"
+            echo "| App version | ${{ steps.build.outputs.app_version || steps.meta.outputs.base_version }} |"
+            echo "| Native build number | ${{ steps.build.outputs.version_code || 'n/a' }} |"
+            echo "| Build id | \`${{ steps.build.outputs.build_id }}\` |"
+            echo "| Install | ${{ steps.build.outputs.install_url }} |"
+            echo ""
+            echo "### Changelog"
+            echo ""
+            echo "${CHANGELOG}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Notify Slack (success)
+        if: steps.skip.outputs.should_skip != 'true' && steps.build.outputs.build_id != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STATUS: success
+          TRIGGER: ${{ steps.meta.outputs.trigger }}
+          PLATFORM: android
+          PROFILE: ${{ env.EAS_PROFILE }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          SHA: ${{ steps.meta.outputs.sha }}
+          AUTHOR: ${{ steps.meta.outputs.author }}
+          BUILD_DATE: ${{ steps.meta.outputs.build_date }}
+          APP_VERSION: ${{ steps.build.outputs.app_version || steps.meta.outputs.base_version }}
+          VERSION_CODE: ${{ steps.build.outputs.version_code }}
+          INSTALL_URL: ${{ steps.build.outputs.install_url }}
+          BUILD_ID: ${{ steps.build.outputs.build_id }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+          RUN_URL: ${{ steps.meta.outputs.run_url }}
+          API_BASE_URL: ${{ steps.api-url.outputs.api_base_url }}
+          FEEDBACK_URL: https://github.com/${{ github.repository }}/issues/new
+        run: bash .github/scripts/notify-slack-nightly.sh
+
+      - name: Notify Slack (failure)
+        if: failure() && steps.skip.outputs.should_skip != 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STATUS: failure
+          TRIGGER: ${{ steps.meta.outputs.trigger }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          SHA: ${{ steps.meta.outputs.sha }}
+          RUN_URL: ${{ steps.meta.outputs.run_url }}
+          FAILED_STEP: ${{ github.job }}
+        run: bash .github/scripts/notify-slack-nightly.sh

--- a/app.config.ts
+++ b/app.config.ts
@@ -17,8 +17,9 @@ const appVersion = resolveAppVersion();
 
 const buildProfile = process.env.EAS_BUILD_PROFILE;
 const usesCleartextTraffic = buildProfile !== 'production';
-// OTA updates apply to EAS preview/production only. Local and development
-// builds use Metro; checking u.expo.dev on launch crashes when no bundle exists.
+// OTA updates apply to EAS preview/production only. Local, development, and
+// nightly builds keep updates disabled (nightly ships a self-contained APK).
+// Checking u.expo.dev on launch crashes when no bundle exists.
 const updatesEnabled =
   buildProfile === 'preview' || buildProfile === 'production';
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,6 +10,7 @@ This repo runs GitHub Actions on pushes and pull requests. This doc maps what ru
 | `test.yml` | `Unit Tests` | Jest (`npm test -- --ci`) |
 | `quality-gates.yml` | `TypeScript`, `expo-doctor`, `expo install --check` | Typecheck + Expo SDK / native-module alignment |
 | `preview-build.yml` | Preview OTA / Android EAS | On-demand when PR has label `preview-build` |
+| `nightly-preview.yml` | Nightly Android APK | Scheduled binary-only internal APK (dev API); also `workflow_dispatch` |
 | `eas-build.yml` | Tag → version sync | Production release path on `v*` tags |
 
 Local mirrors (run before claiming PR-ready):
@@ -40,6 +41,7 @@ Branch protection / required status checks may change over time. Treat the table
 
 - JS-only preview OTA vs native Android APK is decided by `preview-build.yml` + [`.github/scripts/eas-resolve-android-build.sh`](../.github/scripts/eas-resolve-android-build.sh)
 - Human QA steps: [guides/qa-preview-testing.md](guides/qa-preview-testing.md)
+- Nightly internal APK (no OTA): `nightly-preview.yml` + EAS profile `nightly` — see [`.github/README.md`](../.github/README.md)
 - Production: tag `v*` → `eas-build.yml` + [`.eas/README.md`](../.eas/README.md)
 
 ## Future guardrail — do not brick required checks

--- a/docs/guides/qa-preview-testing.md
+++ b/docs/guides/qa-preview-testing.md
@@ -95,4 +95,8 @@ If the app looks unchanged:
 2. Share this guide with QA: `docs/guides/qa-preview-testing.md`
 3. Preview APKs use the EAS `preview` profile (internal distribution, `preview` channel — **not** `developmentClient`).
 
+### Nightly builds (optional)
+
+Separate from PR previews: GitHub Actions can publish a **nightly Android APK** (EAS profile `nightly`, development API). Install from the Slack message or the Actions job summary — **not** from a PR comment. Nightlies are **binary only** (no over-the-air update). See [`.github/README.md`](../../.github/README.md).
+
 Technical details: [`.github/README.md`](../../.github/README.md) · [`.eas/README.md`](../../.eas/README.md)

--- a/eas.json
+++ b/eas.json
@@ -33,6 +33,17 @@
         "buildType": "apk"
       }
     },
+    "nightly": {
+      "extends": "base",
+      "distribution": "internal",
+      "env": {
+        "EAS_USE_CACHE": "1",
+        "EXPO_PUBLIC_API_BASE_URL": "https://dev.api.fluent.bible"
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
     "production": {
       "extends": "base",
       "env": {


### PR DESCRIPTION
### TLDR

Adds a scheduled GitHub Actions workflow that builds a fresh internal Android APK each night (EAS profile `nightly`, development API, **no OTA**). Uses `EXPO_TOKEN` only — no Expo GitHub App. Slack + job summary for install links.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #219

**Type of change:**

- [x] New feature
- [x] Documentation

#### Technical changes

- **`eas.json`** — new `nightly` profile (extends `base`, internal APK, baked `https://dev.api.fluent.bible`, no Updates channel)
- **`.github/workflows/nightly-preview.yml`** — cron + `workflow_dispatch`, skip-if-no-commits, gates, always-new `eas build --wait`
- **`.github/scripts/`** — API URL guard, changelog, EAS build wrapper, Slack notify
- **`app.config.ts`** — clarify Expo Updates stay disabled for nightly
- Docs: `.github/README.md`, `.eas/README.md`, `docs/ci.md`, `docs/guides/qa-preview-testing.md`

#### Testing

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --ci`

### How to verify

1. Confirm secrets: `EXPO_TOKEN`, `SLACK_WEBHOOK_URL`
2. **Actions → Nightly Preview → Run workflow** on this branch with `force_build=true`, `notify_slack=true`
3. Confirm job summary + Slack message with install link
4. Install APK on Android; confirm app uses dev API and does not pull PR preview OTAs
5. Confirm PR `preview-build` label path unchanged

**Expected:** Fresh nightly APK link in Slack/summary; no `eas update`; gates green before build.

### Follow-ups

- [ ] Rotate Slack webhook if the URL was ever pasted in chat
- [ ] Optional later: distinct app name/icon for nightly builds