### PR TITLE
[#249]: Fix nightly EAS profile to ship standalone internal APK (no Metro)

### DIFF
--- a/.eas/README.md
+++ b/.eas/README.md
@@ -62,6 +62,7 @@ Uses the latest git tag for runtime version when available; otherwise falls back
 GitHub Actions [`.github/workflows/nightly-preview.yml`](../.github/workflows/nightly-preview.yml) builds a fresh Android **internal APK** with the EAS **`nightly`** profile each night (or on `workflow_dispatch`).
 
 - Bakes `EXPO_PUBLIC_API_BASE_URL=https://dev.api.fluent.bible`
+- **`developmentClient: false`** — standalone APK with JS bundled (not a Metro / `development` profile build)
 - **No Updates channel** and **no `eas update`** — what you install is what you run
 - Does **not** require the Expo GitHub App (uses `EXPO_TOKEN`, same as PR preview)
 - Distinct from PR `preview` (which may OTA to channel `preview`)

--- a/.github/README.md
+++ b/.github/README.md
@@ -41,8 +41,8 @@ Requires `EXPO_TOKEN` in repository secrets. For JS-only PRs, `.github/scripts/e
 
 Scheduled (and manually dispatchable) workflow [`.github/workflows/nightly-preview.yml`](workflows/nightly-preview.yml):
 
-- Always starts a **new** EAS Android build with profile **`nightly`** (internal APK, baked `https://dev.api.fluent.bible`).
-- **No OTA** (`eas update` is not used). Expo Updates stay disabled for `nightly` so the APK cannot pull PR `preview` channel updates.
+- Always starts a **new** EAS Android build with profile **`nightly`** (internal APK, `developmentClient: false`, baked `https://dev.api.fluent.bible`).
+- **No OTA** (`eas update` is not used). Expo Updates stay disabled for `nightly` so the APK cannot pull PR `preview` channel updates. Not a Metro / `development` client.
 - Skips when `main` HEAD matches the last successful nightly unless `force_build` is set.
 - Posts a GitHub Actions job summary and optional Slack notification.
 

--- a/.github/scripts/validate-nightly-api-url.sh
+++ b/.github/scripts/validate-nightly-api-url.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Fail if the nightly EAS profile would bake a non-dev / production-like API URL.
+# Fail if the nightly EAS profile would bake a non-dev / production-like API URL,
+# or if it would produce a development-client (Metro) APK.
 # Requires: jq, eas.json at repo root.
 set -euo pipefail
 
@@ -8,6 +9,26 @@ EAS_JSON="${EAS_JSON_PATH:-eas.json}"
 
 if [ ! -f "${EAS_JSON}" ]; then
   echo "❌ Missing ${EAS_JSON}"
+  exit 1
+fi
+
+if ! jq -e '.build.nightly' "${EAS_JSON}" >/dev/null; then
+  echo "❌ eas.json build.nightly profile is missing"
+  exit 1
+fi
+
+# Standalone internal APK — must not inherit / enable developmentClient.
+DEV_CLIENT=$(jq -r '.build.nightly.developmentClient // false' "${EAS_JSON}")
+if [ "${DEV_CLIENT}" = "true" ]; then
+  echo "❌ eas.json build.nightly must not set developmentClient: true"
+  echo "   Nightly should ship a standalone internal APK (JS bundled), not a Metro dev client."
+  exit 1
+fi
+
+DISTRIBUTION=$(jq -r '.build.nightly.distribution // empty' "${EAS_JSON}")
+if [ "${DISTRIBUTION}" != "internal" ]; then
+  echo "❌ eas.json build.nightly.distribution must be \"internal\""
+  echo "   Found: ${DISTRIBUTION:-<missing>}"
   exit 1
 fi
 
@@ -34,6 +55,7 @@ case "${HOST}" in
     ;;
 esac
 
+echo "✅ Nightly profile OK: developmentClient=${DEV_CLIENT}, distribution=${DISTRIBUTION}"
 echo "✅ Nightly API URL OK: ${URL}"
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "api_base_url=${URL}" >> "${GITHUB_OUTPUT}"

--- a/eas.json
+++ b/eas.json
@@ -35,6 +35,7 @@
     },
     "nightly": {
       "extends": "base",
+      "developmentClient": false,
       "distribution": "internal",
       "env": {
         "EAS_USE_CACHE": "1",


### PR DESCRIPTION
### TLDR

Nightly Android builds were reported as behaving like development clients (waiting on Metro). This PR locks the EAS `nightly` profile to an explicit `developmentClient: false` standalone internal APK (aligned with `preview`), keeps `development` as a real dev client, and extends the nightly CI validator so a Metro-style nightly cannot regress.

### Reviewer checklist

- [ ] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [ ] How to verify steps completed or valid waiver noted below
- [ ] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [ ] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #249

Root cause / hardening: `nightly` already omitted `developmentClient` and used `distribution: "internal"`, but that intent was not locked. Set `developmentClient: false` explicitly and fail CI if nightly ever enables a development client again. `development` is unchanged (`developmentClient: true`).

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- `eas.json` — `build.nightly.developmentClient: false` (still `distribution: "internal"`, APK, dev API URL)
- `.github/scripts/validate-nightly-api-url.sh` — also asserts nightly is not a development client and keeps `distribution: "internal"`
- `.eas/README.md`, `.github/README.md` — document nightly as binary-only / no Metro

#### Testing

- `bash .github/scripts/validate-nightly-api-url.sh` (pass)
- Negative check: forcing `developmentClient: true` on nightly is rejected by the validator
- `npm run format:check` on touched docs / `eas.json` (pass)
- Full app test suite skipped (config/docs/script only; no app code)

### How to verify

1. Confirm profile shape:
   `jq '.build | {development, nightly, preview}' eas.json`
2. Confirm `development.developmentClient` is still `true` and `nightly.developmentClient` is `false`.
3. Run `bash .github/scripts/validate-nightly-api-url.sh` — expect profile + API URL OK.
4. (Optional, when `EXPO_TOKEN` / EAS access available) build and install:
   `npx eas build --profile nightly --platform android`

**Expected:** Nightly APK launches with bundled JS and does **not** try to connect to Metro. Local/engineering `development` builds still use the development client.

### Follow-ups

- [ ] None — if a shipped nightly still shows Metro after this lands, investigate whether the wrong install artifact / profile was used (separate ticket).