### PR TITLE
[#102]: Freeze verse-audio upload contract (fluent-api #224)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ EXPO_PUBLIC_API_BASE_URL=http://10.0.2.2:9999
 
 # EAS preview builds use https://dev.api.fluent.bible (see eas.json profile "preview").
 # dev.app.fluent.bible is the web app — not used by this mobile client.
+#
+# Do NOT add Azure / R2 storage secrets here — they are server-side only
+# (fluent-api). See docs/guides/recordings-sync-contract.md.

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -51,6 +51,7 @@ Quick map for Cursor agents, other coding tools, and new contributors. Verified 
 | [`.cursor/rules/`](../.cursor/rules/) | Cursor agent rules |
 | [`docs/guides/dependabot-process.md`](guides/dependabot-process.md) | Safe Dependabot merge process |
 | [`docs/guides/local-development-workflow.md`](guides/local-development-workflow.md) | Hosted dev + local Docker API paths |
+| [`docs/guides/recordings-sync-contract.md`](guides/recordings-sync-contract.md) | Verse audio upload contract (#102 / fluent-api #224) |
 | [`.cursor/commands/`](../.cursor/commands/) | Slash commands (`/create-pr`, etc.) |
 
 ## Setup

--- a/docs/guides/api-client-standard.md
+++ b/docs/guides/api-client-standard.md
@@ -39,10 +39,12 @@ Both `publicRequest` and `authedRequest` log sanitized metadata via `summarizeAp
 ## Adding an endpoint
 
 1. Add request/response types under `src/types/api/`.
-2. Add a method on `FluentAPI` using `authedRequest<T>` or `publicRequest<T>`.
+2. Add a method on `FluentAPI` using `authedRequest<T>`, `publicRequest<T>`, or `authedMultipartRequest<T>` (multipart must use `buildMultipartAuthHeaders` — no JSON `Content-Type`).
 3. If the UI needs a one-off network action, wrap in `useMutation` with a key from `queryKeys`.
 4. If sync needs the data, call the new method from `src/services/sync.ts` and persist via `repository.ts`.
-5. Unit-test with mocked `fetch` (see `src/services/api.auth.test.ts`).
+5. Unit-test with mocked `fetch` (see `src/services/api.auth.test.ts`, `api.verseAudio.test.ts`).
+
+Verse audio upload contract (#102): [recordings-sync-contract.md](./recordings-sync-contract.md).
 
 ## Testing
 

--- a/docs/guides/recordings-sync-contract.md
+++ b/docs/guides/recordings-sync-contract.md
@@ -1,0 +1,74 @@
+# Verse audio upload contract (mobile ↔ Fluent API)
+
+Frozen client contract for uploading translator verse audio. Refs GitHub [#102](https://github.com/eten-tech-foundation/fluent-mobile/issues/102), epic [#117](https://github.com/eten-tech-foundation/fluent-mobile/issues/117), upload worker [#100](https://github.com/eten-tech-foundation/fluent-mobile/issues/100).
+
+## fluent-api truth (consulted)
+
+| Source | SHA / ref | Audio upload? |
+| --- | --- | --- |
+| Local clone `/Users/matt/Documents/Development/gloo/fluent-api` **`main`** | `3fd1027313c40c5e7a9fb3abe97c2b72d313e226` | **None** — no `recordings`, `verse-audio`, or R2 modules under `src/domains` |
+| Open [fluent-api PR #224](https://github.com/eten-tech-foundation/fluent-api/pull/224) `feat/verse-audio` | tip of that branch | **Yes** — Azure Blob `PUT/GET/DELETE /verse-audio/...` (built for mobile) |
+| Draft [fluent-api PR #188](https://github.com/eten-tech-foundation/fluent-api/pull/188) `ft/audio-record-sync` | draft, dirty vs main | Competing — `POST /recordings/sync` + Cloudflare R2; conflicts with #224 |
+
+**Frozen for #100:** match **#224** (non-draft, OpenAPI, auth gates, tests). Original #102 text assumed R2 + `/recordings/sync` (#188); that is **not** on `main`. Ticket-level waiver on #102 links API follow-up to merge (or reject) #224 vs #188.
+
+**Server owns storage secrets.** Mobile never ships `AZURE_STORAGE_CONNECTION_STRING`, `AUDIO_CONTAINER`, or any `R2_*` keys. Do not add them to this app’s `.env` / `EXPO_PUBLIC_*`.
+
+## Upload endpoint (#224)
+
+| | |
+| --- | --- |
+| Method / path | `PUT /verse-audio/{projectUnitId}/{bibleTextId}` |
+| Content-Type | `multipart/form-data` (omit manual `Content-Type`; runtime sets boundary) |
+| Auth | Bearer session + server `CONTENT_UPDATE` / chapter-assignment edit gate |
+| Body | `file` (required), `durationSeconds` (optional positive number as text) |
+| IDs | Path only — no user id in the body |
+| Client | `FluentAPI.uploadVerseAudio()` → `src/services/api.ts` |
+| Types | `src/types/api/verseAudio.ts` |
+| Outcome helpers | `src/services/verseAudioContract.ts` |
+
+### Success (`200`)
+
+JSON matching `verseAudioResponseSchema`: `id`, `projectUnitId`, `bibleTextId`, `uploadedBy`, `contentType`, `sizeBytes`, `durationSeconds`, `verseNumber`, `downloadUrl`, `createdAt`, `updatedAt`.
+
+**Local persistence (#100):** `sync_status = 'uploaded'`; store blob key `unit-{projectUnitId}/text-{bibleTextId}` via `blobKeyFromVerseAudioResponse()` (same as server `audioBlobName`).
+
+### Errors → client (#100)
+
+| Status | Body shape | Client |
+| --- | --- | --- |
+| `400` / `413` / other `4xx` (except below) | `{ message }` | `failed` + `upload_error`; **no retry** |
+| `401` | `{ message }` | `AuthError` — clear session |
+| `403` / `404` | `{ message }` (forbidden often masked as 404) | terminal `failed` |
+| `503` | `{ error, details }` storage unconfigured | terminal `failed` (do not backoff-loop) |
+| `5xx` (other) | `{ message }` | retry with backoff |
+| Network / timeout | `ApiError` status `0` | retry with backoff |
+
+### Also on #224 (not required for upload worker)
+
+- `GET /verse-audio/{projectUnitId}/{bibleTextId}` — metadata + 15-min SAS `downloadUrl`
+- `GET /verse-audio?projectUnitId=&bookId=&chapterNumber=` — chapter list
+- `DELETE /verse-audio/{projectUnitId}/{bibleTextId}`
+
+## Deviations from the original #102 proposal
+
+| Proposed in #102 | Frozen to fluent-api #224 |
+| --- | --- |
+| `POST /recordings/sync` + Cloudflare R2 | `PUT /verse-audio/{projectUnitId}/{bibleTextId}` + Azure Blob |
+| Form fields `bible_text_id`, `take_number`, `relative_path`, … | Path IDs + multipart `file` / optional `durationSeconds` |
+| Response `{ blob_key }` | Full metadata + `downloadUrl`; local `blob_key` = deterministic `unit-…/text-…` |
+| R2 env vars server-side | Azure `AZURE_STORAGE_CONNECTION_STRING` / `AUDIO_CONTAINER` server-side |
+
+## Out of scope here
+
+- Upload worker / retries / single-flight — #100
+- Upload orchestrator — #150 (`setChapterUploadWorker`)
+- Live DevQA until #224 (or chosen API) is merged and deployed — waived on #102 with follow-up
+
+## Verification
+
+```bash
+npm run format:check && npm run lint && npm run typecheck && npm test -- --ci
+```
+
+Unit tests mock `fetch` (`api.verseAudio.test.ts`, `verseAudioContract.test.ts`). No live API in CI.

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -8,6 +8,7 @@ Agents: keep this layer thin. Full contract: [docs/guides/api-client-standard.md
 - **SQLite-first reads** — UI loads from `src/db/queries.ts` after sync; do not add react-query list hooks for projects/chapters/verses.
 - **Auth** — bearer via `authToken` / `authedRequest`; `publicRequest` has no bearer. Mobile headers on auth calls only (`signIn`, `forgotPassword`, `signOut`).
 - **Sync** — orchestration + retries live in `sync.ts`; persist through `src/db/repository.ts`; KV timestamps/counts in `storage.ts`.
+- **Verse audio upload** — `FluentAPI.uploadVerseAudio` + [recordings-sync-contract.md](../../docs/guides/recordings-sync-contract.md) (#102). Worker (#100) must not call `fetch` directly.
 - **Errors** — `ApiError` / `AuthError`; no raw response bodies in logs.
 
 ## Adding an endpoint

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,14 +11,24 @@ import {
   UserChapterAssignmentsResponse,
   UserProjectsResponse,
 } from '../types/api/responses';
+import type {
+  UploadVerseAudioParams,
+  VerseAudioResponse,
+} from '../types/api/verseAudio';
 import { checkServerReachable } from './connectivity';
 import {
+  authedMultipartRequest,
   authedRequest,
   publicRequest,
   publicRequestWithResponse,
 } from './httpClient';
 import { resolveSessionToken } from './sessionToken';
 import { createApiError } from './apiError';
+import { parseVerseAudioResponse } from './verseAudioContract';
+import {
+  buildVerseAudioFormData,
+  verseAudioUploadPath,
+} from './verseAudioFormData';
 
 const MOBILE_HEADERS = {
   'x-client-type': 'mobile',
@@ -50,6 +60,17 @@ async function signInRequest(
   }
 
   return { ...data, token };
+}
+
+async function uploadVerseAudioRequest(
+  params: UploadVerseAudioParams,
+): Promise<VerseAudioResponse> {
+  const raw = await authedMultipartRequest<unknown>(
+    verseAudioUploadPath(params.projectUnitId, params.bibleTextId),
+    buildVerseAudioFormData(params),
+    { method: 'PUT' },
+  );
+  return parseVerseAudioResponse(raw);
 }
 
 export const FluentAPI = {
@@ -118,6 +139,15 @@ export const FluentAPI = {
       method: 'POST',
       body: JSON.stringify({ chapters, ...(updatedAfter && { updatedAfter }) }),
     }),
+
+  /**
+   * Upload or replace one verse recording (Azure Blob via Fluent API).
+   * Contract: docs/guides/recordings-sync-contract.md (#102 / fluent-api #224).
+   * Worker orchestration lives in #100 (`recordingSync.ts`).
+   */
+  uploadVerseAudio: (
+    params: UploadVerseAudioParams,
+  ): Promise<VerseAudioResponse> => uploadVerseAudioRequest(params),
 };
 
-export { buildHeaders } from './httpClient';
+export { buildHeaders, buildMultipartAuthHeaders } from './httpClient';

--- a/src/services/api.verseAudio.test.ts
+++ b/src/services/api.verseAudio.test.ts
@@ -1,0 +1,284 @@
+jest.mock('./connectivity', () => ({
+  checkServerReachable: jest.fn(),
+}));
+
+import { ApiError } from '../types/api/errors';
+import { FluentAPI, buildMultipartAuthHeaders } from './api';
+import { AuthError } from './authError';
+import { authToken } from './authToken';
+import { parseApiErrorBody } from './apiError';
+import {
+  buildVerseAudioFormData,
+  verseAudioUploadPath,
+} from './verseAudioFormData';
+
+const successBody = {
+  id: 9,
+  projectUnitId: 12,
+  bibleTextId: 3401,
+  uploadedBy: 3,
+  contentType: 'audio/mp4',
+  sizeBytes: 4096,
+  durationSeconds: 12.5,
+  verseNumber: 1,
+  downloadUrl: 'https://example.test/sas',
+  createdAt: '2026-07-15T00:00:00.000Z',
+  updatedAt: '2026-07-15T00:00:00.000Z',
+};
+
+describe('buildMultipartAuthHeaders', () => {
+  beforeEach(() => {
+    authToken.set(null);
+  });
+
+  it('omits Content-Type so FormData can set the boundary', () => {
+    authToken.set('tok');
+    expect(buildMultipartAuthHeaders()).toEqual({
+      Authorization: 'Bearer tok',
+    });
+    expect(buildMultipartAuthHeaders()).not.toHaveProperty('Content-Type');
+  });
+});
+
+describe('verseAudioFormData helpers', () => {
+  type GlobalWithFormData = typeof globalThis & {
+    FormData: new () => { append: jest.Mock };
+  };
+
+  it('builds the PUT path from path params only', () => {
+    expect(verseAudioUploadPath(12, 3401)).toBe('/verse-audio/12/3401');
+  });
+
+  it('appends file and optional durationSeconds', () => {
+    const append = jest.fn();
+    const g = globalThis as GlobalWithFormData;
+    const OriginalFormData = g.FormData;
+    g.FormData = jest.fn(() => ({ append })) as unknown as typeof g.FormData;
+
+    try {
+      const blob = { __blob: true } as unknown as Blob;
+      buildVerseAudioFormData({ file: blob, durationSeconds: 12.5 });
+      expect(append).toHaveBeenCalledWith('file', blob);
+      expect(append).toHaveBeenCalledWith('durationSeconds', '12.5');
+    } finally {
+      g.FormData = OriginalFormData;
+    }
+  });
+
+  it('accepts React Native uri file parts and omits duration when unset', () => {
+    const append = jest.fn();
+    const g = globalThis as GlobalWithFormData;
+    const OriginalFormData = g.FormData;
+    g.FormData = jest.fn(() => ({ append })) as unknown as typeof g.FormData;
+
+    try {
+      const file = {
+        uri: 'file:///data/recordings/a.m4a',
+        name: 'a.m4a',
+        type: 'audio/mp4',
+      };
+      buildVerseAudioFormData({ file });
+      expect(append).toHaveBeenCalledWith('file', file);
+      expect(append).not.toHaveBeenCalledWith(
+        'durationSeconds',
+        expect.anything(),
+      );
+    } finally {
+      g.FormData = OriginalFormData;
+    }
+  });
+});
+
+describe('parseApiErrorBody (verse-audio 503 shape)', () => {
+  it('joins error + details from storage-unavailable bodies', () => {
+    expect(
+      parseApiErrorBody(
+        JSON.stringify({
+          error: 'Verse audio is not available',
+          details: 'Audio storage is not configured',
+        }),
+      ),
+    ).toEqual({
+      message: 'Verse audio is not available: Audio storage is not configured',
+      code: undefined,
+    });
+  });
+});
+
+describe('FluentAPI.uploadVerseAudio', () => {
+  const fetchMock = jest.fn();
+  const sampleFile = {
+    uri: 'file:///x.m4a',
+    name: 'x.m4a',
+    type: 'audio/mp4',
+  };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(fetchMock as unknown as typeof fetch);
+    authToken.set('session-token');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    authToken.set(null);
+  });
+
+  it('PUTs multipart to /verse-audio/{projectUnitId}/{bibleTextId} with Bearer and no JSON Content-Type', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(successBody),
+    });
+
+    const response = await FluentAPI.uploadVerseAudio({
+      projectUnitId: 12,
+      bibleTextId: 3401,
+      file: sampleFile,
+      durationSeconds: 12.5,
+    });
+
+    expect(response.id).toBe(9);
+    expect(response.downloadUrl).toBe('https://example.test/sas');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:9999/verse-audio/12/3401');
+    expect(init.method).toBe('PUT');
+    expect(init.body).toBeInstanceOf(FormData);
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer session-token');
+    expect(headers['Content-Type']).toBeUndefined();
+  });
+
+  it('throws when a 200 body is missing required fields', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ id: 1 }),
+    });
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toMatchObject({
+      status: 500,
+      message: expect.stringMatching(/Malformed verse audio response/),
+    });
+  });
+
+  it('throws terminal ApiError on 400', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ message: 'Missing audio file' }),
+    });
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      isTerminal: true,
+      isRetryable: false,
+    } as Partial<ApiError>);
+  });
+
+  it('throws terminal ApiError on 413 payload too large', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 413,
+      text: async () =>
+        JSON.stringify({ message: 'Audio file exceeds the 30 MB limit' }),
+    });
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toMatchObject({
+      status: 413,
+      isTerminal: true,
+    } as Partial<ApiError>);
+  });
+
+  it('throws on 503 storage unavailable with error/details message', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () =>
+        JSON.stringify({
+          error: 'Verse audio is not available',
+          details: 'Audio storage is not configured',
+        }),
+    });
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      message: 'Verse audio is not available: Audio storage is not configured',
+    });
+  });
+
+  it('throws retryable ApiError on 500', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({ message: 'Internal server error' }),
+    });
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toMatchObject({
+      status: 500,
+      isRetryable: true,
+    } as Partial<ApiError>);
+  });
+
+  it('throws AuthError on 401', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ message: 'Unauthorized' }),
+    });
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('throws network ApiError (status 0) when fetch fails', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Network request failed'));
+
+    await expect(
+      FluentAPI.uploadVerseAudio({
+        projectUnitId: 1,
+        bibleTextId: 2,
+        file: sampleFile,
+      }),
+    ).rejects.toMatchObject({
+      status: 0,
+      isRetryable: true,
+    } as Partial<ApiError>);
+  });
+});

--- a/src/services/apiError.test.ts
+++ b/src/services/apiError.test.ts
@@ -31,6 +31,20 @@ describe('parseApiErrorBody', () => {
     ).toEqual({ message: 'Invalid session', code: 'AUTH_EXPIRED' });
   });
 
+  it('joins error + details when message is absent (verse-audio 503)', () => {
+    expect(
+      parseApiErrorBody(
+        JSON.stringify({
+          error: 'Verse audio is not available',
+          details: 'Audio storage is not configured',
+        }),
+      ),
+    ).toEqual({
+      message: 'Verse audio is not available: Audio storage is not configured',
+      code: undefined,
+    });
+  });
+
   it('falls back to errorCode when code is present but not a string', () => {
     expect(
       parseApiErrorBody(

--- a/src/services/apiError.ts
+++ b/src/services/apiError.ts
@@ -17,6 +17,15 @@ export function parseApiErrorBody(body: string): ParsedApiErrorBody {
     if (typeof parsed.message === 'string') {
       return { message: parsed.message, code };
     }
+    // fluent-api verse-audio 503: `{ error, details }`
+    if (typeof parsed.error === 'string') {
+      const details =
+        typeof parsed.details === 'string' ? parsed.details : undefined;
+      return {
+        message: details ? `${parsed.error}: ${details}` : parsed.error,
+        code,
+      };
+    }
   } catch {
     // fall through to raw body
   }

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -49,6 +49,20 @@ export function buildHeaders(
   };
 }
 
+/**
+ * Auth headers for multipart uploads. Omits `Content-Type` so the runtime
+ * can set `multipart/form-data` with the correct boundary.
+ */
+export function buildMultipartAuthHeaders(
+  extra?: Record<string, string>,
+): Record<string, string> {
+  const token = authToken.get();
+  return {
+    ...(token && { Authorization: `Bearer ${token}` }),
+    ...extra,
+  };
+}
+
 export async function parseJsonResponse<T>(res: Response): Promise<T> {
   const body = await res.text();
   if (!body.trim()) {
@@ -193,6 +207,28 @@ export async function authedRequest<T>(
     {
       ...options,
       headers: { ...buildHeaders(), ...options?.headers },
+    },
+    true,
+    'API error',
+  ) as Promise<T>;
+}
+
+/** Authenticated multipart POST/PUT — do not set JSON Content-Type. */
+export async function authedMultipartRequest<T>(
+  endpoint: string,
+  body: FormData,
+  options?: Omit<RequestInit, 'body'>,
+): Promise<T> {
+  return executeRequest<T>(
+    endpoint,
+    {
+      method: 'POST',
+      ...options,
+      body,
+      headers: {
+        ...buildMultipartAuthHeaders(),
+        ...options?.headers,
+      },
     },
     true,
     'API error',

--- a/src/services/verseAudioContract.test.ts
+++ b/src/services/verseAudioContract.test.ts
@@ -1,0 +1,110 @@
+import {
+  verseAudioBlobKey,
+  type VerseAudioResponse,
+} from '../types/api/verseAudio';
+import { ApiError } from '../types/api/errors';
+import {
+  blobKeyFromVerseAudioResponse,
+  outcomeFromVerseAudioFailure,
+  outcomeFromVerseAudioSuccess,
+  parseVerseAudioResponse,
+} from './verseAudioContract';
+
+const validResponse: VerseAudioResponse = {
+  id: 9,
+  projectUnitId: 12,
+  bibleTextId: 3401,
+  uploadedBy: 3,
+  contentType: 'audio/mp4',
+  sizeBytes: 4096,
+  durationSeconds: 12.5,
+  verseNumber: 1,
+  downloadUrl: 'https://example.test/sas',
+  createdAt: '2026-07-15T00:00:00.000Z',
+  updatedAt: '2026-07-15T00:00:00.000Z',
+};
+
+describe('verseAudioContract', () => {
+  it('maps success to blob_key matching server audioBlobName', () => {
+    expect(verseAudioBlobKey(12, 3401)).toBe('unit-12/text-3401');
+    expect(blobKeyFromVerseAudioResponse(validResponse)).toBe(
+      'unit-12/text-3401',
+    );
+    expect(outcomeFromVerseAudioSuccess(validResponse)).toEqual({
+      kind: 'uploaded',
+      blobKey: 'unit-12/text-3401',
+      recordingId: 9,
+    });
+  });
+
+  it('treats 4xx as terminal failed', () => {
+    expect(
+      outcomeFromVerseAudioFailure(new ApiError(400, 'Missing audio file')),
+    ).toEqual({
+      kind: 'failed',
+      message: 'Missing audio file',
+      retryable: false,
+    });
+    expect(
+      outcomeFromVerseAudioFailure(
+        new ApiError(413, 'Audio file exceeds the 30 MB limit'),
+      ),
+    ).toMatchObject({ kind: 'failed', retryable: false });
+  });
+
+  it('treats 503 storage-unavailable as terminal failed (no retry loop)', () => {
+    expect(
+      outcomeFromVerseAudioFailure(
+        new ApiError(
+          503,
+          'Verse audio is not available: Audio storage is not configured',
+        ),
+      ),
+    ).toEqual({
+      kind: 'failed',
+      message: 'Verse audio is not available: Audio storage is not configured',
+      retryable: false,
+    });
+  });
+
+  it('treats other 5xx and network as retryable', () => {
+    expect(
+      outcomeFromVerseAudioFailure(new ApiError(500, 'Internal server error')),
+    ).toEqual({
+      kind: 'retryable',
+      message: 'Internal server error',
+      retryable: true,
+    });
+    expect(
+      outcomeFromVerseAudioFailure(new ApiError(0, 'Network request failed')),
+    ).toMatchObject({ kind: 'retryable', retryable: true });
+  });
+
+  it('parses a valid verse audio payload', () => {
+    expect(parseVerseAudioResponse(validResponse)).toEqual(validResponse);
+  });
+
+  it('rejects malformed success bodies', () => {
+    expect(() => parseVerseAudioResponse(null)).toThrow(ApiError);
+    expect(() => parseVerseAudioResponse({})).toThrow(/missing id/);
+    expect(() =>
+      parseVerseAudioResponse({
+        ...validResponse,
+        downloadUrl: '',
+      }),
+    ).toThrow(/downloadUrl/);
+    expect(() =>
+      parseVerseAudioResponse({
+        ...validResponse,
+        contentType: 1,
+      }),
+    ).toThrow(/contentType/);
+  });
+
+  it('allows null durationSeconds', () => {
+    expect(
+      parseVerseAudioResponse({ ...validResponse, durationSeconds: null })
+        .durationSeconds,
+    ).toBeNull();
+  });
+});

--- a/src/services/verseAudioContract.ts
+++ b/src/services/verseAudioContract.ts
@@ -1,0 +1,138 @@
+import { isApiError } from '../types/api/errors';
+import {
+  verseAudioBlobKey,
+  type VerseAudioResponse,
+} from '../types/api/verseAudio';
+import { createApiError } from './apiError';
+
+/**
+ * How #100's upload worker should treat a finished verse-audio upload attempt.
+ * Aligns with `ApiError.isRetryable` / `isTerminal`, with `503` treated as
+ * terminal (storage unconfigured — retrying will not help).
+ */
+export type VerseAudioUploadClientOutcome =
+  | { kind: 'uploaded'; blobKey: string; recordingId: number }
+  | {
+      kind: 'failed';
+      message: string;
+      /** Terminal client/config error — do not retry. */
+      retryable: false;
+    }
+  | {
+      kind: 'retryable';
+      message: string;
+      /** Network (status 0) or other 5xx — backoff and retry in #100. */
+      retryable: true;
+    };
+
+/** Persist into local `recordings.blob_key` (matches server `audioBlobName`). */
+export function blobKeyFromVerseAudioResponse(
+  response: VerseAudioResponse,
+): string {
+  return verseAudioBlobKey(response.projectUnitId, response.bibleTextId);
+}
+
+export function outcomeFromVerseAudioSuccess(
+  response: VerseAudioResponse,
+): VerseAudioUploadClientOutcome {
+  return {
+    kind: 'uploaded',
+    blobKey: blobKeyFromVerseAudioResponse(response),
+    recordingId: response.id,
+  };
+}
+
+export function outcomeFromVerseAudioFailure(
+  error: unknown,
+): Exclude<VerseAudioUploadClientOutcome, { kind: 'uploaded' }> {
+  if (isApiError(error)) {
+    // Storage not configured — permanent for this environment.
+    if (error.status === 503) {
+      return { kind: 'failed', message: error.message, retryable: false };
+    }
+    if (error.isRetryable) {
+      return { kind: 'retryable', message: error.message, retryable: true };
+    }
+    return { kind: 'failed', message: error.message, retryable: false };
+  }
+
+  const message =
+    error instanceof Error ? error.message : 'Verse audio upload failed';
+  return { kind: 'retryable', message, retryable: true };
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Narrows JSON from `PUT/GET /verse-audio/...` to `VerseAudioResponse`.
+ * Throws `ApiError` (status 500) when the body is missing required fields.
+ */
+export function parseVerseAudioResponse(data: unknown): VerseAudioResponse {
+  if (data === null || typeof data !== 'object') {
+    throw createApiError(500, 'Malformed verse audio response');
+  }
+
+  const body = data as Record<string, unknown>;
+  const requiredNumbers = [
+    'id',
+    'projectUnitId',
+    'bibleTextId',
+    'uploadedBy',
+    'sizeBytes',
+    'verseNumber',
+  ] as const;
+
+  for (const key of requiredNumbers) {
+    if (!isFiniteNumber(body[key])) {
+      throw createApiError(
+        500,
+        `Malformed verse audio response: missing ${key}`,
+      );
+    }
+  }
+
+  if (typeof body.contentType !== 'string' || body.contentType.length === 0) {
+    throw createApiError(
+      500,
+      'Malformed verse audio response: missing contentType',
+    );
+  }
+  if (typeof body.downloadUrl !== 'string' || body.downloadUrl.length === 0) {
+    throw createApiError(
+      500,
+      'Malformed verse audio response: missing downloadUrl',
+    );
+  }
+  if (
+    typeof body.createdAt !== 'string' ||
+    typeof body.updatedAt !== 'string'
+  ) {
+    throw createApiError(
+      500,
+      'Malformed verse audio response: missing timestamps',
+    );
+  }
+
+  const durationSeconds =
+    body.durationSeconds === null
+      ? null
+      : isFiniteNumber(body.durationSeconds)
+      ? body.durationSeconds
+      : null;
+
+  return {
+    id: body.id as number,
+    projectUnitId: body.projectUnitId as number,
+    bibleTextId: body.bibleTextId as number,
+    uploadedBy: body.uploadedBy as number,
+    contentType: body.contentType,
+    sizeBytes: body.sizeBytes as number,
+    durationSeconds,
+    verseNumber: body.verseNumber as number,
+    downloadUrl: body.downloadUrl,
+    createdAt: body.createdAt,
+    updatedAt: body.updatedAt,
+  };
+}

--- a/src/services/verseAudioFormData.ts
+++ b/src/services/verseAudioFormData.ts
@@ -1,0 +1,49 @@
+import type {
+  UploadVerseAudioParams,
+  VerseAudioFilePart,
+} from '../types/api/verseAudio';
+
+function isVerseAudioFilePart(
+  file: UploadVerseAudioParams['file'],
+): file is VerseAudioFilePart {
+  return (
+    typeof file === 'object' &&
+    file !== null &&
+    'uri' in file &&
+    typeof (file as VerseAudioFilePart).uri === 'string'
+  );
+}
+
+/**
+ * Multipart body for `PUT /verse-audio/{projectUnitId}/{bibleTextId}`
+ * (fluent-api PR #224). Path carries the IDs; body is `file` + optional
+ * `durationSeconds` only.
+ */
+export function buildVerseAudioFormData(
+  params: Pick<UploadVerseAudioParams, 'file' | 'durationSeconds'>,
+): FormData {
+  const formData = new FormData();
+
+  if (isVerseAudioFilePart(params.file)) {
+    // RN FormData accepts `{ uri, name, type }`; typings expect Blob/File.
+    formData.append('file', params.file as unknown as Blob);
+  } else {
+    formData.append('file', params.file);
+  }
+
+  if (
+    params.durationSeconds !== undefined &&
+    Number.isFinite(params.durationSeconds)
+  ) {
+    formData.append('durationSeconds', String(params.durationSeconds));
+  }
+
+  return formData;
+}
+
+export function verseAudioUploadPath(
+  projectUnitId: number,
+  bibleTextId: number,
+): string {
+  return `/verse-audio/${projectUnitId}/${bibleTextId}`;
+}

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,3 +1,4 @@
 export * from './errors';
 export * from './responses';
 export * from './types';
+export * from './verseAudio';

--- a/src/types/api/verseAudio.ts
+++ b/src/types/api/verseAudio.ts
@@ -1,0 +1,86 @@
+/**
+ * Frozen client contract for verse audio upload/playback.
+ *
+ * Source of truth consulted:
+ * - fluent-api `main` @ 3fd1027313c40c5e7a9fb3abe97c2b72d313e226 — **no** audio routes
+ * - Open PR [fluent-api #224](https://github.com/eten-tech-foundation/fluent-api/pull/224)
+ *   (`feat/verse-audio`) — Azure Blob, `PUT/GET/DELETE /verse-audio/...`
+ *
+ * Draft [fluent-api #188](https://github.com/eten-tech-foundation/fluent-api/pull/188)
+ * (`POST /recordings/sync` + Cloudflare R2) is **not** on main and conflicts with #224.
+ * See docs/guides/recordings-sync-contract.md.
+ */
+
+/** React Native `FormData` file part (uri-based; not a web Blob). */
+export interface VerseAudioFilePart {
+  uri: string;
+  name: string;
+  type: string;
+}
+
+/**
+ * Upload params for `PUT /verse-audio/{projectUnitId}/{bibleTextId}`.
+ * IDs are path params only — never send user id in the multipart body.
+ */
+export interface UploadVerseAudioParams {
+  projectUnitId: number;
+  bibleTextId: number;
+  /** Audio bytes (RN: `{ uri, name, type }`). */
+  file: Blob | VerseAudioFilePart;
+  /** Optional client-measured duration (seconds); form field `durationSeconds`. */
+  durationSeconds?: number;
+}
+
+/** Successful `200` body (`verseAudioResponseSchema` in fluent-api #224). */
+export interface VerseAudioResponse {
+  id: number;
+  projectUnitId: number;
+  bibleTextId: number;
+  uploadedBy: number;
+  contentType: string;
+  sizeBytes: number;
+  durationSeconds: number | null;
+  verseNumber: number;
+  downloadUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VerseAudioListResponse {
+  items: VerseAudioResponse[];
+}
+
+/** `503` when `AZURE_STORAGE_CONNECTION_STRING` is unset (fluent-api #224). */
+export interface VerseAudioStorageUnavailableBody {
+  error: string;
+  details: string;
+}
+
+export interface VerseAudioErrorBody {
+  message: string;
+}
+
+/**
+ * Deterministic Azure blob name used by fluent-api `audioBlobName()`.
+ * Persist this string into local `recordings.blob_key` after a successful upload.
+ */
+export function verseAudioBlobKey(
+  projectUnitId: number,
+  bibleTextId: number,
+): string {
+  return `unit-${projectUnitId}/text-${bibleTextId}`;
+}
+
+/** MIME types accepted by fluent-api #224 (`ALLOWED_AUDIO_CONTENT_TYPES`). */
+export const VERSE_AUDIO_ALLOWED_CONTENT_TYPES = [
+  'audio/mpeg',
+  'audio/mp4',
+  'audio/m4a',
+  'audio/x-m4a',
+  'audio/aac',
+  'audio/webm',
+  'audio/wav',
+  'audio/ogg',
+] as const;
+
+export const VERSE_AUDIO_MAX_BYTES = 30 * 1024 * 1024;


### PR DESCRIPTION
### TLDR

Freezes the mobile upload client contract for #100 against **fluent-api PR #224** (`PUT /verse-audio/{projectUnitId}/{bibleTextId}`, Azure Blob). Consulted fluent-api **main** (`3fd1027313c40c5e7a9fb3abe97c2b72d313e226`) which has **no** audio upload routes. Draft #188 (`POST /recordings/sync` + R2) is documented as a competing, non-main approach — not implemented here.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #102

**Ticket-level waivers (also posted on #102):**

| AC / capability | This PR | Follow-up |
| --- | --- | --- |
| Match `POST /recordings/sync` + R2 (#188) | **Waived** — not on fluent-api main; frozen to open #224 verse-audio instead | Maintainers choose #224 vs #188; revise mobile if #188 wins |
| Live `blob_key` round-trip / DevQA e2e | **Waived** — needs deployed audio API | After fluent-api #224 (or chosen API) merges + deploys; then #100 device QA |
| Upload worker / orchestrator | Out of scope | #100 / #150 |

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/types/api/verseAudio.ts`** — request/response types + `verseAudioBlobKey()` matching server `audioBlobName`
- **`src/services/verseAudioFormData.ts`** — multipart `file` / optional `durationSeconds`
- **`src/services/verseAudioContract.ts`** — parse/validate success body; 2xx/4xx/5xx/503 outcome helpers for #100
- **`src/services/httpClient.ts`** — `buildMultipartAuthHeaders` + `authedMultipartRequest` (no JSON Content-Type)
- **`src/services/api.ts`** — `FluentAPI.uploadVerseAudio` (PUT)
- **`src/services/apiError.ts`** — parse `{ error, details }` (503 storage unavailable)
- **`docs/guides/recordings-sync-contract.md`** — frozen contract + main SHA + #188 vs #224
- Tests: **`api.verseAudio.test.ts`**, **`verseAudioContract.test.ts`**, **`apiError.test.ts`**

#### Testing

`npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test -- --ci` (257 passed, 1 skipped). Node 24.14.0.

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Read `docs/guides/recordings-sync-contract.md` — confirm endpoint/fields match fluent-api #224, and main SHA note
3. Confirm `.env.example` has no Azure/R2 secrets

**Expected:** Contract types + FluentAPI client + unit tests land; no upload worker; no live API required for CI.

### Follow-ups

- [ ] fluent-api: merge or reject #224 vs draft #188 — if #188 wins, revise this contract
- [ ] #100 — `recordingSync.ts` worker calling `FluentAPI.uploadVerseAudio`
- [ ] DevQA e2e after audio API is on a deployed environment