### PR TITLE
[#97]: useVerseAudio as a testable state machine

### DIFF
--- a/src/app/tabs/ViewChapter.tsx
+++ b/src/app/tabs/ViewChapter.tsx
@@ -14,10 +14,15 @@ import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { appStyles as styles } from '../appStyles';
 import { RootStackParamList } from '../../types/navigation/types';
 import { ChapterAssignmentData, VerseData } from '../../types/db/types';
-import { getChapterAssignmentById, getBibleTexts } from '../../db/queries';
+import {
+  getChapterAssignmentById,
+  getBibleTexts,
+  getBibleTextId,
+} from '../../db/queries';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import { usePlaybackEngine } from '../../hooks/usePlaybackEngine';
 import { PlaybackProgressBar } from '../../components/ui/PlaybackProgressBar';
+import { useVerseAudio } from '../../hooks/useVerseAudio';
+import { requestMicPermission } from '../../audio/micPermission';
 
 const log = logger.create('ViewChapter');
 
@@ -26,26 +31,23 @@ if (Platform.OS === 'android') {
 }
 
 type Route = RouteProp<RootStackParamList, 'VerseDetail'>;
-type VerseState = 'idle' | 'recording' | 'recorded';
 
 export default function ViewChapter() {
   const navigation = useNavigation();
   const { chapterId, chapterName, language, projectName } =
     useRoute<Route>().params;
-  const playback = usePlaybackEngine();
 
   const [selectedVerse, setSelectedVerse] = useState<number>(1);
   const [sourceExpanded, setSourceExpanded] = useState<boolean>(false);
-  const [verseStates, setVerseStates] = useState<Record<number, VerseState>>(
-    {},
-  );
-  /** Per-verse review URI once a take exists (#97 will populate on STOP). */
-  const [reviewUris, setReviewUris] = useState<Record<number, string>>({});
   const [verses, setVerses] = useState<VerseData[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [chapterData, setChapterData] = useState<ChapterAssignmentData | null>(
     null,
   );
+  const [bibleTextId, setBibleTextId] = useState<number | null>(null);
+  const [micDenied, setMicDenied] = useState(false);
+
+  const verseAudio = useVerseAudio({ bibleTextId });
 
   useEffect(() => {
     const loadVerses = async () => {
@@ -82,6 +84,28 @@ export default function ViewChapter() {
     loadVerses();
   }, [chapterId]);
 
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!chapterData) {
+        setBibleTextId(null);
+        return;
+      }
+      const id = await getBibleTextId(
+        chapterData.bibleId,
+        chapterData.bookId,
+        chapterData.chapterNumber,
+        selectedVerse,
+      );
+      if (!cancelled) {
+        setBibleTextId(id);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [chapterData, selectedVerse]);
+
   if (loading) {
     return (
       <View style={[styles.container, styles.centered]}>
@@ -98,56 +122,36 @@ export default function ViewChapter() {
     );
   }
 
-  const verseState = verseStates[selectedVerse] ?? 'idle';
   const selectedVerseData = verses.find(v => v.verseNumber === selectedVerse);
   const sourceText = selectedVerseData?.text;
+  const uiState = verseAudio.state;
+  const showRecorded =
+    uiState === 'recorded' || uiState === 'playing' || uiState === 'saving';
+  const showRecording = uiState === 'recording' || uiState === 'paused';
 
   function toggleSource() {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setSourceExpanded(prev => !prev);
   }
 
-  function handleRecord() {
-    setVerseStates((prev: Record<number, VerseState>) => ({
-      ...prev,
-      [selectedVerse]:
-        prev[selectedVerse] === 'recording' ? 'recorded' : 'recording',
-    }));
-  }
-
-  function handleDelete() {
-    void playback.stop();
-    setVerseStates((prev: Record<number, VerseState>) => ({
-      ...prev,
-      [selectedVerse]: 'idle',
-    }));
-    setReviewUris(prev => {
-      const next = { ...prev };
-      delete next[selectedVerse];
-      return next;
-    });
+  async function handleRecordPress() {
+    if (showRecording) {
+      await verseAudio.stop();
+      return;
+    }
+    const permission = await requestMicPermission();
+    if (permission !== 'granted') {
+      setMicDenied(true);
+      return;
+    }
+    setMicDenied(false);
+    await verseAudio.start();
   }
 
   function selectVerse(v: number) {
-    void playback.stop();
     setSelectedVerse(v);
     setSourceExpanded(false);
   }
-
-  async function handleReviewPlayback() {
-    const uri = reviewUris[selectedVerse];
-    if (!uri) {
-      return;
-    }
-    if (playback.status === 'playing') {
-      await playback.pause();
-      return;
-    }
-    await playback.play(uri);
-  }
-
-  const reviewUri = reviewUris[selectedVerse];
-  const canPlayReview = Boolean(reviewUri);
 
   return (
     <View style={styles.container}>
@@ -212,65 +216,89 @@ export default function ViewChapter() {
             {language} - Verse {selectedVerse}
           </Text>
 
-          {verseState === 'idle' && (
+          {micDenied && (
+            <Text style={styles.emptyText}>
+              Microphone access is required to record.
+            </Text>
+          )}
+
+          {uiState === 'idle' || uiState === 'error' ? (
             <TouchableOpacity
               style={styles.recordBtn}
-              onPress={handleRecord}
+              onPress={() => {
+                void handleRecordPress();
+              }}
               activeOpacity={0.8}
+              disabled={bibleTextId === null}
             >
               <Ionicons name="mic" size={28} color="#fff" />
             </TouchableOpacity>
-          )}
+          ) : null}
 
-          {verseState === 'recording' && (
-            <TouchableOpacity
-              style={styles.recordBtn}
-              onPress={handleRecord}
-              activeOpacity={0.8}
-            >
-              <Ionicons name="stop" size={24} color="#fff" />
-            </TouchableOpacity>
-          )}
+          {showRecording ? (
+            <View style={styles.playerRow}>
+              <TouchableOpacity
+                style={styles.playBtn}
+                onPress={() => {
+                  void (uiState === 'paused'
+                    ? verseAudio.resume()
+                    : verseAudio.pause());
+                }}
+              >
+                <Ionicons
+                  name={uiState === 'paused' ? 'mic' : 'pause'}
+                  size={16}
+                  color="#fff"
+                />
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.recordBtn}
+                onPress={() => {
+                  void handleRecordPress();
+                }}
+                activeOpacity={0.8}
+              >
+                <Ionicons name="stop" size={24} color="#fff" />
+              </TouchableOpacity>
+            </View>
+          ) : null}
 
-          {verseState === 'recorded' && (
+          {showRecorded ? (
             <>
               <View style={styles.playerRow}>
                 <TouchableOpacity
                   style={[
                     styles.playBtn,
-                    !canPlayReview && styles.playBtnDisabled,
+                    !verseAudio.latest?.localFilePath && styles.playBtnDisabled,
                   ]}
                   onPress={() => {
-                    void handleReviewPlayback();
+                    void verseAudio.play();
                   }}
-                  disabled={!canPlayReview}
+                  disabled={!verseAudio.latest?.localFilePath}
                   activeOpacity={0.8}
-                  accessibilityLabel={
-                    playback.status === 'playing'
-                      ? 'Pause recording'
-                      : 'Play recording'
-                  }
                 >
                   <Ionicons
-                    name={playback.status === 'playing' ? 'pause' : 'play'}
+                    name={uiState === 'playing' ? 'pause' : 'play'}
                     size={16}
                     color="#fff"
                   />
                 </TouchableOpacity>
                 <PlaybackProgressBar
-                  positionMs={playback.positionMs}
-                  durationMs={playback.durationMs}
+                  positionMs={verseAudio.positionMs}
+                  durationMs={verseAudio.durationMs}
                 />
               </View>
               <TouchableOpacity
                 style={styles.deleteBtn}
-                onPress={handleDelete}
+                onPress={() => {
+                  void verseAudio.deleteCurrent();
+                }}
                 activeOpacity={0.8}
               >
                 <Ionicons name="trash" size={20} color="#fff" />
               </TouchableOpacity>
             </>
-          )}
+          ) : null}
         </View>
       </ScrollView>
 
@@ -283,7 +311,7 @@ export default function ViewChapter() {
         {verses.length > 0 ? (
           verses.map(verse => {
             const hasRecording =
-              (verseStates[verse.verseNumber] ?? 'idle') === 'recorded';
+              verse.verseNumber === selectedVerse && Boolean(verseAudio.latest);
             const isSelected = selectedVerse === verse.verseNumber;
             return (
               <TouchableOpacity

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -517,3 +517,26 @@ export async function getRecordedVerseNumbers(
     return new Set();
   }
 }
+
+/** Resolve `bible_texts.id` for a verse — required for recording persistence. */
+export async function getBibleTextId(
+  bibleId: number,
+  bookId: number,
+  chapterNumber: number,
+  verseNumber: number,
+): Promise<number | null> {
+  const db = getDatabase();
+  try {
+    const result = await db.execute(
+      `SELECT id FROM bible_texts
+       WHERE bible_id = ? AND book_id = ? AND chapter_number = ? AND verse_number = ?
+       LIMIT 1`,
+      [bibleId, bookId, chapterNumber, verseNumber],
+    );
+    const row = (result?.rows as unknown as { id: number }[])?.[0];
+    return row?.id ?? null;
+  } catch (error) {
+    log.error('Error resolving bible_text id', { error });
+    return null;
+  }
+}

--- a/src/hooks/useVerseAudio.ts
+++ b/src/hooks/useVerseAudio.ts
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useReducer, useState } from 'react';
+import * as FileSystem from 'expo-file-system/legacy';
+import {
+  addRecordingTake,
+  deleteRecordingTake,
+  getLatestRecordingForVerse,
+} from '../db/repository';
+import type { Recording } from '../types/db/types';
+import { ensureRecordingsDir, recordingPath } from '../utils/audioStorage';
+import { logger } from '../utils/logger';
+import { usePlaybackEngine } from './usePlaybackEngine';
+import { useRecordingEngine } from './useRecordingEngine';
+import { verseAudioReducer, type VerseAudioState } from './verseAudioReducer';
+
+const log = logger.create('useVerseAudio');
+
+export type VerseAudioPersistDeps = {
+  persistTake?: (args: {
+    bibleTextId: number;
+    tempUri: string;
+    durationMs: number;
+  }) => Promise<{ id: string; localFilePath: string }>;
+  loadLatest?: (bibleTextId: number) => Promise<Recording | null>;
+  deleteTake?: (id: string) => Promise<void>;
+};
+
+export type UseVerseAudioArgs = {
+  bibleTextId: number | null;
+} & VerseAudioPersistDeps;
+
+async function defaultPersistTake(args: {
+  bibleTextId: number;
+  tempUri: string;
+  durationMs: number;
+}): Promise<{ id: string; localFilePath: string }> {
+  await ensureRecordingsDir();
+  const id = `rec_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+  const dest = recordingPath(id);
+  await FileSystem.copyAsync({ from: args.tempUri, to: dest });
+  await addRecordingTake({
+    id,
+    bibleTextId: args.bibleTextId,
+    localFilePath: dest,
+    durationMs: args.durationMs,
+  });
+  return { id, localFilePath: dest };
+}
+
+/**
+ * Composes recorder (#95) + player (#96) + storage (#94) + multi-take (#98)
+ * behind the pure {@link verseAudioReducer}. Permission/Alert UX stays in the screen.
+ */
+export function useVerseAudio({
+  bibleTextId,
+  persistTake = defaultPersistTake,
+  loadLatest = getLatestRecordingForVerse,
+  deleteTake = deleteRecordingTake,
+}: UseVerseAudioArgs) {
+  const recording = useRecordingEngine();
+  const playback = usePlaybackEngine();
+  const [state, dispatch] = useReducer(
+    verseAudioReducer,
+    'idle' as VerseAudioState,
+  );
+  const [latest, setLatest] = useState<Recording | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (bibleTextId === null) {
+        setLatest(null);
+        dispatch({ type: 'REHYDRATE', hasTake: false });
+        return;
+      }
+      try {
+        const row = await loadLatest(bibleTextId);
+        if (cancelled) return;
+        setLatest(row);
+        dispatch({ type: 'REHYDRATE', hasTake: Boolean(row) });
+      } catch (error) {
+        log.error('Failed to load latest take', { error });
+        if (!cancelled) {
+          dispatch({
+            type: 'ERROR',
+            message: error instanceof Error ? error.message : 'load failed',
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bibleTextId, loadLatest]);
+
+  const start = useCallback(async () => {
+    if (bibleTextId === null) return;
+    try {
+      await recording.start();
+      dispatch({ type: 'START' });
+      setErrorMessage(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'start failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [bibleTextId, recording]);
+
+  const pause = useCallback(async () => {
+    try {
+      await recording.pause();
+      dispatch({ type: 'PAUSE' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'pause failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [recording]);
+
+  const resume = useCallback(async () => {
+    try {
+      await recording.resume();
+      dispatch({ type: 'RESUME' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'resume failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [recording]);
+
+  const stop = useCallback(async () => {
+    if (bibleTextId === null) return;
+    try {
+      dispatch({ type: 'STOP' });
+      const { uri, durationMs } = await recording.stop();
+      const saved = await persistTake({
+        bibleTextId,
+        tempUri: uri,
+        durationMs,
+      });
+      const row =
+        (await loadLatest(bibleTextId)) ??
+        ({
+          id: saved.id,
+          bibleTextId,
+          localFilePath: saved.localFilePath,
+          takeNumber: 1,
+          isLatest: true,
+          syncStatus: 'pending',
+          durationMs,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        } satisfies Recording);
+      setLatest(row);
+      dispatch({ type: 'SAVED' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'stop failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [bibleTextId, loadLatest, persistTake, recording]);
+
+  const play = useCallback(async () => {
+    if (!latest?.localFilePath) return;
+    try {
+      await playback.play(latest.localFilePath);
+      dispatch({ type: 'PLAY' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'play failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [latest, playback]);
+
+  const deleteCurrent = useCallback(async () => {
+    try {
+      await playback.stop();
+      if (latest) {
+        await deleteTake(latest.id);
+      }
+      setLatest(null);
+      dispatch({ type: 'DELETE' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'delete failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [deleteTake, latest, playback]);
+
+  return {
+    state,
+    latest,
+    errorMessage,
+    positionMs: playback.positionMs,
+    durationMs: playback.durationMs,
+    start,
+    pause,
+    resume,
+    stop,
+    play,
+    deleteCurrent,
+  };
+}

--- a/src/hooks/verseAudioReducer.test.ts
+++ b/src/hooks/verseAudioReducer.test.ts
@@ -1,0 +1,60 @@
+import {
+  verseAudioReducer,
+  type VerseAudioEvent,
+  type VerseAudioState,
+} from './verseAudioReducer';
+
+describe('verseAudioReducer', () => {
+  const step = (from: VerseAudioState, event: VerseAudioEvent) =>
+    verseAudioReducer(from, event);
+
+  it('idle → recording → paused → recording → saving → recorded', () => {
+    let s: VerseAudioState = 'idle';
+    s = step(s, { type: 'START' });
+    expect(s).toBe('recording');
+    s = step(s, { type: 'PAUSE' });
+    expect(s).toBe('paused');
+    s = step(s, { type: 'RESUME' });
+    expect(s).toBe('recording');
+    s = step(s, { type: 'STOP' });
+    expect(s).toBe('saving');
+    s = step(s, { type: 'SAVED' });
+    expect(s).toBe('recorded');
+  });
+
+  it('REHYDRATE derives recorded vs idle from DB', () => {
+    expect(step('idle', { type: 'REHYDRATE', hasTake: true })).toBe('recorded');
+    expect(step('recorded', { type: 'REHYDRATE', hasTake: false })).toBe(
+      'idle',
+    );
+    expect(step('recording', { type: 'REHYDRATE', hasTake: true })).toBe(
+      'recording',
+    );
+  });
+
+  it('recorded → playing → recorded on PLAYBACK_END', () => {
+    expect(step('recorded', { type: 'PLAY' })).toBe('playing');
+    expect(step('playing', { type: 'PLAYBACK_END' })).toBe('recorded');
+  });
+
+  it('DELETE returns to idle from recorded/playing/error', () => {
+    expect(step('recorded', { type: 'DELETE' })).toBe('idle');
+    expect(step('playing', { type: 'DELETE' })).toBe('idle');
+    expect(step('error', { type: 'DELETE' })).toBe('idle');
+  });
+
+  it('ERROR always transitions to error', () => {
+    expect(step('recording', { type: 'ERROR', message: 'x' })).toBe('error');
+    expect(step('idle', { type: 'ERROR', message: 'x' })).toBe('error');
+  });
+
+  it('ignores illegal transitions', () => {
+    expect(step('idle', { type: 'PAUSE' })).toBe('idle');
+    expect(step('idle', { type: 'STOP' })).toBe('idle');
+    expect(step('recording', { type: 'PLAY' })).toBe('recording');
+  });
+
+  it('START from recorded begins a re-record', () => {
+    expect(step('recorded', { type: 'START' })).toBe('recording');
+  });
+});

--- a/src/hooks/verseAudioReducer.ts
+++ b/src/hooks/verseAudioReducer.ts
@@ -1,0 +1,70 @@
+export type VerseAudioState =
+  | 'idle'
+  | 'recording'
+  | 'paused'
+  | 'recorded'
+  | 'playing'
+  | 'saving'
+  | 'error';
+
+export type VerseAudioEvent =
+  | { type: 'START' }
+  | { type: 'PAUSE' }
+  | { type: 'RESUME' }
+  | { type: 'STOP' }
+  | { type: 'SAVED' }
+  | { type: 'PLAY' }
+  | { type: 'PLAYBACK_END' }
+  | { type: 'DELETE' }
+  | { type: 'REHYDRATE'; hasTake: boolean }
+  | { type: 'ERROR'; message: string };
+
+/**
+ * Pure verse-audio state machine (#97). Side effects live in the hook.
+ */
+export function verseAudioReducer(
+  state: VerseAudioState,
+  event: VerseAudioEvent,
+): VerseAudioState {
+  switch (event.type) {
+    case 'REHYDRATE':
+      if (state === 'recording' || state === 'paused' || state === 'saving') {
+        return state;
+      }
+      return event.hasTake ? 'recorded' : 'idle';
+    case 'START':
+      if (state === 'idle' || state === 'recorded' || state === 'error') {
+        return 'recording';
+      }
+      return state;
+    case 'PAUSE':
+      return state === 'recording' ? 'paused' : state;
+    case 'RESUME':
+      return state === 'paused' ? 'recording' : state;
+    case 'STOP':
+      if (state === 'recording' || state === 'paused') {
+        return 'saving';
+      }
+      return state;
+    case 'SAVED':
+      return state === 'saving' ? 'recorded' : state;
+    case 'PLAY':
+      return state === 'recorded' ? 'playing' : state;
+    case 'PLAYBACK_END':
+      return state === 'playing' ? 'recorded' : state;
+    case 'DELETE':
+      if (
+        state === 'recorded' ||
+        state === 'playing' ||
+        state === 'paused' ||
+        state === 'error'
+      ) {
+        return 'idle';
+      }
+      return state;
+    case 'ERROR':
+      return 'error';
+    default:
+      return state;
+  }
+}

--- a/src/test/mocks/expo-file-system.ts
+++ b/src/test/mocks/expo-file-system.ts
@@ -90,6 +90,24 @@ export async function readAsStringAsync(
   return files.get(path) ?? '';
 }
 
+export async function copyAsync(options: {
+  from: string;
+  to: string;
+}): Promise<void> {
+  const from = resolveUri(options.from);
+  const to = resolveUri(options.to);
+  const content = files.get(from) ?? '';
+  files.set(to, content);
+}
+
+export async function moveAsync(options: {
+  from: string;
+  to: string;
+}): Promise<void> {
+  await copyAsync(options);
+  await deleteAsync(options.from);
+}
+
 resetFileSystemMock();
 
 /** Test-only helper to inspect stored files. */


### PR DESCRIPTION
### TLDR

Adds a pure `verseAudioReducer` and `useVerseAudio` composing #94/#95/#96/#98. `ViewChapter` drops the mock toggle and drives record/pause/stop/play/delete through the hook. Stacked on #98.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #97

**Depends on:** #98 / PR #227 (includes #96/#95/#94).

**Type of change:**

- [x] New feature

#### Technical changes

- **`src/hooks/verseAudioReducer.ts`** — pure transitions + `REHYDRATE` from DB
- **`src/hooks/useVerseAudio.ts`** — composes engines + `addRecordingTake` / file copy
- **`src/db/queries.ts`** — `getBibleTextId` helper for verse → row id
- **`src/app/tabs/ViewChapter.tsx`** — wired to the hook (mic denial message in-screen, no Alert in engine)

#### Testing

- `npm run format:check` · `npm run lint` · `npm run typecheck` · `npm test -- --ci`

### How to verify

1. CI command set above
2. Android device: record/pause/stop/play on a synced chapter — **human QA required**

**Expected:** Reducer tests cover transitions; ViewChapter no longer uses mock verse state toggles.

### Follow-ups

- [ ] #49 — full Record Tab UX (prev/next, accordion, kill-safe pause)
- [ ] Device QA (leave unchecked until human verifies)