### PR TITLE
[#105]: Active-user data attribution for recordings/edits

### DIFF
--- a/docs/guides/recordings-sync-contract.md
+++ b/docs/guides/recordings-sync-contract.md
@@ -65,6 +65,18 @@ JSON matching `verseAudioResponseSchema`: `id`, `projectUnitId`, `bibleTextId`, 
 - Upload orchestrator — #150 (`setChapterUploadWorker`)
 - Live DevQA until #224 (or chosen API) is merged and deployed — waived on #102 with follow-up
 
+## Local attribution (#105)
+
+| | |
+| --- | --- |
+| Column | `recordings.recorded_by_user_id` (nullable FK → `users(id)`, migration v5) |
+| Capture | `addRecordingTake` sets the column from `getActiveUserId()` |
+| Latest / takes | Scoped per `(bible_text_id, recorded_by_user_id)` so shared devices keep separate take stacks |
+| Aggregates | Project / My Work joins filter `r.recorded_by_user_id = ?` for the active user |
+| Upload | `recordingSync` prefers `getCredentials(recordedByUserId)` for each pending row; falls back to the pass token when owner credentials are missing or the row is unattributed (pre-v5) |
+
+Server identity still comes from the Bearer token on `PUT /verse-audio/...`. Local attribution ensures the **correct** token is selected when multiple accounts share a device.
+
 ## Verification
 
 ```bash

--- a/src/db/AGENTS.md
+++ b/src/db/AGENTS.md
@@ -30,10 +30,10 @@ Agents: UI reads here after sync; writes happen only in the repository. See [`.c
 
 - `runMigrations(db)` applies steps with `version > PRAGMA user_version`, once each, in a transaction.
 - Use `rebuildTable()` for SQLite FK/default/type changes (#99 / #103).
-- Current schema version: see `CURRENT_SCHEMA_VERSION` in `migrations.ts` (v3 = `chapter_assignments` assigned-user FK + `idx_ca_assigned_user`; v4 = `user_projects.user_id` FK).
+- Current schema version: see `CURRENT_SCHEMA_VERSION` in `migrations.ts` (v3 = `chapter_assignments` assigned-user FK + `idx_ca_assigned_user`; v4 = `user_projects.user_id` FK; v5 = `recordings.recorded_by_user_id`).
 
 ## Recordings linkage
 
 - Canonical link is `recordings.bible_text_id → bible_texts.id` (not `chapter_assignment_id`).
-- Chapter aggregates join assignments → chapter `bible_texts` → latest recordings (`RECORDINGS_JOIN_CA` in `queries.ts`).
-- Per-user attribution on recordings is #105 — do not add it here.
+- Chapter aggregates join assignments → chapter `bible_texts` → latest recordings for the active user (`RECORDINGS_JOIN_CA` binds `recorded_by_user_id`).
+- Capture attribution: `recorded_by_user_id` from `getActiveUserId()` (#105); take / `is_latest` scoped per user.

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -577,6 +577,26 @@ describe('migrations framework', () => {
     db._seedUsers([5]);
     db._seedProjects([100]);
     db._seedOldUserProjects();
+    // Pre-v5 recordings shape so migration v5 can ADD COLUMN (#105).
+    db._tables.set('recordings', {
+      columns: new Set([
+        'id',
+        'bible_text_id',
+        'local_file_path',
+        'blob_key',
+        'duration_ms',
+        'file_size_bytes',
+        'take_number',
+        'is_latest',
+        'sync_status',
+        'upload_error',
+        'created_at',
+        'updated_at',
+      ]),
+      rows: [],
+      foreignKeys: new Map(),
+      defaults: new Map(),
+    });
 
     const before = await db.execute('SELECT * FROM user_projects');
     expect(before.rows).toHaveLength(2);
@@ -593,6 +613,9 @@ describe('migrations framework', () => {
     expect(after.foreignKeys.get('user_id')).toBe('users');
     expect(after.foreignKeys.get('project_id')).toBe('projects');
     expect(db._indexes.has('idx_up_user')).toBe(true);
+    expect(await columnExists(db, 'recordings', 'recorded_by_user_id')).toBe(
+      true,
+    );
     await expect(getUserVersion(db)).resolves.toBe(CURRENT_SCHEMA_VERSION);
   });
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -593,7 +593,7 @@ describe('migrations framework', () => {
     expect(after.foreignKeys.get('user_id')).toBe('users');
     expect(after.foreignKeys.get('project_id')).toBe('projects');
     expect(db._indexes.has('idx_up_user')).toBe(true);
-    await expect(getUserVersion(db)).resolves.toBe(4);
+    await expect(getUserVersion(db)).resolves.toBe(CURRENT_SCHEMA_VERSION);
   });
 
   it('drops orphan user_projects rows during the integrity rebuild', async () => {
@@ -704,5 +704,46 @@ describe('recordings linkage (#99)', () => {
     expect(recordingsSql).toBeDefined();
     expect(recordingsSql).toContain('bible_text_id');
     expect(recordingsSql).not.toContain('chapter_assignment_id');
+  });
+});
+
+describe('recordings attribution migration (#105)', () => {
+  it('includes recorded_by_user_id in baseline recordings schema', () => {
+    const recordingsSql = createTableQueries.find(q =>
+      q.includes('CREATE TABLE IF NOT EXISTS recordings'),
+    );
+    expect(recordingsSql).toBeDefined();
+    expect(recordingsSql).toContain('recorded_by_user_id');
+    expect(recordingsSql).toContain('REFERENCES users(id)');
+  });
+
+  it('adds recorded_by_user_id when upgrading from v4', async () => {
+    const old = createFakeDb(4);
+    old._tables.set('recordings', {
+      columns: new Set([
+        'id',
+        'bible_text_id',
+        'local_file_path',
+        'blob_key',
+        'duration_ms',
+        'file_size_bytes',
+        'take_number',
+        'is_latest',
+        'sync_status',
+        'upload_error',
+        'created_at',
+        'updated_at',
+      ]),
+      rows: [],
+      foreignKeys: new Map(),
+      defaults: new Map(),
+    });
+
+    await runMigrations(old);
+    expect(await columnExists(old, 'recordings', 'recorded_by_user_id')).toBe(
+      true,
+    );
+    expect(old._indexes.has('idx_rec_verse_user')).toBe(true);
+    await expect(getUserVersion(old)).resolves.toBe(CURRENT_SCHEMA_VERSION);
   });
 });

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -20,7 +20,7 @@ export type Migration = {
   up: (db: SqlExecutor) => Promise<void>;
 };
 
-export const CURRENT_SCHEMA_VERSION = 4;
+export const CURRENT_SCHEMA_VERSION = 5;
 
 export async function getUserVersion(db: SqlExecutor): Promise<number> {
   const result = await db.execute('PRAGMA user_version');
@@ -195,6 +195,30 @@ export async function restoreUserProjectsUserIntegrity(
   });
 }
 
+/**
+ * Attribute recordings to the capturing account (#105).
+ * Existing rows stay nullable; new captures set `recorded_by_user_id`.
+ */
+export async function addRecordingsRecordedByUser(
+  db: SqlExecutor,
+): Promise<void> {
+  // Mid-version fixtures may lack `recordings`; production always has it after v1.
+  const info = await db.execute('PRAGMA table_info(recordings)');
+  if (!info.rows.length) {
+    return;
+  }
+  await addColumnIfMissing(
+    db,
+    'recordings',
+    'recorded_by_user_id',
+    'INTEGER REFERENCES users(id)',
+  );
+  await db.execute(
+    `CREATE INDEX IF NOT EXISTS idx_rec_verse_user
+     ON recordings(bible_text_id, recorded_by_user_id, is_latest)`,
+  );
+}
+
 /** Ordered schema migrations. Version 1 = current CREATE IF NOT EXISTS baseline. */
 export const migrations: Migration[] = [
   {
@@ -216,6 +240,11 @@ export const migrations: Migration[] = [
     version: 4,
     name: 'user_projects_user_integrity',
     up: restoreUserProjectsUserIntegrity,
+  },
+  {
+    version: 5,
+    name: 'recordings_recorded_by_user',
+    up: addRecordingsRecordedByUser,
   },
 ];
 

--- a/src/db/queries.recordingsJoin.test.ts
+++ b/src/db/queries.recordingsJoin.test.ts
@@ -5,4 +5,8 @@ describe('queries recordings join', () => {
     expect(RECORDINGS_JOIN_CA).toContain('r.bible_text_id = bt_r.id');
     expect(RECORDINGS_JOIN_CA).not.toContain('chapter_assignment_id');
   });
+
+  it('scopes latest recordings to recorded_by_user_id (#105)', () => {
+    expect(RECORDINGS_JOIN_CA).toContain('r.recorded_by_user_id = ?');
+  });
 });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -22,13 +22,17 @@ const BIBLE_TEXTS_MATCH_CA = `
   AND bt.chapter_number = ca.chapter_number
 `;
 
-/** Recordings are keyed by bible_text_id; join verses for the chapter assignment. */
+/** Recordings are keyed by bible_text_id; join verses for the chapter assignment.
+ * Bound `recorded_by_user_id = ?` scopes aggregates to the active account (#105).
+ */
 export const RECORDINGS_JOIN_CA = `
   LEFT JOIN bible_texts bt_r
     ON bt_r.bible_id = ca.bible_id
     AND bt_r.book_id = ca.book_id
     AND bt_r.chapter_number = ca.chapter_number
-  LEFT JOIN recordings r ON r.bible_text_id = bt_r.id AND r.is_latest = 1`;
+  LEFT JOIN recordings r ON r.bible_text_id = bt_r.id
+    AND r.is_latest = 1
+    AND r.recorded_by_user_id = ?`;
 
 const RECORDING_AGGREGATES = `
   COUNT(DISTINCT CASE WHEN r.id IS NOT NULL AND r.is_latest = 1 THEN r.id END) AS recording_count,
@@ -107,7 +111,7 @@ export async function getProjectsWithSummary(
       WHERE up.user_id = ?
       GROUP BY p.id
       ORDER BY p.name COLLATE NOCASE;`,
-      [userId],
+      [userId, userId],
     );
 
     const rows = (result?.rows as unknown as DBTypes.ProjectSummaryRow[]) || [];
@@ -316,6 +320,7 @@ function mapProjectChapterRow(
 
 export async function getProjectChapters(
   projectId: number,
+  userId: number,
 ): Promise<DBTypes.ProjectChapter[]> {
   const db = getDatabase();
   try {
@@ -343,7 +348,7 @@ export async function getProjectChapters(
       WHERE pu.project_id = ?
       GROUP BY ca.id
       ORDER BY b.id, ca.chapter_number`,
-      [Number(projectId)],
+      [userId, Number(projectId)],
     );
 
     const rows = (result?.rows as unknown as DBTypes.ProjectChapterRow[]) || [];
@@ -393,7 +398,7 @@ export async function getMyWorkChapters(
       WHERE ${MY_WORK_CHAPTER_WHERE}
       GROUP BY ca.id
       ORDER BY b.id, ca.chapter_number`,
-      getMyWorkChapterQueryParams(userId),
+      [userId, ...getMyWorkChapterQueryParams(userId)],
     );
 
     const rows = (result?.rows as unknown as DBTypes.MyWorkChapterRow[]) || [];

--- a/src/db/recordingsRepository.test.ts
+++ b/src/db/recordingsRepository.test.ts
@@ -3,6 +3,7 @@ import type { RecordingRow } from '../types/db/types';
 type Row = RecordingRow;
 
 let rows: Row[] = [];
+let mockActiveUserId = '1';
 
 function clone(row: Row): Row {
   return { ...row };
@@ -10,6 +11,11 @@ function clone(row: Row): Row {
 
 export function resetRecordingsDbMock(): void {
   rows = [];
+  mockActiveUserId = '1';
+}
+
+export function __setMockActiveUserId(userId: string): void {
+  mockActiveUserId = userId;
 }
 
 export function __getRecordingRows(): Row[] {
@@ -17,6 +23,21 @@ export function __getRecordingRows(): Row[] {
 }
 
 type ExecuteResult = { rows: unknown[] };
+
+function matchesOwner(
+  row: Row,
+  sql: string,
+  params: unknown[],
+  ownerParamIndex: number,
+): boolean {
+  if (sql.includes('recorded_by_user_id IS NULL')) {
+    return row.recorded_by_user_id === null;
+  }
+  if (sql.includes('recorded_by_user_id = ?')) {
+    return row.recorded_by_user_id === (params[ownerParamIndex] as number);
+  }
+  return true;
+}
 
 async function mockExecute(
   sql: string,
@@ -28,7 +49,9 @@ async function mockExecute(
     const bibleTextId = params[1] as number;
     const updatedAt = params[0] as string;
     rows = rows.map(r =>
-      r.bible_text_id === bibleTextId && r.is_latest === 1
+      r.bible_text_id === bibleTextId &&
+      r.is_latest === 1 &&
+      matchesOwner(r, normalized, params, 2)
         ? { ...r, is_latest: 0, updated_at: updatedAt }
         : r,
     );
@@ -38,7 +61,11 @@ async function mockExecute(
   if (normalized.startsWith('SELECT MAX(take_number)')) {
     const bibleTextId = params[0] as number;
     const max = rows
-      .filter(r => r.bible_text_id === bibleTextId)
+      .filter(
+        r =>
+          r.bible_text_id === bibleTextId &&
+          matchesOwner(r, normalized, params, 1),
+      )
       .reduce((m, r) => Math.max(m, r.take_number), 0);
     return { rows: [{ max_take: max || null }] };
   }
@@ -47,6 +74,7 @@ async function mockExecute(
     const [
       id,
       bibleTextId,
+      recordedByUserId,
       localFilePath,
       durationMs,
       fileSizeBytes,
@@ -57,6 +85,7 @@ async function mockExecute(
     ] = params as [
       string,
       number,
+      number | null,
       string,
       number | null,
       number | null,
@@ -68,6 +97,7 @@ async function mockExecute(
     rows.push({
       id,
       bible_text_id: bibleTextId,
+      recorded_by_user_id: recordedByUserId,
       local_file_path: localFilePath,
       blob_key: null,
       duration_ms: durationMs,
@@ -83,26 +113,32 @@ async function mockExecute(
   }
 
   if (
-    normalized.startsWith(
+    normalized.includes(
       'SELECT * FROM recordings WHERE bible_text_id = ? AND is_latest = 1',
     )
   ) {
     const bibleTextId = params[0] as number;
     const match = rows.find(
-      r => r.bible_text_id === bibleTextId && r.is_latest === 1,
+      r =>
+        r.bible_text_id === bibleTextId &&
+        r.is_latest === 1 &&
+        matchesOwner(r, normalized, params, 1),
     );
     return { rows: match ? [clone(match)] : [] };
   }
 
   if (
-    normalized.startsWith(
-      'SELECT * FROM recordings WHERE bible_text_id = ? ORDER BY take_number ASC',
-    )
+    normalized.includes('SELECT * FROM recordings WHERE bible_text_id = ?') &&
+    normalized.includes('ORDER BY take_number ASC')
   ) {
     const bibleTextId = params[0] as number;
     return {
       rows: rows
-        .filter(r => r.bible_text_id === bibleTextId)
+        .filter(
+          r =>
+            r.bible_text_id === bibleTextId &&
+            matchesOwner(r, normalized, params, 1),
+        )
         .sort((a, b) => a.take_number - b.take_number)
         .map(clone),
     };
@@ -110,14 +146,20 @@ async function mockExecute(
 
   if (
     normalized.startsWith(
-      'SELECT bible_text_id, is_latest FROM recordings WHERE id = ?',
+      'SELECT bible_text_id, recorded_by_user_id, is_latest FROM recordings WHERE id = ?',
     )
   ) {
     const id = params[0] as string;
     const match = rows.find(r => r.id === id);
     return {
       rows: match
-        ? [{ bible_text_id: match.bible_text_id, is_latest: match.is_latest }]
+        ? [
+            {
+              bible_text_id: match.bible_text_id,
+              recorded_by_user_id: match.recorded_by_user_id,
+              is_latest: match.is_latest,
+            },
+          ]
         : [],
     };
   }
@@ -129,13 +171,16 @@ async function mockExecute(
   }
 
   if (
-    normalized.startsWith(
-      'SELECT id FROM recordings WHERE bible_text_id = ? ORDER BY take_number DESC LIMIT 1',
-    )
+    normalized.includes('SELECT id FROM recordings WHERE bible_text_id = ?') &&
+    normalized.includes('ORDER BY take_number DESC LIMIT 1')
   ) {
     const bibleTextId = params[0] as number;
     const match = rows
-      .filter(r => r.bible_text_id === bibleTextId)
+      .filter(
+        r =>
+          r.bible_text_id === bibleTextId &&
+          matchesOwner(r, normalized, params, 1),
+      )
       .sort((a, b) => b.take_number - a.take_number)[0];
     return { rows: match ? [{ id: match.id }] : [] };
   }
@@ -161,6 +206,10 @@ jest.mock('./db', () => ({
       await fn({ execute: mockExecute });
     },
   }),
+}));
+
+jest.mock('../services/storage', () => ({
+  getActiveUserId: () => mockActiveUserId,
 }));
 
 import {
@@ -195,13 +244,50 @@ describe('recordingsRepository multi-take', () => {
     expect(takes.map(t => t.takeNumber)).toEqual([1, 2]);
     expect(takes.filter(t => t.isLatest)).toHaveLength(1);
     expect(takes.find(t => t.isLatest)?.id).toBe('take-2');
+    expect(takes.every(t => t.recordedByUserId === 1)).toBe(true);
 
     const latest = await getLatestRecordingForVerse(10);
     expect(latest?.id).toBe('take-2');
     expect(latest?.takeNumber).toBe(2);
+    expect(latest?.recordedByUserId).toBe(1);
   });
 
-  it('keeps exactly one is_latest per bible_text_id', async () => {
+  it('attributes new takes to the active user', async () => {
+    __setMockActiveUserId('42');
+    await addRecordingTake({
+      bibleTextId: 1,
+      localFilePath: 'file:///a.m4a',
+      id: 'owned',
+    });
+    expect(__getRecordingRows()[0].recorded_by_user_id).toBe(42);
+  });
+
+  it('keeps separate latest takes per user on the same verse', async () => {
+    __setMockActiveUserId('1');
+    await addRecordingTake({
+      bibleTextId: 5,
+      localFilePath: 'file:///u1.m4a',
+      id: 'u1',
+    });
+    __setMockActiveUserId('2');
+    await addRecordingTake({
+      bibleTextId: 5,
+      localFilePath: 'file:///u2.m4a',
+      id: 'u2',
+    });
+
+    const latestUser1 = await getLatestRecordingForVerse(5, 1);
+    const latestUser2 = await getLatestRecordingForVerse(5, 2);
+    expect(latestUser1?.id).toBe('u1');
+    expect(latestUser2?.id).toBe('u2');
+    expect(
+      __getRecordingRows().filter(
+        r => r.bible_text_id === 5 && r.is_latest === 1,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('keeps exactly one is_latest per bible_text_id for the active user', async () => {
     await addRecordingTake({
       bibleTextId: 1,
       localFilePath: 'file:///1.m4a',
@@ -218,7 +304,10 @@ describe('recordingsRepository multi-take', () => {
       id: 'c',
     });
     const latestCount = __getRecordingRows().filter(
-      r => r.bible_text_id === 1 && r.is_latest === 1,
+      r =>
+        r.bible_text_id === 1 &&
+        r.recorded_by_user_id === 1 &&
+        r.is_latest === 1,
     );
     expect(latestCount).toHaveLength(1);
   });

--- a/src/db/recordingsRepository.ts
+++ b/src/db/recordingsRepository.ts
@@ -15,10 +15,32 @@ function newRecordingId(): string {
     .slice(2, 10)}`;
 }
 
+function parseActiveUserId(raw: string): number | null {
+  if (!raw) return null;
+  const id = Number(raw);
+  return Number.isFinite(id) && id > 0 ? id : null;
+}
+
+/** Active account id for capture / latest-take scoping (#105). */
+export function resolveRecordedByUserId(
+  override?: number | null,
+): number | null {
+  if (override !== undefined) {
+    return override;
+  }
+  // Lazy require keeps `repository`/`queries` loadable in unit tests that only
+  // import SQL constants without pulling op-sqlite KV storage.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getActiveUserId } =
+    require('../services/storage') as typeof import('../services/storage');
+  return parseActiveUserId(getActiveUserId());
+}
+
 function mapRecordingRow(row: RecordingRow): Recording {
   return {
     id: row.id,
     bibleTextId: row.bible_text_id,
+    recordedByUserId: row.recorded_by_user_id,
     localFilePath: row.local_file_path,
     blobKey: row.blob_key,
     durationMs: row.duration_ms,
@@ -32,6 +54,17 @@ function mapRecordingRow(row: RecordingRow): Recording {
   };
 }
 
+/** SQL predicate + params for optional recorded_by_user_id (incl. NULL). */
+function recordedByClause(
+  userId: number | null,
+  column = 'recorded_by_user_id',
+): { sql: string; params: (number | null)[] } {
+  if (userId === null) {
+    return { sql: `${column} IS NULL`, params: [] };
+  }
+  return { sql: `${column} = ?`, params: [userId] };
+}
+
 export type AddRecordingTakeInput = {
   bibleTextId: number;
   localFilePath: string;
@@ -40,15 +73,19 @@ export type AddRecordingTakeInput = {
   /** Optional stable id (defaults to generated). */
   id?: string;
   syncStatus?: RecordingSyncStatus;
+  /**
+   * Capture-time owner. Defaults to `getActiveUserId()`.
+   * Pass `null` explicitly only in tests for legacy unattributed rows.
+   */
+  recordedByUserId?: number | null;
 };
 
 /**
- * Insert a new take for a verse: clear prior `is_latest`, bump `take_number`,
- * insert with `is_latest = 1` in one transaction.
+ * Insert a new take for a verse: clear prior `is_latest` for this user, bump
+ * per-user `take_number`, insert with `is_latest = 1` in one transaction.
  *
  * Linkage is verse-based (`bible_text_id`) — see #98 / #99. Shared-device
- * `(bible_text_id, user_id)` scoping lands with #105 once `user_id` exists on
- * `recordings` — until then latest is per verse.
+ * scoping is `(bible_text_id, recorded_by_user_id)` (#105).
  */
 export async function addRecordingTake(
   input: AddRecordingTakeInput,
@@ -57,17 +94,20 @@ export async function addRecordingTake(
   const id = input.id ?? newRecordingId();
   const now = new Date().toISOString();
   const syncStatus = input.syncStatus ?? 'pending';
+  const recordedByUserId = resolveRecordedByUserId(input.recordedByUserId);
+  const owner = recordedByClause(recordedByUserId);
 
   await db.transaction(async (tx: Transaction) => {
     await tx.execute(
       `UPDATE recordings SET is_latest = 0, updated_at = ?
-       WHERE bible_text_id = ? AND is_latest = 1`,
-      [now, input.bibleTextId],
+       WHERE bible_text_id = ? AND is_latest = 1 AND ${owner.sql}`,
+      [now, input.bibleTextId, ...owner.params],
     );
 
     const maxResult = await tx.execute(
-      `SELECT MAX(take_number) AS max_take FROM recordings WHERE bible_text_id = ?`,
-      [input.bibleTextId],
+      `SELECT MAX(take_number) AS max_take FROM recordings
+       WHERE bible_text_id = ? AND ${owner.sql}`,
+      [input.bibleTextId, ...owner.params],
     );
     const maxTake = Number(
       (maxResult.rows?.[0] as { max_take?: number | null } | undefined)
@@ -77,12 +117,14 @@ export async function addRecordingTake(
 
     await tx.execute(
       `INSERT INTO recordings (
-         id, bible_text_id, local_file_path, duration_ms, file_size_bytes,
-         take_number, is_latest, sync_status, created_at, updated_at
-       ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`,
+         id, bible_text_id, recorded_by_user_id, local_file_path, duration_ms,
+         file_size_bytes, take_number, is_latest, sync_status, created_at,
+         updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`,
       [
         id,
         input.bibleTextId,
+        recordedByUserId,
         input.localFilePath,
         input.durationMs ?? null,
         input.fileSizeBytes ?? null,
@@ -97,19 +139,23 @@ export async function addRecordingTake(
   log.info('Recording take added', {
     id,
     bibleTextId: input.bibleTextId,
+    recordedByUserId,
   });
   return id;
 }
 
 export async function getLatestRecordingForVerse(
   bibleTextId: number,
+  recordedByUserId?: number | null,
 ): Promise<Recording | null> {
   const db = getDatabase();
+  const ownerId = resolveRecordedByUserId(recordedByUserId);
+  const owner = recordedByClause(ownerId);
   const result = await db.execute(
     `SELECT * FROM recordings
-     WHERE bible_text_id = ? AND is_latest = 1
+     WHERE bible_text_id = ? AND is_latest = 1 AND ${owner.sql}
      LIMIT 1`,
-    [bibleTextId],
+    [bibleTextId, ...owner.params],
   );
   const row = result.rows?.[0] as unknown as RecordingRow | undefined;
   return row ? mapRecordingRow(row) : null;
@@ -117,13 +163,16 @@ export async function getLatestRecordingForVerse(
 
 export async function getTakesForVerse(
   bibleTextId: number,
+  recordedByUserId?: number | null,
 ): Promise<Recording[]> {
   const db = getDatabase();
+  const ownerId = resolveRecordedByUserId(recordedByUserId);
+  const owner = recordedByClause(ownerId);
   const result = await db.execute(
     `SELECT * FROM recordings
-     WHERE bible_text_id = ?
+     WHERE bible_text_id = ? AND ${owner.sql}
      ORDER BY take_number ASC`,
-    [bibleTextId],
+    [bibleTextId, ...owner.params],
   );
   const rows = (result.rows ?? []) as unknown as RecordingRow[];
   return rows.map(mapRecordingRow);
@@ -131,7 +180,7 @@ export async function getTakesForVerse(
 
 /**
  * Delete a take by id. If it was latest, promote the highest remaining
- * `take_number` for that verse (or leave none latest if empty).
+ * `take_number` for that verse + owner (or leave none latest if empty).
  */
 export async function deleteRecordingTake(id: string): Promise<void> {
   const db = getDatabase();
@@ -139,11 +188,16 @@ export async function deleteRecordingTake(id: string): Promise<void> {
 
   await db.transaction(async (tx: Transaction) => {
     const existing = await tx.execute(
-      `SELECT bible_text_id, is_latest FROM recordings WHERE id = ?`,
+      `SELECT bible_text_id, recorded_by_user_id, is_latest
+       FROM recordings WHERE id = ?`,
       [id],
     );
     const row = existing.rows?.[0] as
-      | { bible_text_id: number; is_latest: number }
+      | {
+          bible_text_id: number;
+          recorded_by_user_id: number | null;
+          is_latest: number;
+        }
       | undefined;
     if (!row) {
       return;
@@ -151,6 +205,7 @@ export async function deleteRecordingTake(id: string): Promise<void> {
 
     const wasLatest = row.is_latest === 1;
     const bibleTextId = row.bible_text_id;
+    const owner = recordedByClause(row.recorded_by_user_id);
 
     await tx.execute(`DELETE FROM recordings WHERE id = ?`, [id]);
 
@@ -160,10 +215,10 @@ export async function deleteRecordingTake(id: string): Promise<void> {
 
     const prior = await tx.execute(
       `SELECT id FROM recordings
-       WHERE bible_text_id = ?
+       WHERE bible_text_id = ? AND ${owner.sql}
        ORDER BY take_number DESC
        LIMIT 1`,
-      [bibleTextId],
+      [bibleTextId, ...owner.params],
     );
     const priorId = (prior.rows?.[0] as { id?: string } | undefined)?.id;
     if (priorId) {

--- a/src/db/recordingsRepository.ts
+++ b/src/db/recordingsRepository.ts
@@ -30,7 +30,6 @@ export function resolveRecordedByUserId(
   }
   // Lazy require keeps `repository`/`queries` loadable in unit tests that only
   // import SQL constants without pulling op-sqlite KV storage.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { getActiveUserId } =
     require('../services/storage') as typeof import('../services/storage');
   return parseActiveUserId(getActiveUserId());

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -555,6 +555,7 @@ export async function getPendingRecordings(chapter?: {
        r.bible_text_id AS bible_text_id,
        r.local_file_path AS local_file_path,
        r.duration_ms AS duration_ms,
+       r.recorded_by_user_id AS recorded_by_user_id,
        bt.book_id AS book_id,
        bt.chapter_number AS chapter_number,
        (
@@ -583,6 +584,11 @@ export async function getPendingRecordings(chapter?: {
         ? null
         : Number(projectUnitRaw);
     const durationRaw = row.duration_ms;
+    const recordedByRaw = row.recorded_by_user_id;
+    const recordedByUserId =
+      recordedByRaw === null || recordedByRaw === undefined
+        ? null
+        : Number(recordedByRaw);
     return {
       id: String(row.id),
       bibleTextId: Number(row.bible_text_id),
@@ -596,6 +602,10 @@ export async function getPendingRecordings(chapter?: {
       projectUnitId:
         projectUnitId !== null && Number.isFinite(projectUnitId)
           ? projectUnitId
+          : null,
+      recordedByUserId:
+        recordedByUserId !== null && Number.isFinite(recordedByUserId)
+          ? recordedByUserId
           : null,
     };
   });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -81,11 +81,12 @@ export const createTableQueries: string[] = [
   /**
    * Recordings link to a verse via `bible_text_id` (canonical; see #98 / #99).
    * Do not join recordings on `chapter_assignment_id` — that column is not used.
-   * Per-user attribution on recordings is owned by #105.
+   * `recorded_by_user_id` attributes the take to the active account (#105).
    */
   `CREATE TABLE IF NOT EXISTS recordings (
       id                    TEXT PRIMARY KEY,
       bible_text_id         INTEGER NOT NULL REFERENCES bible_texts(id),
+      recorded_by_user_id   INTEGER REFERENCES users(id),
       local_file_path       TEXT NOT NULL,
       blob_key              TEXT,
       duration_ms           INTEGER,
@@ -99,6 +100,7 @@ export const createTableQueries: string[] = [
     );`,
 
   `CREATE INDEX IF NOT EXISTS idx_rec_verse      ON recordings(bible_text_id, is_latest);`,
+  `CREATE INDEX IF NOT EXISTS idx_rec_verse_user ON recordings(bible_text_id, recorded_by_user_id, is_latest);`,
   `CREATE INDEX IF NOT EXISTS idx_rec_pending    ON recordings(sync_status) WHERE sync_status != 'uploaded';`,
 
   `CREATE TABLE IF NOT EXISTS user_projects (

--- a/src/hooks/useProjectChapters.ts
+++ b/src/hooks/useProjectChapters.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getProjectChapters } from '../db/queries';
 import { ProjectChapter } from '../types/db/types';
+import { parseUserId } from '../utils/parseUserId';
 import { logger } from '../utils/logger';
 
 const log = logger.create('useProjectChapters');
@@ -14,7 +15,12 @@ export function useProjectChapters(projectId: number) {
   const loadChapters = useCallback(async () => {
     try {
       setError(null);
-      setChapters(await getProjectChapters(projectId));
+      const userId = parseUserId();
+      if (userId === null) {
+        setChapters([]);
+        return;
+      }
+      setChapters(await getProjectChapters(projectId, userId));
     } catch (err) {
       log.error('Error loading project chapters:', { error: err, projectId });
       setError(err);

--- a/src/services/recordingSync.test.ts
+++ b/src/services/recordingSync.test.ts
@@ -20,6 +20,7 @@ const mockMarkRecordingUploaded = jest.fn();
 const mockMarkRecordingFailed = jest.fn();
 const mockUploadVerseAudio = jest.fn();
 const mockSetChapterUploadWorker = jest.fn();
+const mockGetCredentials = jest.fn();
 
 jest.mock('../db/repository', () => ({
   getPendingRecordings: (...args: unknown[]) =>
@@ -42,6 +43,10 @@ jest.mock('./uploadOrchestrator', () => ({
     mockSetChapterUploadWorker(...args),
 }));
 
+jest.mock('./keychain', () => ({
+  getCredentials: (...args: unknown[]) => mockGetCredentials(...args),
+}));
+
 const FILE_URI = 'file:///mock-document/recordings/verse-1.m4a';
 
 function pendingRecording(
@@ -55,6 +60,7 @@ function pendingRecording(
     bookId: 40,
     chapterNumber: 1,
     projectUnitId: 12,
+    recordedByUserId: null,
     ...overrides,
   };
 }
@@ -89,6 +95,7 @@ describe('recordingSync', () => {
     mockMarkRecordingUploaded.mockResolvedValue(undefined);
     mockMarkRecordingFailed.mockResolvedValue(undefined);
     mockUploadVerseAudio.mockResolvedValue(successResponse());
+    mockGetCredentials.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -119,6 +126,31 @@ describe('recordingSync', () => {
       'unit-12/text-42',
     );
     expect(mockMarkRecordingFailed).not.toHaveBeenCalled();
+  });
+
+  it('uploads with the recording owner token when credentials exist (#105)', async () => {
+    mockGetPendingRecordings.mockResolvedValue([
+      pendingRecording({ recordedByUserId: 7 }),
+    ]);
+    mockGetCredentials.mockResolvedValue({ token: 'owner-tok' });
+
+    await syncPendingRecordings('active-tok', { delay });
+
+    expect(mockGetCredentials).toHaveBeenCalledWith('7');
+    expect(authToken.get()).toBe('owner-tok');
+    expect(mockUploadVerseAudio).toHaveBeenCalled();
+  });
+
+  it('falls back to the pass token when owner credentials are missing', async () => {
+    mockGetPendingRecordings.mockResolvedValue([
+      pendingRecording({ recordedByUserId: 9 }),
+    ]);
+    mockGetCredentials.mockResolvedValue(null);
+
+    await syncPendingRecordings('pass-tok', { delay });
+
+    expect(mockGetCredentials).toHaveBeenCalledWith('9');
+    expect(authToken.get()).toBe('pass-tok');
   });
 
   it('filters by chapter when provided (orchestrator batching)', async () => {

--- a/src/services/recordingSync.ts
+++ b/src/services/recordingSync.ts
@@ -12,6 +12,7 @@ import { logger } from '../utils/logger';
 import { FluentAPI } from './api';
 import { isAuthError } from './authError';
 import { authToken } from './authToken';
+import { getCredentials } from './keychain';
 import {
   blobKeyFromVerseAudioResponse,
   outcomeFromVerseAudioFailure,
@@ -83,15 +84,42 @@ async function assertLocalFileExists(localFilePath: string): Promise<void> {
   }
 }
 
+/**
+ * Prefer the capture-time owner's stored token so upload attribution stays
+ * stable even if another account is active (#105). Falls back to the pass token.
+ */
+export async function resolveUploadTokenForRecording(
+  recording: PendingRecording,
+  fallbackToken: string,
+): Promise<string> {
+  if (
+    recording.recordedByUserId === null ||
+    !Number.isFinite(recording.recordedByUserId)
+  ) {
+    return fallbackToken;
+  }
+  const creds = await getCredentials(String(recording.recordedByUserId));
+  if (creds?.token) {
+    return creds.token;
+  }
+  log.warn('Owner credentials missing; using active pass token', {
+    recordingId: recording.id,
+    recordedByUserId: recording.recordedByUserId,
+  });
+  return fallbackToken;
+}
+
 async function uploadOneRecording(
   recording: PendingRecording,
   options: {
     signal?: AbortSignal;
     delay: (ms: number) => Promise<void>;
     maxAttempts: number;
+    /** Token for this recording (owner preferred). */
+    token: string;
   },
 ): Promise<'uploaded' | 'failed'> {
-  const { signal, delay, maxAttempts } = options;
+  const { signal, delay, maxAttempts, token } = options;
 
   throwIfAborted(signal);
 
@@ -113,6 +141,7 @@ async function uploadOneRecording(
     return 'failed';
   }
 
+  authToken.set(token);
   await setRecordingSyncStatus(recording.id, 'uploading');
 
   let lastMessage = 'Upload failed';
@@ -146,6 +175,7 @@ async function uploadOneRecording(
       log.info('Recording uploaded', {
         recordingId: recording.id,
         blobKey,
+        recordedByUserId: recording.recordedByUserId,
       });
       // Abort after a successful put still counts as uploaded (server has bytes).
       throwIfAborted(signal);
@@ -231,10 +261,12 @@ async function runUploadPass(
 
   for (const recording of pending) {
     throwIfAborted(options.signal);
+    const uploadToken = await resolveUploadTokenForRecording(recording, token);
     const result = await uploadOneRecording(recording, {
       signal: options.signal,
       delay,
       maxAttempts,
+      token: uploadToken,
     });
     if (result === 'uploaded') {
       uploaded += 1;
@@ -250,6 +282,9 @@ async function runUploadPass(
 /**
  * Upload latest pending recordings (optionally filtered to one chapter).
  * Single-flight: overlapping calls share the in-flight promise.
+ *
+ * Attribution (#105): each recording uploads under its `recorded_by_user_id`
+ * token when credentials exist; otherwise the pass `token` is used.
  */
 export async function syncPendingRecordings(
   token: string,

--- a/src/types/db/types.ts
+++ b/src/types/db/types.ts
@@ -253,6 +253,8 @@ export type RecordingSyncStatus =
 export interface Recording {
   id: string;
   bibleTextId: number;
+  /** Active-user id at capture time (#105); null for pre-attribution rows. */
+  recordedByUserId?: number | null;
   localFilePath: string;
   blobKey?: string | null;
   durationMs?: number | null;
@@ -268,6 +270,7 @@ export interface Recording {
 export interface RecordingRow {
   id: string;
   bible_text_id: number;
+  recorded_by_user_id: number | null;
   local_file_path: string;
   blob_key: string | null;
   duration_ms: number | null;
@@ -293,6 +296,8 @@ export interface PendingRecording {
   chapterNumber: number;
   /** Null when no chapter assignment maps this verse's chapter. */
   projectUnitId: number | null;
+  /** Capture-time owner; upload prefers this account's token (#105). */
+  recordedByUserId: number | null;
 }
 
 export const CHAPTER_ASSIGNMENT_STATUS = {


### PR DESCRIPTION
### TLDR

Adds local capture-time attribution for recordings on multi-account devices: migration **v5** introduces nullable `recordings.recorded_by_user_id`, new takes are tagged from `getActiveUserId()`, latest-take / aggregates are scoped per user, and uploads prefer the owner's stored token. Stacked on #103 (PR #248) so schema versions stay sequential.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #105

**Stacked on:** #103 / PR #248 (`mrace/feature/103-harden-user-projects-fk`). Retarget to `main` after #99/#103 merge.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/db/migrations.ts`** — v5 `recordings_recorded_by_user` (`CURRENT_SCHEMA_VERSION = 5`)
- **`src/db/schema.ts`** — baseline `recorded_by_user_id` + `idx_rec_verse_user`
- **`src/db/recordingsRepository.ts`** — capture attribution; per-user `is_latest` / take stacks
- **`src/db/queries.ts`** — `RECORDINGS_JOIN_CA` binds active `recorded_by_user_id`
- **`src/db/repository.ts`** — pending uploads expose `recordedByUserId`
- **`src/services/recordingSync.ts`** — prefer `getCredentials(owner)` for upload Bearer
- **`docs/guides/recordings-sync-contract.md`** — attribution policy documented
- Types + unit tests for capture, multi-user latest, migration, and owner-token upload

#### Testing

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --ci` (384 passed, 1 skipped)

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Confirm migration v5 adds `recorded_by_user_id` and does not collide with v3/v4 from #99/#103
3. Confirm `addRecordingTake` stores the active user and `recordingSync` selects owner credentials when present

**Expected:** Local rows are attributable per account; uploads use owner token when credentials exist; CI green on required gates (ignore CodeRabbit).

### Follow-ups

- None for this ticket. Do not start #176/#233 here.