### PR TITLE
[#238]: Fix recording upload getInfoAsync deprecation failure

### DIFF
--- a/src/services/recordingSync.test.ts
+++ b/src/services/recordingSync.test.ts
@@ -1,4 +1,4 @@
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { waitFor } from '@testing-library/react-native';
 import { resetFileSystemMock } from '../test/mocks/expo-file-system';
 import type { PendingRecording } from '../types/db/types';

--- a/src/services/recordingSync.ts
+++ b/src/services/recordingSync.ts
@@ -1,4 +1,4 @@
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { getApiBaseUrl } from '../config/apiBaseUrl';
 import type { PendingUploadChapter } from '../db/queries';
 import {


### PR DESCRIPTION
### TLDR

Recording auto-upload was failing because `recordingSync` called `getInfoAsync` from `expo-file-system` (non-legacy). Expo throws that deprecation as an error, so uploads retry then fail. Switch to `expo-file-system/legacy`, matching `audioStorage`.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [ ] How to verify steps completed or valid waiver noted below
- [ ] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #238

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- `src/services/recordingSync.ts` — import `expo-file-system/legacy`
- `src/services/recordingSync.test.ts` — same import for consistency

#### Testing

- `npm test -- --ci --testPathPattern='recordingSync'` (17 passed)

### How to verify

1. Pull this branch / merge to main; reload app (Metro reload is enough)
2. Have pending recordings; watch upload orchestrator logs
3. Confirm uploads no longer fail with the getInfoAsync deprecation message

**Expected:** Recording upload pass completes with uploaded > 0 (or only real network/API failures).

### Follow-ups

- None for this fix. Broader migration off legacy FS can be a later chore.