### PR TITLE
[#236]: Fix blank Record tab, drafting chrome, and draft playback

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { View, ActivityIndicator, Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { NavigationContainer } from '@react-navigation/native';
+import {
+  DefaultTheme,
+  NavigationContainer,
+  type Theme as NavTheme,
+} from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClientProvider } from '@tanstack/react-query';
 import BootSplash from 'react-native-bootsplash';
@@ -22,6 +26,15 @@ import { appStyles } from './src/app/appStyles';
 import { theme } from './src/theme';
 
 const log = logger.create('App');
+
+const navigationTheme: NavTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: theme.colors.background,
+    card: theme.colors.background,
+  },
+};
 
 registerRecordingUploadWorker();
 
@@ -111,9 +124,7 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <GestureHandlerRootView
-        style={dbReady ? appStyles.appRoot : appStyles.containerAppInit}
-      >
+      <GestureHandlerRootView style={appStyles.appRoot}>
         <SafeAreaProvider>
           {!dbReady ? (
             <View style={appStyles.containerAppInit}>
@@ -132,7 +143,7 @@ function App() {
               )}
             </View>
           ) : (
-            <NavigationContainer>
+            <NavigationContainer theme={navigationTheme}>
               <AppNavigator
                 isAuthenticated={isAuthenticated}
                 onLoginSuccess={handleLoginSuccess}

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -13,6 +13,23 @@ jest.mock('react-native-bootsplash', () => ({
 
 // React Native Navigation
 jest.mock('@react-navigation/native', () => ({
+  DefaultTheme: {
+    dark: false,
+    colors: {
+      primary: '#0B50D0',
+      background: '#FFFFFF',
+      card: '#FFFFFF',
+      text: '#1A1A1A',
+      border: '#CCCCCC',
+      notification: '#DC2626',
+    },
+    fonts: {
+      regular: { fontFamily: 'System', fontWeight: '400' },
+      medium: { fontFamily: 'System', fontWeight: '500' },
+      bold: { fontFamily: 'System', fontWeight: '700' },
+      heavy: { fontFamily: 'System', fontWeight: '800' },
+    },
+  },
   NavigationContainer: ({ children }: { children: React.ReactNode }) =>
     children,
 }));

--- a/app.config.ts
+++ b/app.config.ts
@@ -29,6 +29,10 @@ const config: ExpoConfig = {
   scheme: 'fluent',
   version: appVersion,
   icon: './assets/icon.png',
+  // Root / window background after splash — white app chrome (not brand blue).
+  // BootSplash cold-start still uses assets/bootsplash (blue).
+  backgroundColor: '#FFFFFF',
+  userInterfaceStyle: 'light',
   updates: {
     url: `https://u.expo.dev/${EAS_PROJECT_ID}`,
     enabled: updatesEnabled,
@@ -73,6 +77,8 @@ const config: ExpoConfig = {
         assetsDir: 'assets/bootsplash',
       },
     ],
+    // After bootsplash → AppTheme, keep window white (avoids Metro blue flash).
+    './plugins/withAppWindowBackground',
     './plugins/withRNScreensFragmentFactory',
     'expo-secure-store',
     'expo-asset',
@@ -82,6 +88,8 @@ const config: ExpoConfig = {
         // Android RECORD_AUDIO via config plugin (recordAudioAndroid defaults true)
         recordAudioAndroid: true,
         enableBackgroundRecording: false,
+        microphonePermission:
+          'Fluent needs access to your microphone so translators can record verse drafts.',
       },
     ],
   ],

--- a/plugins/withAppWindowBackground.js
+++ b/plugins/withAppWindowBackground.js
@@ -1,7 +1,4 @@
-const {
-  AndroidConfig,
-  withAndroidStyles,
-} = require('@expo/config-plugins');
+const { AndroidConfig, withAndroidStyles } = require('@expo/config-plugins');
 
 /**
  * After BootSplash hands off to AppTheme, keep the Android window white so

--- a/plugins/withAppWindowBackground.js
+++ b/plugins/withAppWindowBackground.js
@@ -1,0 +1,30 @@
+const {
+  AndroidConfig,
+  withAndroidStyles,
+} = require('@expo/config-plugins');
+
+/**
+ * After BootSplash hands off to AppTheme, keep the Android window white so
+ * Metro remounts / brief empty React roots don't flash brand-blue bootsplash.
+ * Cold-start BootTheme still uses bootsplash_background (#0b50d0).
+ */
+function withAppWindowBackground(config) {
+  return withAndroidStyles(config, config => {
+    config.modResults = AndroidConfig.Styles.assignStylesValue(
+      config.modResults,
+      {
+        add: true,
+        parent: {
+          name: 'AppTheme',
+          parent: 'Theme.AppCompat.DayNight.NoActionBar',
+        },
+        name: 'android:windowBackground',
+        // Explicit white — do not reuse bootsplash/splashscreen blue (#0b50d0).
+        value: '@android:color/white',
+      },
+    );
+    return config;
+  });
+}
+
+module.exports = withAppWindowBackground;

--- a/src/app/appStyles.ts
+++ b/src/app/appStyles.ts
@@ -458,15 +458,17 @@ export const appStyles = StyleSheet.create({
     textAlign: 'center',
   },
   bulletText: { flex: 1, fontSize: 15, lineHeight: 22, color: '#172b4d' },
-  //App.tsx
+  // App.tsx — keep white (not brand blue). Metro remount resets `dbReady`, so a
+  // blue init root flashes over white chrome; cold-start bootsplash stays blue.
   appRoot: {
     flex: 1,
+    backgroundColor: '#FFFFFF',
   },
   containerAppInit: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#0b50d0',
+    backgroundColor: '#FFFFFF',
   },
   errorTextAppInit: {
     color: 'red',
@@ -474,7 +476,7 @@ export const appStyles = StyleSheet.create({
     padding: 20,
     textAlign: 'center',
   },
-  loadingTextAppInit: { marginTop: 10, fontSize: 14 },
+  loadingTextAppInit: { marginTop: 10, fontSize: 14, color: '#1A1A1A' },
   menuItemDisabled: {
     opacity: 0.5,
   },

--- a/src/app/screens/DraftingScreen.tsx
+++ b/src/app/screens/DraftingScreen.tsx
@@ -11,13 +11,7 @@ import { RootStackParamList } from '../../types/navigation/types';
 import { useGlobalSyncStatus } from '../../hooks/useGlobalSyncStatus';
 import { DraftingHeader } from '../../components/layout/DraftingHeader';
 import { ChapterAssignmentData, VerseData } from '../../types/db/types';
-import {
-  ActivityIndicator,
-  Alert,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Alert, StyleSheet, Text, View } from 'react-native';
 import { ScreenContainer } from '../../components/layout/ScreenContainer';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useActiveAccountSummary } from '../../hooks/useActiveAccountSummary';
@@ -55,11 +49,7 @@ export default function DraftingScreen() {
   const setActiveTab = useCallback(
     (tab: DraftingTab) => {
       if (tab === activeTab) return;
-      if (
-        recordCaptureActive &&
-        activeTab === 'record' &&
-        tab !== 'record'
-      ) {
+      if (recordCaptureActive && activeTab === 'record' && tab !== 'record') {
         Alert.alert(
           'Recording in progress',
           'Stop or finish the current take before leaving the Record tab.',

--- a/src/app/screens/DraftingScreen.tsx
+++ b/src/app/screens/DraftingScreen.tsx
@@ -2,6 +2,7 @@ import { theme } from '../../theme';
 import { logger } from '../../utils/logger';
 import { BibleTab } from '../tabs/BibleTab';
 import { RecordTab } from '../tabs/RecordTab';
+import { ResourcesTab } from '../tabs/ResourcesTab';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
 import { onSyncComplete } from '../../services/syncEvents';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -10,7 +11,13 @@ import { RootStackParamList } from '../../types/navigation/types';
 import { useGlobalSyncStatus } from '../../hooks/useGlobalSyncStatus';
 import { DraftingHeader } from '../../components/layout/DraftingHeader';
 import { ChapterAssignmentData, VerseData } from '../../types/db/types';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { ScreenContainer } from '../../components/layout/ScreenContainer';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useActiveAccountSummary } from '../../hooks/useActiveAccountSummary';
@@ -19,10 +26,7 @@ import {
   getLastActiveTab,
   setLastActiveTab,
 } from '../../utils/draftingTabState';
-import {
-  DraftingProvider,
-  // useDraftingContext,
-} from '../context/DraftingContext';
+import { DraftingProvider } from '../context/DraftingContext';
 import {
   DraftingTab,
   DraftingTabBar,
@@ -45,13 +49,28 @@ export default function DraftingScreen() {
   const [activeTab, setActiveTabState] = useState<DraftingTab>(
     () => getLastActiveTab(chapterId) ?? 'bible',
   );
+  /** True while Record tab has an in-progress take (recording/paused). */
+  const [recordCaptureActive, setRecordCaptureActive] = useState(false);
 
   const setActiveTab = useCallback(
     (tab: DraftingTab) => {
+      if (tab === activeTab) return;
+      if (
+        recordCaptureActive &&
+        activeTab === 'record' &&
+        tab !== 'record'
+      ) {
+        Alert.alert(
+          'Recording in progress',
+          'Stop or finish the current take before leaving the Record tab.',
+          [{ text: 'OK' }],
+        );
+        return;
+      }
       setActiveTabState(tab);
       setLastActiveTab(chapterId, tab);
     },
-    [chapterId],
+    [activeTab, chapterId, recordCaptureActive],
   );
 
   const [verses, setVerses] = useState<VerseData[]>([]);
@@ -70,7 +89,17 @@ export default function DraftingScreen() {
     setAccountSwitcherVisible(false);
   }, []);
 
-  const goBack = useCallback(() => navigation.goBack(), [navigation]);
+  const goBack = useCallback(() => {
+    if (recordCaptureActive) {
+      Alert.alert(
+        'Recording in progress',
+        'Stop or finish the current take before leaving.',
+        [{ text: 'OK' }],
+      );
+      return;
+    }
+    navigation.goBack();
+  }, [navigation, recordCaptureActive]);
 
   const handleAccountPress = useCallback(() => {
     setAccountSwitcherVisible(true);
@@ -162,9 +191,10 @@ export default function DraftingScreen() {
     };
   }, [chapterId]);
 
+  // Header + tab bar own safe-area insets; keep container white edge-to-edge.
   if (loading) {
     return (
-      <ScreenContainer>
+      <ScreenContainer edges={[]}>
         {renderHeader()}
         <View style={styles.centered}>
           <ActivityIndicator size="large" color={theme.colors.primary} />
@@ -176,7 +206,7 @@ export default function DraftingScreen() {
 
   if (!chapterData) {
     return (
-      <ScreenContainer>
+      <ScreenContainer edges={[]}>
         {renderHeader()}
         <View style={styles.centered}>
           <Text style={styles.emptyText}>No chapter data found</Text>
@@ -187,20 +217,47 @@ export default function DraftingScreen() {
   }
 
   return (
-    <ScreenContainer>
+    <ScreenContainer edges={[]}>
       <DraftingProvider verses={verses} initialVerse={initialVerse}>
         <View style={styles.screen}>
           {renderHeader()}
 
           <View style={styles.content}>
-            {activeTab === 'bible' ? (
-              <BibleTab />
-            ) : (
-              <RecordTab chapterData={chapterData} />
-            )}
+            {/*
+              Keep Record mounted (display:none when inactive) so the native
+              recording session survives Bible/Resources tab switches.
+            */}
+            <View
+              style={[
+                styles.tabPane,
+                activeTab !== 'bible' && styles.tabHidden,
+              ]}
+              pointerEvents={activeTab === 'bible' ? 'auto' : 'none'}
+            >
+              <BibleTab onOpenRecord={() => setActiveTab('record')} />
+            </View>
+            <View
+              style={[
+                styles.tabPane,
+                activeTab !== 'resources' && styles.tabHidden,
+              ]}
+              pointerEvents={activeTab === 'resources' ? 'auto' : 'none'}
+            >
+              <ResourcesTab />
+            </View>
+            <View
+              style={[
+                styles.tabPane,
+                activeTab !== 'record' && styles.tabHidden,
+              ]}
+              pointerEvents={activeTab === 'record' ? 'auto' : 'none'}
+            >
+              <RecordTab
+                chapterData={chapterData}
+                onCaptureActiveChange={setRecordCaptureActive}
+              />
+            </View>
           </View>
-
-          {/* <DraftingPlayerBar verses={verses} /> */}
 
           <DraftingTabBar activeTab={activeTab} onTabChange={setActiveTab} />
         </View>
@@ -217,6 +274,12 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+  },
+  tabPane: {
+    flex: 1,
+  },
+  tabHidden: {
+    display: 'none',
   },
   centered: {
     flex: 1,

--- a/src/app/tabs/BibleTab.test.tsx
+++ b/src/app/tabs/BibleTab.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { BibleTab } from './BibleTab';
+import { DraftingProvider } from '../context/DraftingContext';
+
+const verses = [
+  {
+    bibleId: 1,
+    bookId: 1,
+    chapterNumber: 14,
+    verseNumber: 2,
+    text: 'Source text for verse 2',
+  },
+];
+
+describe('BibleTab', () => {
+  it('selects the verse and opens Record when a verse row is pressed', () => {
+    const onOpenRecord = jest.fn();
+
+    render(
+      <DraftingProvider verses={verses} initialVerse={2}>
+        <BibleTab onOpenRecord={onOpenRecord} />
+      </DraftingProvider>,
+    );
+
+    fireEvent.press(screen.getByLabelText('Verse 2, selected'));
+    expect(onOpenRecord).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/tabs/BibleTab.tsx
+++ b/src/app/tabs/BibleTab.tsx
@@ -11,7 +11,12 @@ import {
 } from 'react-native';
 import { iconSizes, listIconStrokeWidth, theme } from '../../theme';
 
-export function BibleTab() {
+type BibleTabProps = {
+  /** Opens the Record tab for the tapped verse (drafting bottom nav). */
+  onOpenRecord?: () => void;
+};
+
+export function BibleTab({ onOpenRecord }: BibleTabProps = {}) {
   const { verses, selectedVerse, setSelectedVerse, currentlyPlayingVerse } =
     useDraftingContext();
   const listRef = useRef<FlatList<VerseData>>(null);
@@ -23,6 +28,14 @@ export function BibleTab() {
       listRef.current?.scrollToIndex({ index: info.index, animated: false });
     });
   }, []);
+
+  const handleVersePress = useCallback(
+    (verseNumber: number) => {
+      setSelectedVerse(verseNumber);
+      onOpenRecord?.();
+    },
+    [onOpenRecord, setSelectedVerse],
+  );
 
   const renderItem = useCallback(
     ({ item }: { item: VerseData }) => {
@@ -37,7 +50,7 @@ export function BibleTab() {
             isSelected && styles.rowSelected,
             isPlaying && styles.rowPlaying,
           ]}
-          onPress={() => setSelectedVerse(item.verseNumber)}
+          onPress={() => handleVersePress(item.verseNumber)}
           activeOpacity={0.7}
           accessibilityRole="button"
           accessibilityLabel={`Verse ${item.verseNumber}${
@@ -67,7 +80,7 @@ export function BibleTab() {
         </TouchableOpacity>
       );
     },
-    [selectedVerse, currentlyPlayingVerse, setSelectedVerse],
+    [selectedVerse, currentlyPlayingVerse, handleVersePress],
   );
 
   return (
@@ -79,14 +92,20 @@ export function BibleTab() {
       initialScrollIndex={initialIndex > 0 ? initialIndex : undefined}
       onScrollToIndexFailed={handleScrollToIndexFailed}
       contentContainerStyle={styles.content}
+      style={styles.list}
       showsVerticalScrollIndicator={false}
     />
   );
 }
 
 const styles = StyleSheet.create({
+  list: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
   content: {
     paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.background,
   },
   row: {
     flexDirection: 'row',
@@ -96,6 +115,7 @@ const styles = StyleSheet.create({
     gap: theme.spacing.md,
     borderLeftWidth: 3,
     borderLeftColor: 'transparent',
+    backgroundColor: theme.colors.background,
   },
   rowSelected: {
     borderLeftColor: theme.colors.primary,

--- a/src/app/tabs/RecordTab.test.tsx
+++ b/src/app/tabs/RecordTab.test.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react-native';
 import { RecordTab } from './RecordTab';
 import { DraftingProvider } from '../context/DraftingContext';
+import type { useVerseAudio } from '../../hooks/useVerseAudio';
 
 jest.mock('@react-navigation/native', () => ({
   useRoute: () => ({ params: { chapterName: 'Mark 14' } }),
 }));
 
-const idleAudio = {
-  state: 'idle' as const,
+type VerseAudioApi = ReturnType<typeof useVerseAudio>;
+
+const idleAudio: VerseAudioApi = {
+  state: 'idle',
   latest: null,
   errorMessage: null,
   positionMs: 0,
@@ -22,7 +25,7 @@ const idleAudio = {
   deleteCurrent: jest.fn(),
 };
 
-const mockUseVerseAudio = jest.fn(() => idleAudio);
+const mockUseVerseAudio = jest.fn((): VerseAudioApi => idleAudio);
 
 jest.mock('../../hooks/useVerseAudio', () => ({
   useVerseAudio: () => mockUseVerseAudio(),
@@ -75,7 +78,11 @@ describe('RecordTab', () => {
     expect(screen.getByTestId('record-source-toggle')).toBeTruthy();
     expect(screen.getByText('View source text')).toBeTruthy();
     expect(screen.getByTestId('source-audio-bar')).toBeTruthy();
-    expect(screen.getByTestId('source-audio-label')).toBeTruthy();
+    // Stub defaults to empty until #235 wires real source audio.
+    expect(screen.getByTestId('source-audio-label')).toHaveTextContent(
+      'No source audio',
+    );
+    expect(screen.queryByTestId('source-audio-time-stub')).toBeNull();
 
     await waitFor(() => {
       expect(screen.queryByTestId('record-syncing-hint')).toBeNull();
@@ -88,9 +95,14 @@ describe('RecordTab', () => {
       state: 'recorded',
       latest: {
         id: 'rec_1',
-        takeNumber: 1,
-        durationMs: 13000,
+        bibleTextId: 42,
         localFilePath: 'file:///take.m4a',
+        takeNumber: 1,
+        isLatest: true,
+        durationMs: 13000,
+        syncStatus: 'pending',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
       },
       positionMs: 0,
       durationMs: 13000,
@@ -110,9 +122,8 @@ describe('RecordTab', () => {
     expect(screen.getByTestId('record-delete-button')).toBeTruthy();
     expect(screen.getByTestId('record-new-take-button')).toBeTruthy();
     expect(screen.getByText('Record New Take')).toBeTruthy();
-    // Source dock times are decorative stubs — not the take engine clock.
-    expect(screen.getByTestId('source-audio-time-stub')).toHaveTextContent(
-      '0:00',
+    expect(screen.getByTestId('source-audio-label')).toHaveTextContent(
+      'No source audio',
     );
   });
 
@@ -141,9 +152,14 @@ describe('RecordTab', () => {
       state: 'recorded',
       latest: {
         id: 'rec_1',
-        takeNumber: 1,
-        durationMs: 1000,
+        bibleTextId: 42,
         localFilePath: 'file:///take.m4a',
+        takeNumber: 1,
+        isLatest: true,
+        durationMs: 1000,
+        syncStatus: 'pending',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
       },
       durationMs: 1000,
     });

--- a/src/app/tabs/RecordTab.test.tsx
+++ b/src/app/tabs/RecordTab.test.tsx
@@ -1,26 +1,31 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, waitFor } from '@testing-library/react-native';
 import { RecordTab } from './RecordTab';
+import { DraftingProvider } from '../context/DraftingContext';
 
 jest.mock('@react-navigation/native', () => ({
   useRoute: () => ({ params: { chapterName: 'Mark 14' } }),
 }));
-import { DraftingProvider } from '../context/DraftingContext';
+
+const idleAudio = {
+  state: 'idle' as const,
+  latest: null,
+  errorMessage: null,
+  positionMs: 0,
+  durationMs: 0,
+  start: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  stop: jest.fn(),
+  play: jest.fn(),
+  pausePlayback: jest.fn(),
+  deleteCurrent: jest.fn(),
+};
+
+const mockUseVerseAudio = jest.fn(() => idleAudio);
 
 jest.mock('../../hooks/useVerseAudio', () => ({
-  useVerseAudio: () => ({
-    state: 'idle',
-    latest: null,
-    errorMessage: null,
-    positionMs: 0,
-    durationMs: 0,
-    start: jest.fn(),
-    pause: jest.fn(),
-    resume: jest.fn(),
-    stop: jest.fn(),
-    play: jest.fn(),
-    deleteCurrent: jest.fn(),
-  }),
+  useVerseAudio: () => mockUseVerseAudio(),
 }));
 
 jest.mock('../../db/queries', () => ({
@@ -40,21 +45,24 @@ const chapterData = {
   bookName: 'Mark',
 } as never;
 
+const verses = [
+  {
+    bibleId: 1,
+    bookId: 1,
+    chapterNumber: 14,
+    verseNumber: 3,
+    text: 'Source text',
+  },
+];
+
 describe('RecordTab', () => {
-  it('renders idle design chrome: verse nav, record, source link, source audio', () => {
+  beforeEach(() => {
+    mockUseVerseAudio.mockReturnValue(idleAudio);
+  });
+
+  it('renders idle design chrome: verse nav, record, source link, source audio', async () => {
     render(
-      <DraftingProvider
-        verses={[
-          {
-            bibleId: 1,
-            bookId: 1,
-            chapterNumber: 14,
-            verseNumber: 3,
-            text: 'Source text',
-          },
-        ]}
-        initialVerse={3}
-      >
+      <DraftingProvider verses={verses} initialVerse={3}>
         <RecordTab chapterData={chapterData} />
       </DraftingProvider>,
     );
@@ -62,10 +70,94 @@ describe('RecordTab', () => {
     expect(screen.getByTestId('record-tab')).toBeTruthy();
     expect(screen.getByTestId('record-verse-reference')).toBeTruthy();
     expect(screen.getByTestId('record-start-button')).toBeTruthy();
+    expect(screen.getByText('Record Mark 14:3')).toBeTruthy();
     expect(screen.getByTestId('record-play-idle-placeholder')).toBeTruthy();
     expect(screen.getByTestId('record-source-toggle')).toBeTruthy();
     expect(screen.getByText('View source text')).toBeTruthy();
     expect(screen.getByTestId('source-audio-bar')).toBeTruthy();
     expect(screen.getByTestId('source-audio-label')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('record-syncing-hint')).toBeNull();
+    });
+  });
+
+  it('renders has-draft chrome with take row and Record New Take', () => {
+    mockUseVerseAudio.mockReturnValue({
+      ...idleAudio,
+      state: 'recorded',
+      latest: {
+        id: 'rec_1',
+        takeNumber: 1,
+        durationMs: 13000,
+        localFilePath: 'file:///take.m4a',
+      },
+      positionMs: 0,
+      durationMs: 13000,
+    });
+
+    render(
+      <DraftingProvider verses={verses} initialVerse={3}>
+        <RecordTab chapterData={chapterData} />
+      </DraftingProvider>,
+    );
+
+    expect(screen.getByTestId('record-take-row')).toBeTruthy();
+    expect(screen.getByTestId('record-take-badge')).toBeTruthy();
+    expect(screen.getByTestId('record-play-button')).toBeTruthy();
+    expect(screen.getByTestId('record-take-time')).toBeTruthy();
+    expect(screen.getByText('0:00 / 0:13')).toBeTruthy();
+    expect(screen.getByTestId('record-delete-button')).toBeTruthy();
+    expect(screen.getByTestId('record-new-take-button')).toBeTruthy();
+    expect(screen.getByText('Record New Take')).toBeTruthy();
+    // Source dock times are decorative stubs — not the take engine clock.
+    expect(screen.getByTestId('source-audio-time-stub')).toHaveTextContent(
+      '0:00',
+    );
+  });
+
+  it('notifies captureActive during recording and clears after stop', async () => {
+    const onCaptureActiveChange = jest.fn();
+
+    mockUseVerseAudio.mockReturnValue({
+      ...idleAudio,
+      state: 'recording',
+    });
+
+    const { rerender } = render(
+      <DraftingProvider verses={verses} initialVerse={3}>
+        <RecordTab
+          chapterData={chapterData}
+          onCaptureActiveChange={onCaptureActiveChange}
+        />
+      </DraftingProvider>,
+    );
+
+    expect(onCaptureActiveChange).toHaveBeenCalledWith(true);
+    expect(screen.getByTestId('playback-progress-animated')).toBeTruthy();
+
+    mockUseVerseAudio.mockReturnValue({
+      ...idleAudio,
+      state: 'recorded',
+      latest: {
+        id: 'rec_1',
+        takeNumber: 1,
+        durationMs: 1000,
+        localFilePath: 'file:///take.m4a',
+      },
+      durationMs: 1000,
+    });
+    rerender(
+      <DraftingProvider verses={verses} initialVerse={3}>
+        <RecordTab
+          chapterData={chapterData}
+          onCaptureActiveChange={onCaptureActiveChange}
+        />
+      </DraftingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(onCaptureActiveChange).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/src/app/tabs/RecordTab.tsx
+++ b/src/app/tabs/RecordTab.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import {
   Alert,
   Linking,
-  LayoutAnimation,
   Platform,
   StyleSheet,
   Text,
@@ -16,11 +15,7 @@ import {
   CircleDot,
   Pause,
   Play,
-  RefreshCw,
   Square,
-  Trash2,
-  ChevronDown,
-  ChevronUp,
 } from 'lucide-react-native';
 import { useRoute, RouteProp } from '@react-navigation/native';
 import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
@@ -29,6 +24,9 @@ import { getBibleTextId } from '../../db/queries';
 import { useVerseAudio } from '../../hooks/useVerseAudio';
 import { requestMicPermission } from '../../audio/micPermission';
 import { PlaybackProgressBar } from '../../components/ui/PlaybackProgressBar';
+import { DraftTakeRow } from '../../components/ui/DraftTakeRow';
+import { RecordCircleButton } from '../../components/ui/RecordCircleButton';
+import { SourceTextAccordion } from '../../components/ui/SourceTextAccordion';
 import { SourceAudioPlayerBar } from '../../components/layout/SourceAudioPlayerBar';
 import { RootStackParamList } from '../../types/navigation/types';
 import { ChapterAssignmentData } from '../../types/db/types';
@@ -49,14 +47,24 @@ function formatDuration(ms: number): string {
 
 type RecordTabProps = {
   chapterData: ChapterAssignmentData;
+  /**
+   * Notifies DraftingScreen when an in-progress capture should block tab
+   * switches (recording/paused). Keep Record mounted while hidden so the
+   * native session survives tab switches — unmounting tears down expo-audio's
+   * recorder.
+   */
+  onCaptureActiveChange?: (active: boolean) => void;
 };
 
 /**
  * Record tab — draft capture / review for the selected drafting verse.
- * Visual states follow docs/design/record-tab/01–04 (Matt).
+ * Visual states follow docs/design/record-tab/01–04 + Lovable chrome.
  * Built on useVerseAudio (#97); kill-safe ADTS multi-segment pause is #176/#170.
  */
-export function RecordTab({ chapterData }: RecordTabProps) {
+export function RecordTab({
+  chapterData,
+  onCaptureActiveChange,
+}: RecordTabProps) {
   const { chapterName } = useRoute<Route>().params;
   const { verses, selectedVerse, setSelectedVerse } = useDraftingContext();
   const [bibleTextId, setBibleTextId] = useState<number | null>(null);
@@ -69,9 +77,13 @@ export function RecordTab({ chapterData }: RecordTabProps) {
   const nextDisabled = verseIndex < 0 || verseIndex >= verses.length - 1;
   const selected = verses.find(v => v.verseNumber === selectedVerse);
   const reference = `${chapterName}:${selectedVerse}`;
+  const takeNumber = verseAudio.latest?.takeNumber;
+  const hasTake = Boolean(verseAudio.latest);
 
   useEffect(() => {
     let cancelled = false;
+    // Clear immediately so we never keep the previous verse's id while lookup runs.
+    setBibleTextId(null);
     (async () => {
       const id = await getBibleTextId(
         chapterData.bibleId,
@@ -104,6 +116,18 @@ export function RecordTab({ chapterData }: RecordTabProps) {
       setElapsedMs(0);
     }
   }, [verseAudio.state]);
+
+  useEffect(() => {
+    const active =
+      verseAudio.state === 'recording' || verseAudio.state === 'paused';
+    onCaptureActiveChange?.(active);
+    return () => onCaptureActiveChange?.(false);
+  }, [verseAudio.state, onCaptureActiveChange]);
+
+  useEffect(() => {
+    if (!verseAudio.errorMessage) return;
+    Alert.alert('Audio error', verseAudio.errorMessage);
+  }, [verseAudio.errorMessage]);
 
   const recordDisabled = bibleTextId === null;
   const syncingMessage =
@@ -175,14 +199,19 @@ export function RecordTab({ chapterData }: RecordTabProps) {
     setSelectedVerse(next);
   }
 
-  const showIdle = verseAudio.state === 'idle' || verseAudio.state === 'error';
+  // error + no take → idle chrome; error after a saved take → keep review so
+  // a failed play/delete doesn't look like the draft vanished.
+  const showIdle =
+    verseAudio.state === 'idle' ||
+    (verseAudio.state === 'error' && !hasTake);
   const isRecording = verseAudio.state === 'recording';
   const isPaused = verseAudio.state === 'paused';
   const showCapture = isRecording || isPaused;
   const showReview =
     verseAudio.state === 'recorded' ||
     verseAudio.state === 'playing' ||
-    verseAudio.state === 'saving';
+    verseAudio.state === 'saving' ||
+    (verseAudio.state === 'error' && hasTake);
   const showSourceAudio = showIdle || showReview;
   const isPlaying = verseAudio.state === 'playing';
 
@@ -243,17 +272,18 @@ export function RecordTab({ chapterData }: RecordTabProps) {
       </View>
 
       <View style={styles.main}>
-        {showCapture || showReview ? (
+        {showCapture ? (
           <View style={styles.waveformWrap} testID="record-waveform">
             <PlaybackProgressBar
-              positionMs={showCapture ? elapsedMs : verseAudio.positionMs}
-              durationMs={
-                showCapture ? Math.max(elapsedMs, 1) : verseAudio.durationMs
-              }
-              barCount={22}
+              positionMs={elapsedMs}
+              durationMs={Math.max(elapsedMs, 1)}
+              barCount={28}
               tall
+              animate={isRecording}
               accentColor={
-                isRecording ? theme.colors.recordAccent : theme.colors.primary
+                isRecording
+                  ? theme.colors.recordAccent
+                  : theme.colors.waveformActive
               }
             />
           </View>
@@ -268,36 +298,34 @@ export function RecordTab({ chapterData }: RecordTabProps) {
 
           {showIdle ? (
             <View style={styles.idleGroup}>
-              <TouchableOpacity
-                style={[styles.recordCircle, recordDisabled && styles.disabled]}
+              <RecordCircleButton
+                variant="record"
                 onPress={() => {
                   void handleStart();
                 }}
                 disabled={recordDisabled}
-                accessibilityRole="button"
                 accessibilityLabel={`Record ${reference}`}
                 testID="record-start-button"
               >
                 <CircleDot
-                  size={44}
+                  size={iconSizes.recordIdleGlyph}
                   color={theme.colors.primaryForeground}
                   strokeWidth={listIconStrokeWidth}
                 />
-              </TouchableOpacity>
+              </RecordCircleButton>
               <Text style={styles.recordLabel}>Record {reference}</Text>
-              <View
-                style={styles.mutedPlay}
-                accessibilityRole="button"
+              <RecordCircleButton
+                variant="muted"
+                disabled
                 accessibilityLabel="Playback unavailable until a draft is recorded"
-                accessibilityState={{ disabled: true }}
                 testID="record-play-idle-placeholder"
               >
                 <Play
-                  size={22}
+                  size={iconSizes.headerTab}
                   color={theme.colors.mutedForeground}
                   strokeWidth={listIconStrokeWidth}
                 />
-              </View>
+              </RecordCircleButton>
             </View>
           ) : null}
 
@@ -307,27 +335,25 @@ export function RecordTab({ chapterData }: RecordTabProps) {
                 {formatDuration(elapsedMs)}
               </Text>
               <View style={styles.row}>
-                <TouchableOpacity
-                  style={styles.stopCircle}
+                <RecordCircleButton
+                  variant="stop"
                   onPress={() => {
                     void handleStop();
                   }}
-                  accessibilityRole="button"
                   accessibilityLabel="Stop recording"
                   testID="record-stop-button"
                 >
                   <Square
-                    size={26}
+                    size={iconSizes.header}
                     color={theme.colors.foreground}
                     strokeWidth={listIconStrokeWidth}
                   />
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={styles.primaryRecordCircle}
+                </RecordCircleButton>
+                <RecordCircleButton
+                  variant="primary"
                   onPress={() => {
                     void (isPaused ? verseAudio.resume() : verseAudio.pause());
                   }}
-                  accessibilityRole="button"
                   accessibilityLabel={isPaused ? 'Resume recording' : 'Pause'}
                   testID={
                     isPaused ? 'record-resume-button' : 'record-pause-button'
@@ -335,20 +361,23 @@ export function RecordTab({ chapterData }: RecordTabProps) {
                 >
                   {isPaused ? (
                     <CircleDot
-                      size={30}
+                      size={iconSizes.recordPrimaryGlyph}
                       color={theme.colors.primaryForeground}
                       strokeWidth={listIconStrokeWidth}
                     />
                   ) : (
                     <Pause
-                      size={30}
+                      size={iconSizes.recordPrimaryGlyph}
                       color={theme.colors.primaryForeground}
                       strokeWidth={listIconStrokeWidth}
                     />
                   )}
-                </TouchableOpacity>
+                </RecordCircleButton>
               </View>
-              <Text style={styles.hint} testID="record-tip">
+              <Text
+                style={[styles.hint, isPaused && styles.hintPaused]}
+                testID="record-tip"
+              >
                 {isPaused
                   ? 'Recording paused — review the source below, then resume.'
                   : 'Tap pause to study the source, stop to finish.'}
@@ -358,115 +387,49 @@ export function RecordTab({ chapterData }: RecordTabProps) {
 
           {showReview ? (
             <View style={styles.reviewGroup}>
-              <View style={styles.row}>
-                <View
-                  style={styles.mutedPlay}
-                  accessibilityRole="image"
-                  accessibilityLabel="Recording complete"
-                  testID="record-review-secondary"
-                >
-                  <CircleDot
-                    size={22}
-                    color={theme.colors.mutedForeground}
-                    strokeWidth={listIconStrokeWidth}
-                  />
-                </View>
-                <TouchableOpacity
-                  style={styles.playCircle}
-                  onPress={() => {
-                    void verseAudio.play();
+              {typeof takeNumber === 'number' && takeNumber > 0 ? (
+                <DraftTakeRow
+                  takeNumber={takeNumber}
+                  positionMs={verseAudio.positionMs}
+                  durationMs={verseAudio.durationMs}
+                  isPlaying={isPlaying}
+                  onPlayPause={() => {
+                    void (isPlaying
+                      ? verseAudio.pausePlayback()
+                      : verseAudio.play());
                   }}
-                  accessibilityRole="button"
-                  accessibilityLabel={isPlaying ? 'Pause draft' : 'Play draft'}
-                  testID="record-play-button"
-                >
-                  {isPlaying ? (
-                    <Pause
-                      size={30}
-                      color={theme.colors.primaryForeground}
-                      strokeWidth={listIconStrokeWidth}
-                    />
-                  ) : (
-                    <Play
-                      size={30}
-                      color={theme.colors.primaryForeground}
-                      strokeWidth={listIconStrokeWidth}
-                    />
-                  )}
-                </TouchableOpacity>
-              </View>
-              <View style={styles.reviewActions}>
-                <TouchableOpacity
-                  style={[
-                    styles.reRecordButton,
-                    recordDisabled && styles.disabled,
-                  ]}
-                  onPress={() => {
-                    void handleReRecord();
-                  }}
-                  disabled={recordDisabled}
-                  testID="record-rerecord-button"
-                >
-                  <RefreshCw
-                    size={18}
-                    color={theme.colors.foreground}
-                    strokeWidth={listIconStrokeWidth}
-                  />
-                  <Text style={styles.reRecordLabel}>Re-record</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={styles.deleteButton}
-                  onPress={handleDelete}
-                  testID="record-delete-button"
-                >
-                  <Trash2
-                    size={18}
-                    color={theme.colors.destructive}
-                    strokeWidth={listIconStrokeWidth}
-                  />
-                  <Text style={styles.deleteLabel}>Delete</Text>
-                </TouchableOpacity>
-              </View>
+                  onDelete={handleDelete}
+                />
+              ) : null}
+              <TouchableOpacity
+                style={[
+                  styles.newTakeButton,
+                  recordDisabled && styles.disabled,
+                ]}
+                onPress={() => {
+                  void handleReRecord();
+                }}
+                disabled={recordDisabled}
+                accessibilityRole="button"
+                accessibilityLabel="Record new take"
+                testID="record-new-take-button"
+              >
+                <CircleDot
+                  size={iconSizes.headerTab}
+                  color={theme.colors.primaryForeground}
+                  strokeWidth={listIconStrokeWidth}
+                />
+                <Text style={styles.newTakeLabel}>Record New Take</Text>
+              </TouchableOpacity>
             </View>
           ) : null}
         </View>
 
-        <TouchableOpacity
-          onPress={() => {
-            LayoutAnimation.configureNext(
-              LayoutAnimation.Presets.easeInEaseOut,
-            );
-            setSourceExpanded(v => !v);
-          }}
-          style={styles.sourceLink}
-          accessibilityRole="button"
-          accessibilityLabel={
-            sourceExpanded ? 'Hide source text' : 'View source text'
-          }
-          testID="record-source-toggle"
-        >
-          {sourceExpanded ? (
-            <ChevronUp
-              size={iconSizes.chevron}
-              color={theme.colors.primary}
-              strokeWidth={listIconStrokeWidth}
-            />
-          ) : (
-            <ChevronDown
-              size={iconSizes.chevron}
-              color={theme.colors.primary}
-              strokeWidth={listIconStrokeWidth}
-            />
-          )}
-          <Text style={styles.sourceLinkLabel}>
-            {sourceExpanded ? 'Hide source text' : 'View source text'}
-          </Text>
-        </TouchableOpacity>
-        {sourceExpanded && selected?.text ? (
-          <View style={styles.sourceBody} testID="record-source-body">
-            <Text style={styles.sourceText}>{selected.text}</Text>
-          </View>
-        ) : null}
+        <SourceTextAccordion
+          expanded={sourceExpanded}
+          onToggle={() => setSourceExpanded(v => !v)}
+          text={selected?.text}
+        />
       </View>
 
       {showSourceAudio ? (
@@ -506,55 +469,27 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   waveformWrap: {
-    minHeight: 72,
-    width: '55%',
-    alignSelf: 'center',
+    minHeight: theme.waveform.tallHeight,
+    width: '100%',
+    alignSelf: 'stretch',
+    paddingHorizontal: theme.spacing.sm,
   },
-  controls: { alignItems: 'center', gap: theme.spacing.md },
+  controls: { alignItems: 'center', gap: theme.spacing.md, width: '100%' },
   syncHint: {
     color: theme.colors.mutedForeground,
     fontSize: theme.typography.sizes.sm,
     textAlign: 'center',
   },
   idleGroup: { alignItems: 'center', gap: theme.spacing.md },
-  recordCircle: {
-    width: 88,
-    height: 88,
-    borderRadius: theme.radius.full,
-    backgroundColor: theme.colors.recordAccent,
-    borderWidth: 4,
-    borderColor: theme.colors.primaryForeground,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  primaryRecordCircle: {
-    width: 72,
-    height: 72,
-    borderRadius: theme.radius.full,
-    backgroundColor: theme.colors.recordAccent,
-    borderWidth: 3,
-    borderColor: theme.colors.primaryForeground,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
   disabled: { opacity: 0.4 },
   recordLabel: {
     fontSize: theme.typography.sizes.md,
     color: theme.colors.foreground,
     fontWeight: theme.typography.weights.medium,
   },
-  mutedPlay: {
-    width: 48,
-    height: 48,
-    borderRadius: theme.radius.full,
-    backgroundColor: theme.colors.cardBackground,
-    alignItems: 'center',
-    justifyContent: 'center',
-    opacity: 0.6,
-  },
   captureGroup: { alignItems: 'center', gap: theme.spacing.md },
   duration: {
-    fontSize: 32,
+    fontSize: theme.typography.sizes.display,
     fontWeight: theme.typography.weights.medium,
     fontVariant: ['tabular-nums'],
     color: theme.colors.mutedForeground,
@@ -564,89 +499,35 @@ const styles = StyleSheet.create({
     gap: theme.spacing.lg,
     alignItems: 'center',
   },
-  stopCircle: {
-    width: 56,
-    height: 56,
-    borderRadius: theme.radius.full,
-    backgroundColor: theme.colors.background,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    alignItems: 'center',
-    justifyContent: 'center',
-    // Light shadow for white stop control (design)
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 4,
-    shadowOffset: { width: 0, height: 1 },
-    elevation: 2,
-  },
   hint: {
     color: theme.colors.mutedForeground,
     fontSize: theme.typography.sizes.sm,
     textAlign: 'center',
     paddingHorizontal: theme.spacing.lg,
   },
-  reviewGroup: { alignItems: 'center', gap: theme.spacing.lg },
-  playCircle: {
-    width: 72,
-    height: 72,
-    borderRadius: theme.radius.full,
-    backgroundColor: theme.colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  reviewActions: {
-    flexDirection: 'row',
-    gap: theme.spacing.md,
-  },
-  reRecordButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: theme.spacing.sm,
-    paddingHorizontal: theme.spacing.lg,
-    paddingVertical: theme.spacing.md,
-    borderRadius: theme.radius.md,
-    backgroundColor: theme.colors.cardBackground,
-  },
-  reRecordLabel: {
+  hintPaused: {
     color: theme.colors.foreground,
-    fontSize: theme.typography.sizes.md,
-    fontWeight: theme.typography.weights.medium,
+    fontWeight: theme.typography.weights.semibold,
   },
-  deleteButton: {
-    flexDirection: 'row',
+  reviewGroup: {
     alignItems: 'center',
-    gap: theme.spacing.sm,
-    paddingHorizontal: theme.spacing.lg,
-    paddingVertical: theme.spacing.md,
-    borderRadius: theme.radius.md,
-    borderWidth: 1,
-    borderColor: theme.colors.destructive,
-    backgroundColor: theme.colors.background,
+    gap: theme.spacing.lg,
+    width: '100%',
   },
-  deleteLabel: {
-    color: theme.colors.destructive,
-    fontSize: theme.typography.sizes.md,
-    fontWeight: theme.typography.weights.medium,
-  },
-  sourceLink: {
+  newTakeButton: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: theme.spacing.xs,
-    paddingVertical: theme.spacing.sm,
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.xxl,
+    paddingVertical: theme.spacing.md,
+    borderRadius: theme.radius.lg,
+    backgroundColor: theme.colors.recordAccent,
+    ...theme.shadows.elevated,
   },
-  sourceLinkLabel: {
-    fontSize: theme.typography.sizes.sm,
-    fontWeight: theme.typography.weights.medium,
-    color: theme.colors.primary,
-  },
-  sourceBody: {
-    padding: theme.spacing.md,
-  },
-  sourceText: {
+  newTakeLabel: {
+    color: theme.colors.primaryForeground,
     fontSize: theme.typography.sizes.md,
-    lineHeight: theme.typography.lineHeights.normal,
-    color: theme.colors.foreground,
+    fontWeight: theme.typography.weights.semibold,
   },
 });

--- a/src/app/tabs/RecordTab.tsx
+++ b/src/app/tabs/RecordTab.tsx
@@ -202,8 +202,7 @@ export function RecordTab({
   // error + no take → idle chrome; error after a saved take → keep review so
   // a failed play/delete doesn't look like the draft vanished.
   const showIdle =
-    verseAudio.state === 'idle' ||
-    (verseAudio.state === 'error' && !hasTake);
+    verseAudio.state === 'idle' || (verseAudio.state === 'error' && !hasTake);
   const isRecording = verseAudio.state === 'recording';
   const isPaused = verseAudio.state === 'paused';
   const showCapture = isRecording || isPaused;

--- a/src/app/tabs/ResourcesTab.tsx
+++ b/src/app/tabs/ResourcesTab.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { BookOpen } from 'lucide-react-native';
+import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
+
+/**
+ * Drafting Resources tab chrome (Lovable third tab). Download/content
+ * wiring is out of scope — placeholder keeps tab parity with the prototype.
+ */
+export function ResourcesTab() {
+  return (
+    <View style={styles.container} testID="resources-tab">
+      <BookOpen
+        size={iconSizes.phaseIconGlyph}
+        color={theme.colors.mutedForeground}
+        strokeWidth={listIconStrokeWidth}
+      />
+      <Text style={styles.title}>Resources</Text>
+      <Text style={styles.body}>
+        Translation resources for this chapter will show up here.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: theme.spacing.xxl,
+    gap: theme.spacing.md,
+    backgroundColor: theme.colors.background,
+  },
+  title: {
+    fontSize: theme.typography.sizes.lg,
+    fontWeight: theme.typography.weights.semibold,
+    color: theme.colors.foreground,
+  },
+  body: {
+    fontSize: theme.typography.sizes.sm,
+    color: theme.colors.mutedForeground,
+    textAlign: 'center',
+    lineHeight: theme.typography.lineHeights.normal,
+  },
+});

--- a/src/audio/createPlaybackEngine.test.ts
+++ b/src/audio/createPlaybackEngine.test.ts
@@ -1,48 +1,48 @@
 import { createPlaybackEngine } from './createPlaybackEngine';
 import type { EnginePlayer } from './createPlaybackEngine';
 
-function makeFakePlayer(): EnginePlayer & {
-  _uri: string | null;
-  _time: number;
-  _duration: number;
-  _playing: boolean;
+function makeFakePlayer(options?: {
+  /** Polls of `isLoaded` that return false after replace. */
+  unloadPolls?: number;
+  /** Duration in seconds once loaded. */
+  durationSec?: number;
+}): EnginePlayer & {
   calls: string[];
 } {
+  const unloadPolls = options?.unloadPolls ?? 0;
+  const durationSec = options?.durationSec ?? 2.5;
   const state = {
-    _uri: null as string | null,
-    _time: 0,
-    _duration: 0,
-    _playing: false,
+    uri: null as string | null,
+    time: 0,
+    duration: 0,
+    playing: false,
+    remainingUnloadPolls: 0,
     calls: [] as string[],
   };
 
-  return {
+  const player: EnginePlayer & { calls: string[] } = {
     get calls() {
       return state.calls;
     },
-    get _uri() {
-      return state._uri;
-    },
-    get _time() {
-      return state._time;
-    },
-    get _duration() {
-      return state._duration;
-    },
-    get _playing() {
-      return state._playing;
-    },
     get playing() {
-      return state._playing;
+      return state.playing;
     },
     get currentTime() {
-      return state._time;
+      return state.time;
     },
     get duration() {
-      return state._duration;
+      return state.duration;
     },
     get isLoaded() {
-      return Boolean(state._uri);
+      if (!state.uri) return false;
+      if (state.remainingUnloadPolls > 0) {
+        state.remainingUnloadPolls -= 1;
+        if (state.remainingUnloadPolls === 0) {
+          state.duration = durationSec;
+        }
+        return false;
+      }
+      return true;
     },
     replace(source: string | { uri: string } | null) {
       state.calls.push('replace');
@@ -52,29 +52,37 @@ function makeFakePlayer(): EnginePlayer & {
           : source && typeof source === 'object'
           ? source.uri
           : null;
-      state._uri = uri;
-      state._duration = uri ? 2.5 : 0;
-      state._time = 0;
-      state._playing = false;
+      state.uri = uri;
+      state.time = 0;
+      state.playing = false;
+      if (!uri) {
+        state.duration = 0;
+        state.remainingUnloadPolls = 0;
+        return;
+      }
+      state.remainingUnloadPolls = unloadPolls;
+      state.duration = unloadPolls === 0 ? durationSec : 0;
     },
     play() {
       state.calls.push('play');
-      state._playing = true;
+      state.playing = true;
     },
     pause() {
       state.calls.push('pause');
-      state._playing = false;
+      state.playing = false;
     },
     async seekTo(seconds: number) {
       state.calls.push(`seek:${seconds}`);
-      state._time = seconds;
+      state.time = seconds;
     },
     remove() {
       state.calls.push('remove');
-      state._uri = null;
-      state._playing = false;
+      state.uri = null;
+      state.playing = false;
     },
   };
+
+  return player;
 }
 
 describe('createPlaybackEngine', () => {
@@ -84,6 +92,7 @@ describe('createPlaybackEngine', () => {
     const engine = createPlaybackEngine({
       player,
       onStatusChange: s => statuses.push(s),
+      delayMs: async () => undefined,
     });
 
     await engine.play('file:///take.m4a');
@@ -103,12 +112,94 @@ describe('createPlaybackEngine', () => {
     expect(player.calls).toContain('play');
     expect(player.calls).toContain('pause');
     expect(player.calls.some(c => c.startsWith('seek:'))).toBe(true);
+    // stop must keep the player alive for later play()/delete→re-record cycles
+    expect(player.calls).not.toContain('remove');
+  });
+
+  it('waits for isLoaded before play and emits non-zero duration', async () => {
+    const player = makeFakePlayer({ unloadPolls: 3, durationSec: 4 });
+    const positions: Array<[number, number]> = [];
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+      onPositionChange: (pos, dur) => positions.push([pos, dur]),
+    });
+
+    await engine.play('file:///take.m4a');
+    expect(engine.getStatus()).toBe('playing');
+    expect(engine.durationMs).toBe(4000);
+    expect(player.calls.filter(c => c === 'play')).toHaveLength(1);
+    expect(positions.some(([, dur]) => dur === 4000)).toBe(true);
+  });
+
+  it('rejects when play does not start and duration stays 0', async () => {
+    const player = makeFakePlayer({ durationSec: 0 });
+    // play() is a no-op for "corrupt" — stays not playing with 0 duration.
+    player.play = () => {
+      player.calls.push('play');
+    };
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+    });
+
+    await expect(engine.play('file:///empty.m4a')).rejects.toThrow(
+      /duration 0:00/,
+    );
+    expect(engine.getStatus()).toBe('idle');
+  });
+
+  it('allows play when duration is 0 but player starts (ADTS-style)', async () => {
+    const player = makeFakePlayer({ durationSec: 0 });
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+    });
+
+    await engine.play('file:///adts.aac');
+    expect(engine.getStatus()).toBe('playing');
+    expect(player.calls).toContain('play');
+  });
+
+  it('rejects when load never completes', async () => {
+    const player = makeFakePlayer();
+    Object.defineProperty(player, 'isLoaded', {
+      get: () => false,
+      configurable: true,
+    });
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+      loadTimeoutMs: 5,
+    });
+
+    await expect(engine.play('file:///missing.m4a')).rejects.toThrow(
+      /failed to load/,
+    );
+    expect(player.calls).not.toContain('play');
+  });
+
+  it('stop then play reuses the same player', async () => {
+    const player = makeFakePlayer();
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+    });
+    await engine.play('file:///take.m4a');
+    await engine.stop();
+    await engine.play('file:///take2.m4a');
+    expect(engine.getStatus()).toBe('playing');
+    expect(player.calls.filter(c => c === 'remove')).toHaveLength(0);
   });
 
   it('calls prepareAudioMode once', async () => {
     const player = makeFakePlayer();
     const prepareAudioMode = jest.fn(async () => undefined);
-    const engine = createPlaybackEngine({ player, prepareAudioMode });
+    const engine = createPlaybackEngine({
+      player,
+      prepareAudioMode,
+      delayMs: async () => undefined,
+    });
     await engine.play('file:///a.m4a');
     await engine.pause();
     await engine.play('file:///b.m4a');

--- a/src/audio/createPlaybackEngine.ts
+++ b/src/audio/createPlaybackEngine.ts
@@ -19,18 +19,35 @@ export type PlaybackEngineDeps = {
   onPositionChange?: (positionMs: number, durationMs: number) => void;
   /** Optional audio-mode setup before first play. */
   prepareAudioMode?: () => Promise<void>;
+  /** Injectable delay for tests (load polling). */
+  delayMs?: (ms: number) => Promise<void>;
+  /** Max wait for `isLoaded` after `replace`. */
+  loadTimeoutMs?: number;
 };
 
 export type PlaybackEngine = PlayerApi & {
   getStatus(): PlayerStatus;
 };
 
+const DEFAULT_LOAD_TIMEOUT_MS = 8000;
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 /**
  * UI-agnostic playback engine around an expo-audio player instance.
  * Waveform visualization is separate (`PlaybackProgressBar`).
  */
 export function createPlaybackEngine(deps: PlaybackEngineDeps): PlaybackEngine {
-  const { player, onStatusChange, onPositionChange, prepareAudioMode } = deps;
+  const {
+    player,
+    onStatusChange,
+    onPositionChange,
+    prepareAudioMode,
+    delayMs = defaultDelay,
+    loadTimeoutMs = DEFAULT_LOAD_TIMEOUT_MS,
+  } = deps;
   let status: PlayerStatus = 'idle';
   let modeReady = false;
 
@@ -54,6 +71,23 @@ export function createPlaybackEngine(deps: PlaybackEngineDeps): PlaybackEngine {
     modeReady = true;
   }
 
+  /**
+   * `replace` prepares asynchronously on the native queue. Calling `play`
+   * before `isLoaded` leaves duration/position at 0 and looks like a stuck
+   * 0:00 take. Poll until ready (or fail visibly).
+   */
+  async function waitUntilLoaded(): Promise<void> {
+    const deadline = Date.now() + loadTimeoutMs;
+    while (!player.isLoaded) {
+      if (Date.now() >= deadline) {
+        throw new Error(
+          'Take failed to load for playback. The file may be missing or corrupt.',
+        );
+      }
+      await delayMs(50);
+    }
+  }
+
   return {
     get status() {
       return status;
@@ -69,8 +103,18 @@ export function createPlaybackEngine(deps: PlaybackEngineDeps): PlaybackEngine {
     },
     async play(uri: string) {
       await ensureMode();
+      // Leave prior status until load succeeds so UI does not show "playing" at 0:00.
       player.replace({ uri });
+      await waitUntilLoaded();
       player.play();
+      // Some containers (e.g. raw ADTS) report duration 0 until playback starts.
+      await delayMs(100);
+      const durationMs = Math.max(0, Math.round(player.duration * 1000));
+      if (!player.playing && durationMs <= 0) {
+        throw new Error(
+          'Take has no playable audio (duration 0:00). Re-record this verse.',
+        );
+      }
       setStatus('playing');
       emitPosition();
     },
@@ -88,9 +132,10 @@ export function createPlaybackEngine(deps: PlaybackEngineDeps): PlaybackEngine {
       emitPosition();
     },
     async stop() {
+      // Do not call player.remove() here — usePlaybackEngine owns a singleton
+      // player for the Record tab lifetime. remove() is only for unmount cleanup.
       player.pause();
       await player.seekTo(0);
-      player.remove?.();
       setStatus('idle');
       emitPosition();
     },

--- a/src/audio/createRecordingEngine.test.ts
+++ b/src/audio/createRecordingEngine.test.ts
@@ -102,15 +102,33 @@ describe('createRecordingEngine', () => {
     await expect(engine.stop()).rejects.toThrow(/idle/i);
   });
 
-  it('throws when stop yields no uri', async () => {
+  it('calls releaseAudioMode after stop so the session drops recording', async () => {
     const recorder = makeFakeRecorder();
+    const releaseAudioMode = jest.fn(async () => undefined);
+    const engine = createRecordingEngine({
+      recorder,
+      prepareAudioMode: async () => undefined,
+      releaseAudioMode,
+    });
+
+    await engine.start();
+    await engine.stop();
+    expect(releaseAudioMode).toHaveBeenCalledTimes(1);
+    expect(engine.getStatus()).toBe('idle');
+  });
+
+  it('still releases audio mode when stop yields no uri', async () => {
+    const recorder = makeFakeRecorder();
+    const releaseAudioMode = jest.fn(async () => undefined);
     recorder.stop = async () => {
       recorder.calls.push('stop');
       recorder._uri = null;
       recorder._time = 0;
     };
-    const engine = createRecordingEngine({ recorder });
+    const engine = createRecordingEngine({ recorder, releaseAudioMode });
     await engine.start();
     await expect(engine.stop()).rejects.toThrow(/URI/i);
+    expect(releaseAudioMode).toHaveBeenCalledTimes(1);
+    expect(engine.getStatus()).toBe('idle');
   });
 });

--- a/src/audio/createRecordingEngine.ts
+++ b/src/audio/createRecordingEngine.ts
@@ -16,6 +16,11 @@ export type RecordingEngineDeps = {
   recorder: EngineRecorder;
   /** Optional audio-mode setup before first start (injectable for tests). */
   prepareAudioMode?: () => Promise<void>;
+  /**
+   * Drop recording capability after stop/cleanup so Android / the audio
+   * session no longer treat the app as actively recording.
+   */
+  releaseAudioMode?: () => Promise<void>;
   /** Override status notifications (React setState, etc.). */
   onStatusChange?: (status: RecorderStatus) => void;
 };
@@ -31,7 +36,8 @@ export type RecordingEngine = RecorderApi & {
 export function createRecordingEngine(
   deps: RecordingEngineDeps,
 ): RecordingEngine {
-  const { recorder, prepareAudioMode, onStatusChange } = deps;
+  const { recorder, prepareAudioMode, releaseAudioMode, onStatusChange } =
+    deps;
   let status: RecorderStatus = 'idle';
   let prepared = false;
 
@@ -49,6 +55,17 @@ export function createRecordingEngine(
     }
     await recorder.prepareToRecordAsync();
     prepared = true;
+  }
+
+  async function releaseMode(): Promise<void> {
+    if (!releaseAudioMode) {
+      return;
+    }
+    try {
+      await releaseAudioMode();
+    } catch {
+      // Best-effort — never block stop/cleanup on mode reset failure.
+    }
   }
 
   return {
@@ -84,11 +101,19 @@ export function createRecordingEngine(
       if (status !== 'recording' && status !== 'paused') {
         throw new Error('Cannot stop recorder while idle');
       }
-      await recorder.stop();
-      const durationMs = Math.max(0, Math.round(recorder.currentTime * 1000));
-      const uri = recorder.uri;
-      prepared = false;
-      setStatus('idle');
+      let uri: string | null = null;
+      let durationMs = 0;
+      try {
+        await recorder.stop();
+        durationMs = Math.max(0, Math.round(recorder.currentTime * 1000));
+        uri = recorder.uri;
+      } finally {
+        // Native MediaRecorder is released inside expo-audio stop; clear our
+        // prepared flag and drop allowsRecording so the OS mic session ends.
+        prepared = false;
+        setStatus('idle');
+        await releaseMode();
+      }
       if (!uri) {
         throw new Error('Recording stopped without a file URI');
       }

--- a/src/audio/createRecordingEngine.ts
+++ b/src/audio/createRecordingEngine.ts
@@ -36,8 +36,7 @@ export type RecordingEngine = RecorderApi & {
 export function createRecordingEngine(
   deps: RecordingEngineDeps,
 ): RecordingEngine {
-  const { recorder, prepareAudioMode, releaseAudioMode, onStatusChange } =
-    deps;
+  const { recorder, prepareAudioMode, releaseAudioMode, onStatusChange } = deps;
   let status: RecorderStatus = 'idle';
   let prepared = false;
 

--- a/src/components/layout/DraftingHeader.tsx
+++ b/src/components/layout/DraftingHeader.tsx
@@ -48,7 +48,8 @@ export function DraftingHeader({
     <View style={[styles.header, headerPadding]}>
       <StatusBar
         barStyle="dark-content"
-        backgroundColor={theme.colors.cardBackground}
+        backgroundColor={theme.colors.background}
+        translucent={false}
       />
       <View style={styles.sideSlot}>
         <TouchableOpacity
@@ -57,6 +58,7 @@ export function DraftingHeader({
           style={styles.backButton}
           accessibilityRole="button"
           accessibilityLabel="Go back"
+          activeOpacity={0.7}
         >
           <ChevronLeft
             size={iconSizes.header}
@@ -74,7 +76,11 @@ export function DraftingHeader({
 
       <View style={styles.rightActions}>
         {syncStatus && onSyncPress ? (
-          <PageHeaderSyncButton syncStatus={syncStatus} onPress={onSyncPress} />
+          <PageHeaderSyncButton
+            syncStatus={syncStatus}
+            onPress={onSyncPress}
+            cloudColor={theme.colors.foreground}
+          />
         ) : null}
         {showAccountIndicator && onAccountPress ? (
           <AccountInitialsButton
@@ -97,8 +103,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: headerLayout.paddingHorizontal,
     minHeight: headerLayout.minHeight,
-    backgroundColor: theme.colors.cardBackground,
-    borderBottomWidth: 1,
+    backgroundColor: theme.colors.background,
+    borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: theme.colors.border,
   },
   sideSlot: {

--- a/src/components/layout/DraftingTabBar.test.tsx
+++ b/src/components/layout/DraftingTabBar.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react-native';
+import { theme } from '../../theme';
+import { DraftingTabBar } from './DraftingTabBar';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 16, left: 0 }),
+}));
+
+describe('DraftingTabBar', () => {
+  it('renders Bible, Resources, Record in Lovable order with active top indicator', () => {
+    const onTabChange = jest.fn();
+    render(<DraftingTabBar activeTab="record" onTabChange={onTabChange} />);
+
+    const bar = screen.getByTestId('drafting-tab-bar');
+    expect(bar).toHaveStyle({
+      backgroundColor: theme.colors.tabBarBackground,
+    });
+    const tabs = within(bar).getAllByRole('tab');
+    expect(tabs.map(t => t.props.accessibilityLabel)).toEqual([
+      'Bible',
+      'Resources',
+      'Record',
+    ]);
+    expect(tabs[2]?.props.accessibilityState?.selected).toBe(true);
+
+    fireEvent.press(screen.getByLabelText('Resources'));
+    expect(onTabChange).toHaveBeenCalledWith('resources');
+  });
+});

--- a/src/components/layout/DraftingTabBar.tsx
+++ b/src/components/layout/DraftingTabBar.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import {
+  BookOpen,
+  Headphones,
+  Mic,
+  type LucideIcon,
+} from 'lucide-react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { DraftingTab } from '../../types/drafting/types';
-import { Headphones, Mic, LucideIcon } from 'lucide-react-native';
 import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
 export type { DraftingTab };
 
@@ -11,8 +17,10 @@ interface DraftingTabBarProps {
   onTabChange: (tab: DraftingTab) => void;
 }
 
+/** Lovable drafting order: Bible → Resources → Record; active tab has top rule. */
 const TABS: { id: DraftingTab; label: string; Icon: LucideIcon }[] = [
   { id: 'bible', label: 'Bible', Icon: Headphones },
+  { id: 'resources', label: 'Resources', Icon: BookOpen },
   { id: 'record', label: 'Record', Icon: Mic },
 ];
 
@@ -20,20 +28,33 @@ export function DraftingTabBar({
   activeTab,
   onTabChange,
 }: DraftingTabBarProps) {
+  const insets = useSafeAreaInsets();
+
   return (
-    <View style={styles.container}>
+    <View
+      style={[styles.container, { paddingBottom: insets.bottom }]}
+      testID="drafting-tab-bar"
+    >
       {TABS.map(({ id, label, Icon }) => {
         const isActive = activeTab === id;
 
         return (
-          <TouchableOpacity
+          <Pressable
             key={id}
             style={styles.tab}
             onPress={() => onTabChange(id)}
             accessibilityRole="tab"
             accessibilityState={{ selected: isActive }}
             accessibilityLabel={label}
+            android_ripple={{ color: 'transparent' }}
           >
+            {/* Stable top rule — avoid borderColor swap / margin overlap flicker. */}
+            <View
+              style={[
+                styles.activeRule,
+                isActive ? styles.activeRuleOn : styles.activeRuleOff,
+              ]}
+            />
             <Icon
               size={iconSizes.headerTab}
               color={
@@ -49,7 +70,7 @@ export function DraftingTabBar({
             >
               {label}
             </Text>
-          </TouchableOpacity>
+          </Pressable>
         );
       })}
     </View>
@@ -59,8 +80,9 @@ export function DraftingTabBar({
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
+    // Lovable drafting tabs: `border-t border-border bg-card` (not pure white).
     backgroundColor: theme.colors.tabBarBackground,
-    borderTopWidth: 1,
+    borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: theme.colors.border,
   },
   tab: {
@@ -68,10 +90,26 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: theme.spacing.xs,
-    paddingVertical: theme.spacing.sm,
+    paddingTop: theme.spacing.md + 2,
+    paddingBottom: theme.spacing.md,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  activeRule: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 2,
+  },
+  activeRuleOn: {
+    backgroundColor: theme.colors.primary,
+  },
+  activeRuleOff: {
+    backgroundColor: 'transparent',
   },
   label: {
-    fontSize: theme.typography.sizes.xs,
+    fontSize: theme.typography.sizes.sm,
     fontWeight: theme.typography.weights.medium,
   },
   labelActive: {

--- a/src/components/layout/SourceAudioPlayerBar.tsx
+++ b/src/components/layout/SourceAudioPlayerBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pause, Play, RotateCw } from 'lucide-react-native';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import {
@@ -8,36 +8,55 @@ import {
   touchHitSlop,
 } from '../../theme';
 import { VerseData } from '../../types/db/types';
+import { PlaybackProgressBar } from '../ui/PlaybackProgressBar';
 
-type LoadState = 'loading' | 'ready' | 'error';
+export type SourceAudioLoadState = 'loading' | 'ready' | 'empty' | 'error';
 
 interface SourceAudioPlayerBarProps {
   verses: VerseData[];
   selectedVerse: number;
   /** Bible / source name shown in the footer label (e.g. BSB). */
   sourceLabel?: string;
+  /**
+   * Source-audio availability. Playback is still a **stub** — chrome matches
+   * Lovable; times and the play toggle are decorative until source audio is
+   * wired to a real player.
+   */
+  loadState?: SourceAudioLoadState;
 }
 
 /**
  * Bottom source-audio strip for Record tab idle/review (design 01 / 04).
- * Playback wiring is still a stub — UI matches the design panel chrome.
+ *
+ * STUB: play control, waveform progress, and `0:00` / `--:--` are decorative.
+ * They do **not** reflect real source-audio duration or position. Draft take
+ * review time lives on `DraftTakeRow` (engine-backed).
  */
 export function SourceAudioPlayerBar({
   verses,
   selectedVerse,
   sourceLabel = 'Source',
+  // Default empty until #235 wires real source audio (avoid fake "ready" chrome).
+  loadState: loadStateProp = 'empty',
 }: SourceAudioPlayerBarProps) {
-  // Decorative ready state until real source-audio playback lands.
-  const [loadState, setLoadState] = useState<LoadState>('ready');
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [loadState, setLoadState] =
+    useState<SourceAudioLoadState>(loadStateProp);
+  /** Decorative only — does not drive audio. */
+  const [isPlayingVisual, setIsPlayingVisual] = useState(false);
+
+  useEffect(() => {
+    setLoadState(loadStateProp);
+    setIsPlayingVisual(false);
+  }, [loadStateProp, selectedVerse]);
 
   const handleRetry = () => {
-    setLoadState('ready');
+    setLoadState(loadStateProp === 'empty' ? 'empty' : 'ready');
   };
 
   const handleTogglePlay = () => {
     if (loadState !== 'ready') return;
-    setIsPlaying(prev => !prev);
+    // Stub: toggle chrome only. No player / no advancing timer.
+    setIsPlayingVisual(prev => !prev);
   };
 
   if (loadState === 'error') {
@@ -63,23 +82,40 @@ export function SourceAudioPlayerBar({
   }
 
   const isLoading = loadState === 'loading';
-  const barCount = 40;
+  const isEmpty = loadState === 'empty';
+  const playDisabled = isLoading || isEmpty;
   const step = Math.max(1, Math.floor(verses.length / 6) || 1);
   const markers = verses.filter((_, i) => i % step === 0).slice(0, 8);
+  // Decorative progress keyed to selected verse index — not clock time.
   const selectedIndex = verses.findIndex(v => v.verseNumber === selectedVerse);
+  const stubProgressMs =
+    verses.length > 0 && selectedIndex >= 0
+      ? ((selectedIndex + 1) / verses.length) * 1000
+      : 0;
+
+  const footerLabel = isLoading
+    ? 'Loading source audio…'
+    : isEmpty
+    ? 'No source audio'
+    : `${sourceLabel} Source Audio · Verse ${selectedVerse}`;
 
   return (
     <View style={styles.bar} testID="source-audio-bar">
       <Pressable
         onPress={handleTogglePlay}
-        disabled={isLoading}
-        style={[styles.playButton, isLoading && styles.playButtonDisabled]}
+        disabled={playDisabled}
+        style={[styles.playButton, playDisabled && styles.playButtonDisabled]}
         accessibilityRole="button"
         accessibilityLabel={
-          isPlaying ? 'Pause source audio' : 'Play source audio'
+          isPlayingVisual
+            ? 'Pause source audio (not wired yet)'
+            : 'Play source audio (not wired yet)'
         }
+        accessibilityState={{ disabled: playDisabled }}
+        android_ripple={{ color: 'transparent' }}
+        testID="source-audio-play-stub"
       >
-        {isPlaying ? (
+        {isPlayingVisual ? (
           <Pause
             size={iconSizes.headerTab}
             color={theme.colors.primaryForeground}
@@ -95,7 +131,7 @@ export function SourceAudioPlayerBar({
       </Pressable>
 
       <View style={styles.waveformArea}>
-        {isLoading ? (
+        {isLoading || isEmpty ? (
           <View style={styles.waveformPlaceholder} />
         ) : (
           <>
@@ -106,41 +142,32 @@ export function SourceAudioPlayerBar({
                 </Text>
               ))}
             </View>
-            <View style={styles.waveformRow}>
-              {Array.from({ length: barCount }, (_, i) => {
-                const height = 8 + ((i * 11) % 20);
-                const active =
-                  verses.length === 0
-                    ? false
-                    : Math.floor((i / barCount) * verses.length) <=
-                      Math.max(0, selectedIndex);
-                return (
-                  <View
-                    key={i}
-                    style={[
-                      styles.waveBar,
-                      { height },
-                      active ? styles.waveBarActive : styles.waveBarIdle,
-                    ]}
-                  />
-                );
-              })}
+            <View style={styles.waveformRow} testID="source-audio-waveform">
+              <PlaybackProgressBar
+                positionMs={stubProgressMs}
+                durationMs={1000}
+                barCount={56}
+                accentColor={theme.colors.waveformActive}
+              />
             </View>
             <View style={styles.timeRow}>
-              <Text style={styles.timeText}>0:00</Text>
-              <Text style={styles.timeText}>—</Text>
+              {/* Hardcoded stub times — not engine position/duration. */}
+              <Text style={styles.timeText} testID="source-audio-time-stub">
+                0:00
+              </Text>
+              <Text style={styles.timeText}>--:--</Text>
             </View>
           </>
         )}
         <Text style={styles.footerLabel} testID="source-audio-label">
-          {sourceLabel} Source Audio · Verse {selectedVerse}
+          {footerLabel}
         </Text>
       </View>
     </View>
   );
 }
 
-const TOUCH_TARGET = 48;
+const TOUCH_TARGET = theme.recordControlSizes.secondary;
 
 const styles = StyleSheet.create({
   bar: {
@@ -150,8 +177,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: theme.spacing.md,
     paddingVertical: theme.spacing.sm,
     backgroundColor: theme.colors.cardBackground,
-    borderTopWidth: 1,
+    borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: theme.colors.border,
+    width: '100%',
   },
   playButton: {
     width: TOUCH_TARGET,
@@ -160,49 +188,40 @@ const styles = StyleSheet.create({
     backgroundColor: theme.colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
+    flexShrink: 0,
   },
   playButtonDisabled: {
     backgroundColor: theme.colors.mutedForeground,
   },
   waveformArea: {
     flex: 1,
+    minWidth: 0,
     justifyContent: 'center',
     gap: 2,
   },
   waveformPlaceholder: {
     height: 4,
+    width: '100%',
     borderRadius: theme.radius.full,
     backgroundColor: theme.colors.border,
   },
   markerRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    width: '100%',
   },
   marker: {
-    fontSize: 10,
+    fontSize: theme.typography.sizes.xs,
     color: theme.colors.mutedForeground,
   },
   waveformRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    width: '100%',
     height: 28,
-    gap: 1,
-  },
-  waveBar: {
-    flex: 1,
-    maxWidth: 3,
-    borderRadius: 1,
-    backgroundColor: theme.colors.primary,
-  },
-  waveBarActive: {
-    opacity: 1,
-  },
-  waveBarIdle: {
-    opacity: 0.45,
   },
   timeRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    width: '100%',
   },
   timeText: {
     fontSize: theme.typography.sizes.xs,

--- a/src/components/ui/DraftTakeRow.tsx
+++ b/src/components/ui/DraftTakeRow.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Pause, Play, Trash2 } from 'lucide-react-native';
+import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
+import { PlaybackProgressBar } from './PlaybackProgressBar';
+import { RecordCircleButton } from './RecordCircleButton';
+
+type DraftTakeRowProps = {
+  takeNumber: number;
+  /** Live engine position (ms). */
+  positionMs: number;
+  /** Engine duration, or DB fallback from capture (ms). */
+  durationMs: number;
+  isPlaying: boolean;
+  onPlayPause: () => void;
+  onDelete: () => void;
+};
+
+/** Design timer: `0:13` (no leading zero on minutes). */
+function formatDuration(ms: number): string {
+  const totalSec = Math.floor(Math.max(0, ms) / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * Latest-take row for Record has-draft (Lovable: select / play / waveform / delete).
+ * Time + progress are wired to real take playback (`useVerseAudio` → engine).
+ * Multi-take list selection stays deferred until more than one take is shown.
+ */
+export function DraftTakeRow({
+  takeNumber,
+  positionMs,
+  durationMs,
+  isPlaying,
+  onPlayPause,
+  onDelete,
+}: DraftTakeRowProps) {
+  const timeLabel =
+    durationMs > 0
+      ? `${formatDuration(positionMs)} / ${formatDuration(durationMs)}`
+      : formatDuration(positionMs);
+
+  return (
+    <View style={styles.row} testID="record-take-row">
+      <View style={styles.selectedDot} accessibilityLabel="Selected take" />
+      <Text style={styles.takeLabel} testID="record-take-badge">
+        Take {takeNumber}
+      </Text>
+      <RecordCircleButton
+        variant="play"
+        size={theme.recordControlSizes.secondary}
+        onPress={onPlayPause}
+        accessibilityLabel={isPlaying ? 'Pause draft' : 'Play draft'}
+        testID="record-play-button"
+      >
+        {isPlaying ? (
+          <Pause
+            size={iconSizes.headerTab}
+            color={theme.colors.primaryForeground}
+            strokeWidth={listIconStrokeWidth}
+          />
+        ) : (
+          <Play
+            size={iconSizes.headerTab}
+            color={theme.colors.primaryForeground}
+            strokeWidth={listIconStrokeWidth}
+          />
+        )}
+      </RecordCircleButton>
+      <View style={styles.waveform}>
+        <PlaybackProgressBar
+          positionMs={positionMs}
+          durationMs={durationMs}
+          barCount={24}
+          accentColor={theme.colors.waveformActive}
+        />
+      </View>
+      <Text
+        style={styles.time}
+        testID="record-take-time"
+        accessibilityLabel={`Take time ${timeLabel}`}
+      >
+        {timeLabel}
+      </Text>
+      <TouchableOpacity
+        onPress={onDelete}
+        accessibilityRole="button"
+        accessibilityLabel="Delete take"
+        testID="record-delete-button"
+        hitSlop={8}
+        style={styles.deleteHit}
+      >
+        <Trash2
+          size={iconSizes.chevron}
+          color={theme.colors.destructive}
+          strokeWidth={listIconStrokeWidth}
+        />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    width: '100%',
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radius.md,
+    backgroundColor: theme.colors.cardBackground,
+  },
+  selectedDot: {
+    width: 8,
+    height: 8,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.primary,
+  },
+  takeLabel: {
+    fontSize: theme.typography.sizes.sm,
+    fontWeight: theme.typography.weights.medium,
+    color: theme.colors.foreground,
+    minWidth: 52,
+  },
+  waveform: {
+    flex: 1,
+    minHeight: 28,
+  },
+  time: {
+    fontSize: theme.typography.sizes.xs,
+    fontVariant: ['tabular-nums'],
+    color: theme.colors.mutedForeground,
+    minWidth: 64,
+    textAlign: 'right',
+  },
+  deleteHit: {
+    padding: theme.spacing.xs,
+  },
+});

--- a/src/components/ui/PageHeaderSyncButton.tsx
+++ b/src/components/ui/PageHeaderSyncButton.tsx
@@ -7,11 +7,14 @@ import { SyncStatus, SYNC_STATUS_LABELS } from '../../utils/syncStatusState';
 interface PageHeaderSyncButtonProps {
   syncStatus: SyncStatus;
   onPress: () => void;
+  /** Cloud outline color — use foreground on white headers. */
+  cloudColor?: string;
 }
 
 export function PageHeaderSyncButton({
   syncStatus,
   onPress,
+  cloudColor,
 }: PageHeaderSyncButtonProps) {
   return (
     <TouchableOpacity
@@ -20,8 +23,13 @@ export function PageHeaderSyncButton({
       accessibilityLabel={SYNC_STATUS_LABELS[syncStatus]}
       accessibilityRole="button"
       hitSlop={touchHitSlop}
+      activeOpacity={0.7}
     >
-      <CloudSyncStatusIcon status={syncStatus} decorative />
+      <CloudSyncStatusIcon
+        status={syncStatus}
+        decorative
+        cloudColor={cloudColor}
+      />
     </TouchableOpacity>
   );
 }

--- a/src/components/ui/PlaybackProgressBar.test.tsx
+++ b/src/components/ui/PlaybackProgressBar.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { PlaybackProgressBar } from './PlaybackProgressBar';
+import { theme } from '../../theme';
+
+describe('PlaybackProgressBar', () => {
+  it('renders static progress bars by default', () => {
+    render(
+      <PlaybackProgressBar positionMs={500} durationMs={1000} barCount={8} />,
+    );
+    expect(screen.getByTestId('playback-progress')).toBeTruthy();
+  });
+
+  it('uses animated capture testID when animate+tall (live recording pulse)', () => {
+    render(
+      <PlaybackProgressBar
+        positionMs={1200}
+        durationMs={1200}
+        barCount={12}
+        tall
+        animate
+        accentColor={theme.colors.recordAccent}
+      />,
+    );
+    expect(screen.getByTestId('playback-progress-animated')).toBeTruthy();
+  });
+});

--- a/src/components/ui/PlaybackProgressBar.tsx
+++ b/src/components/ui/PlaybackProgressBar.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { Animated, Easing, StyleSheet, View } from 'react-native';
 import { theme } from '../../theme';
 
 type Props = {
@@ -11,12 +11,28 @@ type Props = {
   accentColor?: string;
   /** Taller bars for Record-tab capture/review waveforms. */
   tall?: boolean;
+  /**
+   * Live capture pulse (Lovable `animate-waveform` / `scaleY`). Uses the native
+   * driver so motion stays smooth; heights are decorative, not mic metering.
+   */
+  animate?: boolean;
 };
+
+/** Lovable-style decorative height: sine envelope + light phase noise (0–1). */
+function barAmplitude(index: number, seedMs: number, tall: boolean): number {
+  const t = index * 0.8 + seedMs / 900;
+  const wave = 0.42 + Math.sin(t) * 0.28 + Math.sin(t * 1.7 + index) * 0.18;
+  const floor = tall ? 0.22 : 0.28;
+  return Math.min(1, Math.max(floor, wave));
+}
 
 /**
  * Waveform decision (#96): **static placeholder bars** keyed to playback
- * position — no Simform, no extra native deps. Live metering can replace
- * the decorative heights later without changing the player engine.
+ * position — decorative amplitudes (not mic metering). Optional `animate`
+ * mode for capture-state pulse (Lovable scaleY loop). Live metering can
+ * replace decorative heights later. Progress fill is real when `durationMs` /
+ * `positionMs` come from the playback engine; source-audio dock passes stub
+ * values on purpose.
  */
 export function PlaybackProgressBar({
   positionMs,
@@ -24,33 +40,129 @@ export function PlaybackProgressBar({
   barCount = 24,
   accentColor = theme.colors.primary,
   tall = false,
+  animate = false,
 }: Props) {
   const progress =
     durationMs > 0 ? Math.min(1, Math.max(0, positionMs / durationMs)) : 0;
   const activeBars = Math.round(progress * barCount);
-  const rowHeight = tall ? 72 : 28;
+  const rowHeight = tall
+    ? theme.waveform.tallHeight
+    : theme.waveform.dockHeight;
+
+  // One Animated.Value per bar — kept across elapsedMs re-renders so the
+  // capture loop is not restarted by the duration timer.
+  const scalesRef = useRef<Animated.Value[]>([]);
+  if (scalesRef.current.length !== barCount) {
+    scalesRef.current = Array.from(
+      { length: barCount },
+      () => new Animated.Value(0.3),
+    );
+  }
+
+  useEffect(() => {
+    const scales = scalesRef.current;
+    if (!animate) {
+      scales.forEach(scale => {
+        scale.stopAnimation();
+        scale.setValue(1);
+      });
+      return;
+    }
+
+    // Lovable: @keyframes waveform-animate { 0.3 → 1 → 0.6 → 0.9 → 0.3 }
+    // over 0.8s ease-in-out, infinite, with per-bar stagger.
+    const loops = scales.map((scale, i) => {
+      scale.setValue(0.3);
+      const step = 200;
+      const anim = Animated.loop(
+        Animated.sequence([
+          Animated.timing(scale, {
+            toValue: 1,
+            duration: step,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(scale, {
+            toValue: 0.6,
+            duration: step,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(scale, {
+            toValue: 0.9,
+            duration: step,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(scale, {
+            toValue: 0.3,
+            duration: step,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+        ]),
+      );
+      const starter = Animated.sequence([
+        Animated.delay((i % 8) * 55),
+        anim,
+      ]);
+      starter.start();
+      return { starter, anim };
+    });
+
+    return () => {
+      loops.forEach(({ starter, anim }) => {
+        starter.stop();
+        anim.stop();
+      });
+    };
+  }, [animate, barCount]);
 
   return (
     <View
-      style={[styles.row, { height: rowHeight }]}
+      style={[styles.row, { height: rowHeight, gap: theme.waveform.barGap }]}
       accessibilityRole="progressbar"
       accessibilityValue={{
         min: 0,
         max: durationMs,
         now: positionMs,
       }}
+      testID={animate ? 'playback-progress-animated' : 'playback-progress'}
     >
       {Array.from({ length: barCount }, (_, i) => {
-        const height = tall
-          ? 14 + ((Math.abs(Math.sin((positionMs + i * 40) / 90)) * 48) | 0)
-          : 6 + ((i * 7) % 14);
+        // Capture pulse uses a stable seed so timer ticks don't jump heights.
+        const amplitude = barAmplitude(i, animate ? i * 120 : positionMs, tall);
+        const baseHeight = Math.round(
+          Math.max(
+            theme.waveform.barMinHeight,
+            amplitude * (rowHeight - theme.spacing.xs),
+          ),
+        );
         const active = tall || i < activeBars;
+
+        if (animate && tall) {
+          return (
+            <Animated.View
+              key={i}
+              style={[
+                styles.bar,
+                {
+                  height: baseHeight,
+                  backgroundColor: accentColor,
+                  opacity: 1,
+                  transform: [{ scaleY: scalesRef.current[i]! }],
+                },
+              ]}
+            />
+          );
+        }
+
         return (
           <View
             key={i}
             style={[
-              tall ? styles.barTall : styles.bar,
-              { height, backgroundColor: accentColor },
+              styles.bar,
+              { height: baseHeight, backgroundColor: accentColor },
               active ? styles.barActive : styles.barIdle,
             ]}
           />
@@ -63,20 +175,16 @@ export function PlaybackProgressBar({
 const styles = StyleSheet.create({
   row: {
     flex: 1,
+    width: '100%',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    gap: 2,
   },
+  /** Lovable: `flex-1 rounded-full` capsule bars. */
   bar: {
     flex: 1,
-    borderRadius: 1,
-    maxWidth: 4,
-  },
-  barTall: {
-    width: 5,
-    borderRadius: 2.5,
-    maxWidth: 5,
+    minWidth: theme.waveform.barMinWidth,
+    borderRadius: theme.radius.full,
   },
   barActive: {
     opacity: 1,

--- a/src/components/ui/PlaybackProgressBar.tsx
+++ b/src/components/ui/PlaybackProgressBar.tsx
@@ -102,10 +102,7 @@ export function PlaybackProgressBar({
           }),
         ]),
       );
-      const starter = Animated.sequence([
-        Animated.delay((i % 8) * 55),
-        anim,
-      ]);
+      const starter = Animated.sequence([Animated.delay((i % 8) * 55), anim]);
       starter.start();
       return { starter, anim };
     });

--- a/src/components/ui/RecordCircleButton.tsx
+++ b/src/components/ui/RecordCircleButton.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import {
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { theme } from '../../theme';
+
+type RecordCircleVariant = 'record' | 'primary' | 'play' | 'stop' | 'muted';
+
+type Props = {
+  variant: RecordCircleVariant;
+  onPress?: () => void;
+  disabled?: boolean;
+  accessibilityLabel: string;
+  testID?: string;
+  children: React.ReactNode;
+  /** Override diameter; defaults follow Lovable h-24 / h-20 / h-14. */
+  size?: number;
+};
+
+const VARIANT_SIZE: Record<RecordCircleVariant, number> = {
+  record: theme.recordControlSizes.idle,
+  primary: theme.recordControlSizes.primary,
+  play: theme.recordControlSizes.primary,
+  stop: theme.recordControlSizes.stop,
+  muted: theme.recordControlSizes.secondary,
+};
+
+/**
+ * Shared circular control for Record-tab idle / capture / review.
+ * Matches Lovable + docs/design/record-tab button chrome.
+ */
+export function RecordCircleButton({
+  variant,
+  onPress,
+  disabled = false,
+  accessibilityLabel,
+  testID,
+  children,
+  size,
+}: Props) {
+  const diameter = size ?? VARIANT_SIZE[variant];
+  const style: StyleProp<ViewStyle> = [
+    styles.base,
+    { width: diameter, height: diameter, borderRadius: diameter / 2 },
+    variantStyles[variant],
+    disabled && styles.disabled,
+  ];
+
+  if (!onPress) {
+    return (
+      <View
+        style={style}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={{ disabled: true }}
+        testID={testID}
+      >
+        {children}
+      </View>
+    );
+  }
+
+  return (
+    <TouchableOpacity
+      style={style}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled }}
+      testID={testID}
+      activeOpacity={0.85}
+    >
+      {children}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  disabled: { opacity: 0.4 },
+});
+
+const variantStyles = StyleSheet.create({
+  record: {
+    backgroundColor: theme.colors.recordAccent,
+    borderWidth: 4,
+    borderColor: theme.colors.primaryForeground,
+    ...theme.shadows.elevated,
+  },
+  primary: {
+    backgroundColor: theme.colors.recordAccent,
+    borderWidth: 3,
+    borderColor: theme.colors.primaryForeground,
+    ...theme.shadows.elevated,
+  },
+  play: {
+    backgroundColor: theme.colors.primary,
+    ...theme.shadows.elevated,
+  },
+  stop: {
+    backgroundColor: theme.colors.background,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    ...theme.shadows.soft,
+  },
+  muted: {
+    backgroundColor: theme.colors.cardBackground,
+    opacity: 0.6,
+  },
+});

--- a/src/components/ui/SourceTextAccordion.tsx
+++ b/src/components/ui/SourceTextAccordion.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  LayoutAnimation,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  UIManager,
+  View,
+} from 'react-native';
+import { ChevronDown, ChevronUp } from 'lucide-react-native';
+import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
+
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental?.(true);
+}
+
+type SourceTextAccordionProps = {
+  expanded: boolean;
+  onToggle: () => void;
+  text?: string | null;
+  /** Empty-copy when expanded with no verse text. */
+  emptyMessage?: string;
+  testID?: string;
+};
+
+/**
+ * Collapsible source text for Record (Lovable View/Hide source text).
+ */
+export function SourceTextAccordion({
+  expanded,
+  onToggle,
+  text,
+  emptyMessage = 'No source text for this verse yet.',
+  testID = 'record-source-toggle',
+}: SourceTextAccordionProps) {
+  const body = text?.trim() ? text : emptyMessage;
+
+  return (
+    <View>
+      <TouchableOpacity
+        onPress={() => {
+          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+          onToggle();
+        }}
+        style={styles.link}
+        accessibilityRole="button"
+        accessibilityLabel={expanded ? 'Hide source text' : 'View source text'}
+        testID={testID}
+      >
+        {expanded ? (
+          <ChevronUp
+            size={iconSizes.chevron}
+            color={theme.colors.primary}
+            strokeWidth={listIconStrokeWidth}
+          />
+        ) : (
+          <ChevronDown
+            size={iconSizes.chevron}
+            color={theme.colors.primary}
+            strokeWidth={listIconStrokeWidth}
+          />
+        )}
+        <Text style={styles.linkLabel}>
+          {expanded ? 'Hide source text' : 'View source text'}
+        </Text>
+      </TouchableOpacity>
+      {expanded ? (
+        <View style={styles.body} testID="record-source-body">
+          <ScrollView
+            style={styles.scroll}
+            nestedScrollEnabled
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={styles.bodyText}>{body}</Text>
+          </ScrollView>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  link: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing.xs,
+    paddingVertical: theme.spacing.sm,
+  },
+  linkLabel: {
+    fontSize: theme.typography.sizes.sm,
+    fontWeight: theme.typography.weights.medium,
+    color: theme.colors.primary,
+  },
+  body: {
+    maxHeight: 160,
+    borderRadius: theme.radius.lg,
+    backgroundColor: theme.colors.cardBackground,
+    padding: theme.spacing.md,
+  },
+  scroll: {
+    maxHeight: 128,
+  },
+  bodyText: {
+    fontSize: theme.typography.sizes.md,
+    lineHeight: theme.typography.lineHeights.normal,
+    color: theme.colors.foreground,
+  },
+});

--- a/src/hooks/usePlaybackEngine.ts
+++ b/src/hooks/usePlaybackEngine.ts
@@ -11,10 +11,14 @@ export type UsePlaybackEngineApi = PlayerApi;
 
 /**
  * React wrapper around the #96 playback engine.
- * Position/duration refresh from expo-audio status polling.
+ * Position/duration refresh from expo-audio status updates (updateInterval).
  */
 export function usePlaybackEngine(): UsePlaybackEngineApi {
-  const player = useMemo(() => createAudioPlayer(null), []);
+  // 100ms keeps take-row progress / time labels moving during review play.
+  const player = useMemo(
+    () => createAudioPlayer(null, { updateInterval: 100 }),
+    [],
+  );
   const nativeStatus = useAudioPlayerStatus(player);
   const [status, setStatus] = useState<PlayerStatus>('idle');
   const [positionMs, setPositionMs] = useState(0);
@@ -39,18 +43,26 @@ export function usePlaybackEngine(): UsePlaybackEngineApi {
 
   useEffect(() => {
     setPositionMs(Math.max(0, Math.round(nativeStatus.currentTime * 1000)));
-    setDurationMs(Math.max(0, Math.round(nativeStatus.duration * 1000)));
+    const nextDuration = Math.max(0, Math.round(nativeStatus.duration * 1000));
+    if (nextDuration > 0) {
+      setDurationMs(nextDuration);
+    }
+
+    if (nativeStatus.didJustFinish) {
+      setStatus('idle');
+      return;
+    }
     if (nativeStatus.playing) {
       setStatus('playing');
-    } else if (status === 'playing' && nativeStatus.isLoaded) {
-      setStatus('paused');
     }
+    // Do not map !playing → paused here. After `replace`, the player is briefly
+    // unloaded/not playing; flipping to paused races PLAYBACK_END and freezes
+    // the take UI at 0:00. Explicit pause/stop go through the engine.
   }, [
     nativeStatus.currentTime,
     nativeStatus.duration,
     nativeStatus.playing,
-    nativeStatus.isLoaded,
-    status,
+    nativeStatus.didJustFinish,
   ]);
 
   useEffect(() => {

--- a/src/hooks/useRecordingEngine.ts
+++ b/src/hooks/useRecordingEngine.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   RecordingPresets,
   setAudioModeAsync,
@@ -12,6 +12,20 @@ export type UseRecordingEngineApi = RecorderApi & {
   requestMicPermission: typeof requestMicPermission;
 };
 
+async function prepareRecordingAudioMode(): Promise<void> {
+  await setAudioModeAsync({
+    playsInSilentMode: true,
+    allowsRecording: true,
+  });
+}
+
+async function releaseRecordingAudioMode(): Promise<void> {
+  await setAudioModeAsync({
+    playsInSilentMode: true,
+    allowsRecording: false,
+  });
+}
+
 /**
  * React wrapper around the #95 recording engine.
  * Mic denial is returned from `requestMicPermission` — screens own UX.
@@ -24,15 +38,28 @@ export function useRecordingEngine(): UseRecordingEngineApi {
     () =>
       createRecordingEngine({
         recorder,
-        prepareAudioMode: () =>
-          setAudioModeAsync({
-            playsInSilentMode: true,
-            allowsRecording: true,
-          }),
+        prepareAudioMode: prepareRecordingAudioMode,
+        releaseAudioMode: releaseRecordingAudioMode,
         onStatusChange: setStatus,
       }),
     [recorder],
   );
+
+  // Dual-mount Record tab keeps this hook alive across Bible/Resources. On
+  // true unmount (leave drafting), force-stop so the SharedObject release
+  // isn't the only path that drops the mic.
+  useEffect(() => {
+    return () => {
+      const current = engine.getStatus();
+      if (current === 'recording' || current === 'paused') {
+        void engine.stop().catch(() => {
+          void releaseRecordingAudioMode();
+        });
+      } else {
+        void releaseRecordingAudioMode();
+      }
+    };
+  }, [engine]);
 
   return {
     status,

--- a/src/hooks/useVerseAudio.ts
+++ b/src/hooks/useVerseAudio.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import * as FileSystem from 'expo-file-system/legacy';
 import {
   addRecordingTake,
@@ -6,7 +6,12 @@ import {
   getLatestRecordingForVerse,
 } from '../db/repository';
 import type { Recording } from '../types/db/types';
-import { ensureRecordingsDir, recordingPath } from '../utils/audioStorage';
+import {
+  ensureRecordingsDir,
+  fileExists,
+  fileSize,
+  recordingPath,
+} from '../utils/audioStorage';
 import { ensureSeekableTakeUri } from '../audio/ensureSeekableTakeUri';
 import { logger } from '../utils/logger';
 import { usePlaybackEngine } from './usePlaybackEngine';
@@ -68,6 +73,8 @@ export function useVerseAudio({
   );
   const [latest, setLatest] = useState<Recording | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  /** Stable verse id for the in-flight take — stop must not no-op if lookup clears. */
+  const captureBibleTextIdRef = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -100,15 +107,24 @@ export function useVerseAudio({
   const start = useCallback(async () => {
     if (bibleTextId === null) return;
     try {
+      // Stop review playback first so re-record from `playing` can transition
+      // and so audio mode is free for the mic (see createRecordingEngine).
+      try {
+        await playback.stop();
+      } catch {
+        // Ignore — recorder start below is what matters.
+      }
+      captureBibleTextIdRef.current = bibleTextId;
       await recording.start();
       dispatch({ type: 'START' });
       setErrorMessage(null);
     } catch (error) {
+      captureBibleTextIdRef.current = null;
       const message = error instanceof Error ? error.message : 'start failed';
       setErrorMessage(message);
       dispatch({ type: 'ERROR', message });
     }
-  }, [bibleTextId, recording]);
+  }, [bibleTextId, playback, recording]);
 
   const pause = useCallback(async () => {
     try {
@@ -133,20 +149,23 @@ export function useVerseAudio({
   }, [recording]);
 
   const stop = useCallback(async () => {
-    if (bibleTextId === null) return;
+    const id = captureBibleTextIdRef.current ?? bibleTextId;
+    if (id === null) return;
     try {
-      dispatch({ type: 'STOP' });
+      // Release the native mic first so captureActive / navigation guards only
+      // clear after Android no longer considers us recording.
       const { uri, durationMs } = await recording.stop();
+      dispatch({ type: 'STOP' });
       const saved = await persistTake({
-        bibleTextId,
+        bibleTextId: id,
         tempUri: uri,
         durationMs,
       });
       const row =
-        (await loadLatest(bibleTextId)) ??
+        (await loadLatest(id)) ??
         ({
           id: saved.id,
-          bibleTextId,
+          bibleTextId: id,
           localFilePath: saved.localFilePath,
           takeNumber: 1,
           isLatest: true,
@@ -156,8 +175,10 @@ export function useVerseAudio({
           updatedAt: new Date().toISOString(),
         } satisfies Recording);
       setLatest(row);
+      captureBibleTextIdRef.current = null;
       dispatch({ type: 'SAVED' });
     } catch (error) {
+      captureBibleTextIdRef.current = null;
       const message = error instanceof Error ? error.message : 'stop failed';
       setErrorMessage(message);
       dispatch({ type: 'ERROR', message });
@@ -167,7 +188,21 @@ export function useVerseAudio({
   const play = useCallback(async () => {
     if (!latest?.localFilePath) return;
     try {
-      await playback.play(latest.localFilePath);
+      const path = latest.localFilePath;
+      const exists = await fileExists(path);
+      if (!exists) {
+        throw new Error('Take file is missing on disk. Re-record this verse.');
+      }
+      const size = await fileSize(path);
+      if (size === undefined || size <= 0) {
+        throw new Error(
+          'Take file is empty (0 bytes). Re-record this verse.',
+        );
+      }
+      setErrorMessage(null);
+      // Dispatch PLAY only after the engine confirms load + non-zero duration
+      // so the take row never shows "playing" stuck at 0:00.
+      await playback.play(path);
       dispatch({ type: 'PLAY' });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'play failed';
@@ -175,6 +210,28 @@ export function useVerseAudio({
       dispatch({ type: 'ERROR', message });
     }
   }, [latest, playback]);
+
+  /** Pause draft review playback (design review control shows Pause while playing). */
+  const pausePlayback = useCallback(async () => {
+    try {
+      await playback.pause();
+      dispatch({ type: 'PLAYBACK_END' });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'pause playback failed';
+      setErrorMessage(message);
+      dispatch({ type: 'ERROR', message });
+    }
+  }, [playback]);
+
+  // Natural end (`didJustFinish` → idle). Explicit pause already dispatches
+  // PLAYBACK_END. Do not treat brief !playing during load as end — that raced
+  // the take UI back to recorded with duration stuck at 0:00.
+  useEffect(() => {
+    if (state === 'playing' && playback.status === 'idle') {
+      dispatch({ type: 'PLAYBACK_END' });
+    }
+  }, [state, playback.status]);
 
   const deleteCurrent = useCallback(async () => {
     try {
@@ -191,17 +248,27 @@ export function useVerseAudio({
     }
   }, [deleteTake, latest, playback]);
 
+  // Prefer live player duration; fall back to DB duration from capture so the
+  // take row can show a real length before/without a successful play().
+  const storedDurationMs =
+    typeof latest?.durationMs === 'number' && latest.durationMs > 0
+      ? latest.durationMs
+      : 0;
+  const durationMs =
+    playback.durationMs > 0 ? playback.durationMs : storedDurationMs;
+
   return {
     state,
     latest,
     errorMessage,
     positionMs: playback.positionMs,
-    durationMs: playback.durationMs,
+    durationMs,
     start,
     pause,
     resume,
     stop,
     play,
+    pausePlayback,
     deleteCurrent,
   };
 }

--- a/src/hooks/useVerseAudio.ts
+++ b/src/hooks/useVerseAudio.ts
@@ -195,9 +195,7 @@ export function useVerseAudio({
       }
       const size = await fileSize(path);
       if (size === undefined || size <= 0) {
-        throw new Error(
-          'Take file is empty (0 bytes). Re-record this verse.',
-        );
+        throw new Error('Take file is empty (0 bytes). Re-record this verse.');
       }
       setErrorMessage(null);
       // Dispatch PLAY only after the engine confirms load + non-zero duration

--- a/src/hooks/verseAudioReducer.test.ts
+++ b/src/hooks/verseAudioReducer.test.ts
@@ -57,4 +57,8 @@ describe('verseAudioReducer', () => {
   it('START from recorded begins a re-record', () => {
     expect(step('recorded', { type: 'START' })).toBe('recording');
   });
+
+  it('START from playing begins a re-record', () => {
+    expect(step('playing', { type: 'START' })).toBe('recording');
+  });
 });

--- a/src/hooks/verseAudioReducer.ts
+++ b/src/hooks/verseAudioReducer.ts
@@ -33,7 +33,12 @@ export function verseAudioReducer(
       }
       return event.hasTake ? 'recorded' : 'idle';
     case 'START':
-      if (state === 'idle' || state === 'recorded' || state === 'error') {
+      if (
+        state === 'idle' ||
+        state === 'recorded' ||
+        state === 'playing' ||
+        state === 'error'
+      ) {
         return 'recording';
       }
       return state;

--- a/src/theme/iconSpecs.ts
+++ b/src/theme/iconSpecs.ts
@@ -23,6 +23,10 @@ export const iconSizes = {
   /** Phase status circle on project chapter rows (`h-12 w-12` in mock). */
   phaseIcon: 48,
   phaseIconGlyph: 24,
+  /** Glyph inside idle Record CTA (Lovable / design `h-24` control). */
+  recordIdleGlyph: 44,
+  /** Glyph inside capture/review primary control (`h-20`). */
+  recordPrimaryGlyph: 30,
 } as const;
 
 /** Phase icon stroke (`strokeWidth="1.75"` in mock). */

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -5,6 +5,9 @@ import {
   typography,
   workflowBadges,
   workflowStages,
+  recordControlSizes,
+  shadows,
+  waveform,
 } from './tokens';
 import { homeListContent, listCard, workflowBadge } from './layout';
 
@@ -15,6 +18,9 @@ export {
   typography,
   workflowBadges,
   workflowStages,
+  recordControlSizes,
+  shadows,
+  waveform,
   hslToHex,
 } from './tokens';
 export type { WorkflowStageId } from './tokens';
@@ -38,6 +44,9 @@ export const theme = {
   typography,
   workflowBadges,
   workflowStages,
+  recordControlSizes,
+  shadows,
+  waveform,
   homeListContent,
   listCard,
   workflowBadge,

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -70,6 +70,8 @@ export const colors = {
   destructive: '#DC2626',
   /** Record button + live-recording waveform (drafting Record tab). */
   recordAccent: '#DC2626',
+  /** Progress / paused waveform fill (Lovable `--waveform-active`). */
+  waveformActive: hslToHex(219, 87, 59),
   workflowBadgeDraftBorder: '#FBBF24',
   workflowBadgeDraftText: '#1A1A1A',
   workflowBadgePeerCheckBorder: '#EA580C',
@@ -156,6 +158,8 @@ export const typography = {
     md: 16,
     lg: 18,
     xl: 20,
+    /** Record capture timer (`text-4xl` / 2.25rem in Lovable). */
+    display: 32,
   },
   weights: {
     regular: '400' as const,
@@ -166,5 +170,44 @@ export const typography = {
   lineHeights: {
     tight: 20,
     normal: 24,
+  },
+} as const;
+
+/** Record-tab control diameters (Lovable `h-24` / `h-20` / `h-14`). */
+export const recordControlSizes = {
+  idle: 96,
+  primary: 80,
+  stop: 56,
+  secondary: 48,
+} as const;
+
+/**
+ * Decorative waveform chrome (Lovable `flex-1 rounded-full` / `w-1.5 rounded-full`).
+ * Capsule bars that flex across the row — not stubby max-width rectangles.
+ */
+export const waveform = {
+  /** Gap between bars (`gap-0.5` ≈ 2px, slightly roomier for RN). */
+  barGap: 3,
+  barMinWidth: 3,
+  barMinHeight: 4,
+  dockHeight: 28,
+  tallHeight: 72,
+} as const;
+
+/** Soft elevation for white stop control + red record CTA. */
+export const shadows = {
+  soft: {
+    shadowColor: '#000000',
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 2,
+  },
+  elevated: {
+    shadowColor: '#000000',
+    shadowOpacity: 0.12,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
   },
 } as const;

--- a/src/types/drafting/types.ts
+++ b/src/types/drafting/types.ts
@@ -1,1 +1,1 @@
-export type DraftingTab = 'bible' | 'record';
+export type DraftingTab = 'bible' | 'resources' | 'record';


### PR DESCRIPTION
### TLDR

Critical post-merge fix so drafting/Record works again after the Record stack landed. Keeps Record mounted across tabs, releases the mic after stop, waits for take load before play (no stuck 0:00), and aligns Record chrome with Lovable for built states. Source-audio dock stays an explicit stub (#235).

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #236

Root causes addressed: Record unmount killed the native recorder; playback called play before `isLoaded`; stop cleared UI before releasing the mic; Metro remount flashed brand-blue init chrome; Bible verse taps did not open Record.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- `src/app/screens/DraftingScreen.tsx` — dual-mount Record; block leave while capturing
- `src/app/tabs/RecordTab.tsx` / `BibleTab.tsx` — verse → Record; capture UI; error alerts
- `src/hooks/useVerseAudio.ts` / `useRecordingEngine.ts` / `usePlaybackEngine.ts` — stop order, mic release, play load-wait, DB duration fallback
- `src/audio/createPlaybackEngine.ts` / `createRecordingEngine.ts` — wait for load; `releaseAudioMode`; no `player.remove()` on stop
- `src/components/layout/DraftingTabBar.tsx` — Bible → Resources → Record; theme tab bar
- `src/components/ui/PlaybackProgressBar.tsx` / `DraftTakeRow.tsx` / `RecordCircleButton.tsx` / `SourceTextAccordion.tsx` — Lovable chrome
- `src/components/layout/SourceAudioPlayerBar.tsx` — stub defaults to empty until #235
- `plugins/withAppWindowBackground.js` / `App.tsx` / `app.config.ts` — white window/init (cold splash stays blue)

#### Testing

- Focused: `createPlaybackEngine`, `createRecordingEngine`, `verseAudioReducer`, `RecordTab`, `DraftingTabBar`, `PlaybackProgressBar`, `BibleTab`, `App.test` (28 passed)
- Full CI gates expected on this PR: format, lint, typecheck, unit tests

### How to verify

1. `npm install` if needed; `npm run prebuild` then `npm run android -- --device` after native/audio config changes
2. Open chapter from My Work → drafting not blank; tabs Bible | Resources | Record
3. Record → pause → stop → leave (no Recording in progress after stop)
4. Play take → time advances on take row (ignore source dock stub)
5. Bible verse tap → switches to Record for that verse

**Expected:** Draft capture and review work end-to-end; source dock remains empty stub (#235).

### Follow-ups

- [x] #235 — Wire Source audio dock to real fetch + playback (deferred stub)
- [ ] Android device QA on this PR (mic / playback) — required before considering fully verified; merging as **critical fix** with admin bypass once CI is green per author request

**Merge note:** Author requests admin merge when CI is green. This is a **critical fix** restoring Record after the stacked Record merges left a blank/broken drafting path on device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Resources tab to the drafting workspace.
  * Added redesigned recording controls, waveform animations, take review, deletion, and source-text expansion.
  * Added protection against leaving a draft while recording is in progress.
* **Bug Fixes**
  * Improved audio loading, playback, recording cleanup, and handling of missing or empty recordings.
  * Improved duration display and playback state updates.
* **Style**
  * Updated navigation, loading, drafting, and recording screens with a light theme and refined layouts.
* **Tests**
  * Expanded coverage for tabs, recording states, playback, and audio transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->