### PR TITLE
[#240]: Fix verse-audio FormData upload and Record CR leftovers

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -85,11 +85,10 @@ const config: ExpoConfig = {
     [
       'expo-audio',
       {
-        // Android RECORD_AUDIO via config plugin (recordAudioAndroid defaults true)
+        // Android RECORD_AUDIO via config plugin (recordAudioAndroid defaults true).
+        // No microphonePermission — that string is iOS-only and this app is Android-only.
         recordAudioAndroid: true,
         enableBackgroundRecording: false,
-        microphonePermission:
-          'Fluent needs access to your microphone so translators can record verse drafts.',
       },
     ],
   ],

--- a/src/app/screens/DraftingScreen.tsx
+++ b/src/app/screens/DraftingScreen.tsx
@@ -79,17 +79,28 @@ export default function DraftingScreen() {
     setAccountSwitcherVisible(false);
   }, []);
 
+  const alertRecordingInProgress = useCallback(() => {
+    Alert.alert(
+      'Recording in progress',
+      'Stop or finish the current take before leaving.',
+      [{ text: 'OK' }],
+    );
+  }, []);
+
+  // Block header back, Android system back, and any other pop while capturing.
+  useEffect(() => {
+    return navigation.addListener('beforeRemove', e => {
+      if (!recordCaptureActive) {
+        return;
+      }
+      e.preventDefault();
+      alertRecordingInProgress();
+    });
+  }, [alertRecordingInProgress, navigation, recordCaptureActive]);
+
   const goBack = useCallback(() => {
-    if (recordCaptureActive) {
-      Alert.alert(
-        'Recording in progress',
-        'Stop or finish the current take before leaving.',
-        [{ text: 'OK' }],
-      );
-      return;
-    }
     navigation.goBack();
-  }, [navigation, recordCaptureActive]);
+  }, [navigation]);
 
   const handleAccountPress = useCallback(() => {
     setAccountSwitcherVisible(true);
@@ -97,9 +108,14 @@ export default function DraftingScreen() {
 
   // CHANGED: was `triggerSync`. Tapping the icon now navigates to the
   // Sync page instead of kicking off a sync directly (per #38 / #149).
+  // Sync pushes another route (beforeRemove may not fire) — guard explicitly.
   const handleSyncPress = useCallback(() => {
+    if (recordCaptureActive) {
+      alertRecordingInProgress();
+      return;
+    }
     navigation.navigate('Sync');
-  }, [navigation]);
+  }, [alertRecordingInProgress, navigation, recordCaptureActive]);
 
   const renderHeader = () => (
     <DraftingHeader

--- a/src/audio/createPlaybackEngine.test.ts
+++ b/src/audio/createPlaybackEngine.test.ts
@@ -192,6 +192,42 @@ describe('createPlaybackEngine', () => {
     expect(player.calls.filter(c => c === 'remove')).toHaveLength(0);
   });
 
+  it('pause then play same URI resumes without replace', async () => {
+    const player = makeFakePlayer();
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+    });
+
+    await engine.play('file:///take.m4a');
+    await engine.pause();
+    // Simulate progress during play before pause.
+    await player.seekTo(1.25);
+    player.calls.length = 0;
+
+    await engine.play('file:///take.m4a');
+    expect(engine.getStatus()).toBe('playing');
+    expect(player.calls).not.toContain('replace');
+    expect(player.calls).toContain('play');
+    expect(engine.positionMs).toBe(1250);
+  });
+
+  it('play different URI replaces after a prior take', async () => {
+    const player = makeFakePlayer();
+    const engine = createPlaybackEngine({
+      player,
+      delayMs: async () => undefined,
+    });
+
+    await engine.play('file:///take-a.m4a');
+    await engine.pause();
+    player.calls.length = 0;
+
+    await engine.play('file:///take-b.m4a');
+    expect(player.calls[0]).toBe('replace');
+    expect(engine.getStatus()).toBe('playing');
+  });
+
   it('calls prepareAudioMode once', async () => {
     const player = makeFakePlayer();
     const prepareAudioMode = jest.fn(async () => undefined);

--- a/src/audio/createPlaybackEngine.ts
+++ b/src/audio/createPlaybackEngine.ts
@@ -50,6 +50,8 @@ export function createPlaybackEngine(deps: PlaybackEngineDeps): PlaybackEngine {
   } = deps;
   let status: PlayerStatus = 'idle';
   let modeReady = false;
+  /** URI last successfully loaded via `replace` — skip replace on same-URI resume. */
+  let loadedUri: string | null = null;
 
   function setStatus(next: PlayerStatus): void {
     status = next;
@@ -103,9 +105,13 @@ export function createPlaybackEngine(deps: PlaybackEngineDeps): PlaybackEngine {
     },
     async play(uri: string) {
       await ensureMode();
-      // Leave prior status until load succeeds so UI does not show "playing" at 0:00.
-      player.replace({ uri });
-      await waitUntilLoaded();
+      // `replace` resets currentTime to 0 — only load a new take, not pause→play.
+      if (loadedUri !== uri || !player.isLoaded) {
+        // Leave prior status until load succeeds so UI does not show "playing" at 0:00.
+        player.replace({ uri });
+        await waitUntilLoaded();
+        loadedUri = uri;
+      }
       player.play();
       // Some containers (e.g. raw ADTS) report duration 0 until playback starts.
       await delayMs(100);

--- a/src/hooks/usePlaybackEngine.ts
+++ b/src/hooks/usePlaybackEngine.ts
@@ -52,7 +52,8 @@ export function usePlaybackEngine(): UsePlaybackEngineApi {
       setStatus('idle');
       return;
     }
-    if (nativeStatus.playing) {
+    // Don't let a late status tick override an explicit engine pause.
+    if (nativeStatus.playing && status !== 'paused') {
       setStatus('playing');
     }
     // Do not map !playing → paused here. After `replace`, the player is briefly
@@ -63,6 +64,7 @@ export function usePlaybackEngine(): UsePlaybackEngineApi {
     nativeStatus.duration,
     nativeStatus.playing,
     nativeStatus.didJustFinish,
+    status,
   ]);
 
   useEffect(() => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -65,9 +65,10 @@ async function signInRequest(
 async function uploadVerseAudioRequest(
   params: UploadVerseAudioParams,
 ): Promise<VerseAudioResponse> {
+  const formData = await buildVerseAudioFormData(params);
   const raw = await authedMultipartRequest<unknown>(
     verseAudioUploadPath(params.projectUnitId, params.bibleTextId),
-    buildVerseAudioFormData(params),
+    formData,
     { method: 'PUT' },
   );
   return parseVerseAudioResponse(raw);

--- a/src/services/api.verseAudio.test.ts
+++ b/src/services/api.verseAudio.test.ts
@@ -11,6 +11,10 @@ import {
   buildVerseAudioFormData,
   verseAudioUploadPath,
 } from './verseAudioFormData';
+import {
+  resetFileSystemMock,
+  writeAsStringAsync,
+} from '../test/mocks/expo-file-system';
 
 const successBody = {
   id: 9,
@@ -49,7 +53,7 @@ describe('verseAudioFormData helpers', () => {
     expect(verseAudioUploadPath(12, 3401)).toBe('/verse-audio/12/3401');
   });
 
-  it('appends file and optional durationSeconds', () => {
+  it('appends file and optional durationSeconds', async () => {
     const append = jest.fn();
     const g = globalThis as GlobalWithFormData;
     const OriginalFormData = g.FormData;
@@ -57,7 +61,7 @@ describe('verseAudioFormData helpers', () => {
 
     try {
       const blob = { __blob: true } as unknown as Blob;
-      buildVerseAudioFormData({ file: blob, durationSeconds: 12.5 });
+      await buildVerseAudioFormData({ file: blob, durationSeconds: 12.5 });
       expect(append).toHaveBeenCalledWith('file', blob);
       expect(append).toHaveBeenCalledWith('durationSeconds', '12.5');
     } finally {
@@ -65,20 +69,35 @@ describe('verseAudioFormData helpers', () => {
     }
   });
 
-  it('accepts React Native uri file parts and omits duration when unset', () => {
+  it('reads uri file parts into an Expo bytes-part before append', async () => {
+    resetFileSystemMock();
+    const uri = 'file:///mock-document/recordings/a.m4a';
+    // ASCII "hi" as base64 — Expo fetch rejects raw `{ uri }` FormData parts,
+    // and RN Blob rejects ArrayBufferView.
+    await writeAsStringAsync(uri, 'aGk=');
+
     const append = jest.fn();
     const g = globalThis as GlobalWithFormData;
     const OriginalFormData = g.FormData;
     g.FormData = jest.fn(() => ({ append })) as unknown as typeof g.FormData;
 
     try {
-      const file = {
-        uri: 'file:///data/recordings/a.m4a',
-        name: 'a.m4a',
-        type: 'audio/mp4',
-      };
-      buildVerseAudioFormData({ file });
-      expect(append).toHaveBeenCalledWith('file', file);
+      await buildVerseAudioFormData({
+        file: {
+          uri,
+          name: 'a.m4a',
+          type: 'audio/mp4',
+        },
+      });
+      expect(append).toHaveBeenCalledWith(
+        'file',
+        expect.objectContaining({
+          name: 'a.m4a',
+          type: 'audio/mp4',
+          bytes: expect.any(Function),
+        }),
+        'a.m4a',
+      );
       expect(append).not.toHaveBeenCalledWith(
         'durationSeconds',
         expect.anything(),
@@ -108,12 +127,28 @@ describe('parseApiErrorBody (verse-audio 503 shape)', () => {
 describe('FluentAPI.uploadVerseAudio', () => {
   const fetchMock = jest.fn();
   const sampleFile = {
-    uri: 'file:///x.m4a',
+    uri: 'file:///mock-document/x.m4a',
     name: 'x.m4a',
     type: 'audio/mp4',
   };
 
-  beforeEach(() => {
+  type GlobalWithFormData = typeof globalThis & {
+    FormData: new () => { append: jest.Mock };
+  };
+
+  let OriginalFormData: GlobalWithFormData['FormData'];
+
+  beforeEach(async () => {
+    resetFileSystemMock();
+    await writeAsStringAsync(sampleFile.uri, 'aGk=');
+
+    // Jest's FormData requires real Blobs; production uses Expo bytes-parts.
+    const g = globalThis as GlobalWithFormData;
+    OriginalFormData = g.FormData;
+    g.FormData = class MockFormData {
+      append = jest.fn();
+    } as unknown as GlobalWithFormData['FormData'];
+
     fetchMock.mockReset();
     jest
       .spyOn(globalThis, 'fetch')
@@ -122,6 +157,7 @@ describe('FluentAPI.uploadVerseAudio', () => {
   });
 
   afterEach(() => {
+    (globalThis as GlobalWithFormData).FormData = OriginalFormData;
     jest.restoreAllMocks();
     authToken.set(null);
   });
@@ -145,7 +181,9 @@ describe('FluentAPI.uploadVerseAudio', () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('http://localhost:9999/verse-audio/12/3401');
     expect(init.method).toBe('PUT');
-    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body).toEqual(
+      expect.objectContaining({ append: expect.any(Function) }),
+    );
     const headers = init.headers as Record<string, string>;
     expect(headers.Authorization).toBe('Bearer session-token');
     expect(headers['Content-Type']).toBeUndefined();

--- a/src/services/verseAudioFormData.ts
+++ b/src/services/verseAudioFormData.ts
@@ -1,3 +1,5 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
 import type {
   UploadVerseAudioParams,
   VerseAudioFilePart,
@@ -14,21 +16,73 @@ function isVerseAudioFilePart(
   );
 }
 
+function base64ToUint8Array(base64: string): Uint8Array {
+  // Hermes / RN provide atob; typings on globalThis are incomplete here.
+  const decode = (
+    globalThis as typeof globalThis & { atob: (data: string) => string }
+  ).atob;
+  const binary = decode(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Expo winter `fetch` (`convertFormDataAsync`) accepts Blob or
+ * `{ bytes(), name?, type? }`. React Native BlobManager cannot build Blobs
+ * from ArrayBufferView (`Creating blobs from 'ArrayBuffer' and
+ * 'ArrayBufferView' are not supported`), and `{ uri }` parts are also
+ * rejected — so uri uploads must use a bytes-part.
+ */
+async function uriToExpoFilePart(file: VerseAudioFilePart): Promise<Blob> {
+  const base64 = await FileSystem.readAsStringAsync(file.uri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  const bytes = base64ToUint8Array(base64);
+  return {
+    name: file.name,
+    type: file.type,
+    bytes: () => bytes,
+  } as unknown as Blob;
+}
+
+/**
+ * Resolve the multipart file value for verse-audio upload.
+ */
+export async function verseAudioFileToBlob(
+  file: UploadVerseAudioParams['file'],
+): Promise<{ blob: Blob; filename?: string }> {
+  if (!isVerseAudioFilePart(file)) {
+    return { blob: file };
+  }
+
+  return {
+    blob: await uriToExpoFilePart(file),
+    filename: file.name,
+  };
+}
+
+type FormDataWithFilename = FormData & {
+  append(name: string, value: Blob, fileName?: string): void;
+};
+
 /**
  * Multipart body for `PUT /verse-audio/{projectUnitId}/{bibleTextId}`
  * (fluent-api PR #224). Path carries the IDs; body is `file` + optional
  * `durationSeconds` only.
  */
-export function buildVerseAudioFormData(
+export async function buildVerseAudioFormData(
   params: Pick<UploadVerseAudioParams, 'file' | 'durationSeconds'>,
-): FormData {
-  const formData = new FormData();
+): Promise<FormData> {
+  const formData = new FormData() as FormDataWithFilename;
+  const { blob, filename } = await verseAudioFileToBlob(params.file);
 
-  if (isVerseAudioFilePart(params.file)) {
-    // RN FormData accepts `{ uri, name, type }`; typings expect Blob/File.
-    formData.append('file', params.file as unknown as Blob);
+  if (filename !== undefined) {
+    formData.append('file', blob, filename);
   } else {
-    formData.append('file', params.file);
+    formData.append('file', blob);
   }
 
   if (

--- a/src/test/mocks/expo-file-system.ts
+++ b/src/test/mocks/expo-file-system.ts
@@ -11,6 +11,12 @@ const directories = new Set<string>();
 export const documentDirectory = 'file:///mock-document/';
 export const cacheDirectory = 'file:///mock-cache/';
 
+/** Mirrors `expo-file-system/legacy` EncodingType. */
+export const EncodingType = {
+  UTF8: 'utf8',
+  Base64: 'base64',
+} as const;
+
 export function resetFileSystemMock(): void {
   files.clear();
   directories.clear();

--- a/src/types/api/verseAudio.ts
+++ b/src/types/api/verseAudio.ts
@@ -25,7 +25,10 @@ export interface VerseAudioFilePart {
 export interface UploadVerseAudioParams {
   projectUnitId: number;
   bibleTextId: number;
-  /** Audio bytes (RN: `{ uri, name, type }`). */
+  /**
+   * Audio bytes. Callers may pass RN `{ uri, name, type }`; the upload path
+   * reads the file and appends a Blob (Expo fetch rejects uri FormData parts).
+   */
   file: Blob | VerseAudioFilePart;
   /** Optional client-measured duration (seconds); form field `durationSeconds`. */
   durationSeconds?: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
     "types": ["jest"],
     "typeRoots": ["./src/types", "./node_modules/@types"]
   },
-  "exclude": ["**/node_modules", "**/Pods"],
+  "exclude": ["**/node_modules", "**/Pods", "tmp"],
 }


### PR DESCRIPTION
### TLDR

Recording uploads were dying in Expo/RN FormData before they hit the API. This switches uri uploads to Expo bytes-parts, and picks up the remaining CodeRabbit items from #237 (nav guard while recording, pause/resume without replace, drop unused iOS mic permission text). Client FormData is fixed; API 404s until fluent-api verse-audio is deployed are expected.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #240

Root cause: Expo winter fetch rejects RN `{ uri, name, type }` FormData parts, and RN BlobManager rejects ArrayBufferView when building Blobs. Fix reads the file and appends an Expo `{ bytes, name, type }` part. Also gates Sync/system back while capturing, resumes same-URI playback without `replace()`, and removes unused iOS `microphonePermission`.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- `src/services/verseAudioFormData.ts` — uri → Expo bytes FormData part
- `src/services/api.ts` / `src/services/api.verseAudio.test.ts` — async FormData build + coverage
- `src/app/screens/DraftingScreen.tsx` — `beforeRemove` + Sync guard while recording
- `src/audio/createPlaybackEngine.ts` (+ test) — resume same URI without replace
- `src/hooks/usePlaybackEngine.ts` — do not override explicit pause from native ticks
- `app.config.ts` — remove iOS-only `microphonePermission`
- `tsconfig.json` — exclude `tmp/` from typecheck

#### Testing

- `npm run format:check`
- `npm run lint -- --ignore-pattern 'tmp/**'` (0 errors)
- `npm run typecheck`
- `npm test -- --ci` (367 passed)

### How to verify

1. Reload the app with pending recordings; watch RecordingSync logs
2. Confirm FormData / ArrayBufferView client errors are gone
3. Confirm requests reach the API (404 Not Found is OK until fluent-api #224 / verse-audio is deployed)
4. While recording: Sync and Android back should alert and stay put
5. Play a take, pause mid-way, play again — position should resume, not reset to 0:00

**Expected:** Uploads no longer fail on FormData construction. 404 from missing verse-audio routes is terminal/non-retryable and expected pre-API. Recording navigation guards and pause/resume behave as above.

### Follow-ups

- None for client FormData. Live upload success still depends on fluent-api verse-audio (#224) being merged/deployed.