### PR TITLE
[255]-Replace-Settings-Menu-Overlay-with-Slide-Out-Panel

### DIFF
--- a/src/app/screens/HomeScreen.tsx
+++ b/src/app/screens/HomeScreen.tsx
@@ -76,6 +76,7 @@ export default function HomeScreen({
   const hasResolvedRef = useRef(hasResolved);
   const uploadOverCellularRef = useRef(uploadOverCellular);
   const prepareOfflinePromptShownThisAppOpenRef = useRef(false);
+  const isSettlingRef = useRef(false);
 
   const evaluateRef = useRef<(() => Promise<void>) | undefined>(undefined);
   const appStateRef = useRef(AppState.currentState);
@@ -100,11 +101,13 @@ export default function HomeScreen({
   const handleSyncComplete = useCallback(() => {
     setIsNewUserLoading(false);
     setIsSyncingLocal(false);
+    void evaluateRef.current?.();
   }, []);
 
   const isSyncingGlobal = useGlobalSyncStatus(() => {
     setIsNewUserLoading(false);
     setRefreshKey(key => key + 1);
+    void evaluateRef.current?.();
   });
   const { isSyncing, triggerSync } = useSync({
     onSyncComplete: handleSyncComplete,
@@ -122,10 +125,16 @@ export default function HomeScreen({
   const autoRepairSyncAttempted = useRef(false);
 
   useEffect(() => {
+    isSettlingRef.current =
+      isNewUserLoading || postLoginSyncActive || isSyncingLocal || isSyncing;
+  }, [isNewUserLoading, postLoginSyncActive, isSyncingLocal, isSyncing]);
+
+  useEffect(() => {
     const unsubscribeComplete = onSyncComplete(() => {
       setIsNewUserLoading(false);
       setIsSyncingLocal(false);
       setRefreshKey(key => key + 1);
+      void evaluateRef.current?.();
     });
     const unsubscribeStart = onSyncStart(() => {
       setIsSyncingLocal(true);
@@ -163,6 +172,7 @@ export default function HomeScreen({
   useEffect(() => {
     const evaluate = async () => {
       if (!isFocusedRef.current || !hasResolvedRef.current) return;
+      if (isSettlingRef.current) return;
 
       const eligibleConnection =
         connectivityIsOnlineRef.current &&

--- a/src/app/screens/HomeScreen.tsx
+++ b/src/app/screens/HomeScreen.tsx
@@ -55,7 +55,6 @@ export default function HomeScreen({
   const [activeTab, setActiveTab] = useState<HomeTab>('myWork');
   const [refreshKey, setRefreshKey] = useState(0);
   const [settingsVisible, setSettingsVisible] = useState(false);
-  const [settingsAnchor, setSettingsAnchor] = useState({ top: 56, left: 16 });
   const [isNewUserLoading, setIsNewUserLoading] = useState(
     () => route.params?.newUserLoading === true,
   );
@@ -256,7 +255,6 @@ export default function HomeScreen({
   ]);
 
   const handleSettingsPress = () => {
-    setSettingsAnchor({ top: 56, left: 16 });
     setSettingsVisible(true);
   };
 
@@ -311,7 +309,6 @@ export default function HomeScreen({
       <UserSettingsMenu
         visible={settingsVisible}
         onClose={() => setSettingsVisible(false)}
-        anchor={settingsAnchor}
         onSignOut={onSignOut}
         onUserSwitched={handleUserSwitched}
       />

--- a/src/components/ui/UserSettingsMenu.test.tsx
+++ b/src/components/ui/UserSettingsMenu.test.tsx
@@ -3,6 +3,22 @@ import { Alert } from 'react-native';
 import { UserSettingsMenu } from './UserSettingsMenu';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
+jest.mock('react-native-gesture-handler', () => {
+  const actualReact = jest.requireActual('react');
+  const chainable = () => {
+    const gesture: Record<string, unknown> = {};
+    ['activeOffsetX', 'failOffsetY', 'onUpdate', 'onEnd'].forEach(method => {
+      gesture[method] = () => gesture;
+    });
+    return gesture;
+  };
+  return {
+    GestureDetector: ({ children }: { children: React.ReactNode }) =>
+      actualReact.createElement(actualReact.Fragment, null, children),
+    Gesture: { Pan: chainable },
+  };
+});
+
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
@@ -71,7 +87,6 @@ describe('UserSettingsMenu', () => {
   const onClose = jest.fn();
   const onUserSwitched = jest.fn();
   const onSignOut = jest.fn();
-  const anchor = { top: 0, left: 0 };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -86,7 +101,6 @@ describe('UserSettingsMenu', () => {
       <UserSettingsMenu
         visible
         onClose={onClose}
-        anchor={anchor}
         onSignOut={onSignOut}
         onUserSwitched={onUserSwitched}
       />,

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -66,9 +66,16 @@ export function UserSettingsMenu({
   const scrimOpacity = useRef(new Animated.Value(0)).current;
   const [isMounted, setIsMounted] = useState(visible);
 
+  const isMountedRef = useRef(isMounted);
+
   useEffect(() => {
+    const wasMounted = isMountedRef.current;
+
     if (visible) {
       setIsMounted(true);
+      isMountedRef.current = true;
+      if (wasMounted) return;
+
       translateX.setValue(-panelWidth);
       scrimOpacity.setValue(0);
       Animated.parallel([
@@ -83,7 +90,7 @@ export function UserSettingsMenu({
           useNativeDriver: true,
         }),
       ]).start();
-    } else if (isMounted) {
+    } else if (wasMounted) {
       Animated.parallel([
         Animated.timing(translateX, {
           toValue: -panelWidth,
@@ -96,10 +103,13 @@ export function UserSettingsMenu({
           useNativeDriver: true,
         }),
       ]).start(({ finished }) => {
-        if (finished) setIsMounted(false);
+        if (finished) {
+          setIsMounted(false);
+          isMountedRef.current = false;
+        }
       });
     }
-  }, [visible, panelWidth, isMounted, translateX, scrimOpacity]);
+  }, [visible, panelWidth, translateX, scrimOpacity]);
 
   const panGesture = Gesture.Pan()
     .activeOffsetX(-10)
@@ -371,11 +381,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     backgroundColor: theme.colors.cardBackground,
-    elevation: 8,
-    shadowColor: '#000',
-    shadowOffset: { width: 2, height: 0 },
-    shadowOpacity: 0.15,
-    shadowRadius: 8,
+    ...theme.shadows.elevated,
   },
   panelContent: {
     paddingTop: 24,

--- a/src/components/ui/UserSettingsMenu.tsx
+++ b/src/components/ui/UserSettingsMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -8,7 +8,10 @@ import {
   Alert,
   StyleSheet,
   ActivityIndicator,
+  Animated,
+  useWindowDimensions,
 } from 'react-native';
+import { theme } from '../../theme';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
@@ -21,10 +24,16 @@ import {
   switchToDeviceAccount,
 } from '../../services/accountSession';
 import { useDeviceAccounts } from '../../hooks/useDeviceAccounts';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { logger } from '../../utils/logger';
 
 const MENU_ICON_COLOR = '#333';
 const MENU_ICON_ACTIVE = '#1a6ef5';
+
+const OPEN_ANIM_DURATION = 250;
+const CLOSE_ANIM_DURATION = 200;
+const SWIPE_CLOSE_RATIO = 0.3;
+const SWIPE_VELOCITY_THRESHOLD = 800;
 
 const log = logger.create('UserSettingsMenu');
 
@@ -33,7 +42,6 @@ type Nav = StackNavigationProp<RootStackParamList>;
 interface UserSettingsMenuProps {
   visible: boolean;
   onClose: () => void;
-  anchor: { top: number; left: number };
   onSignOut?: () => void;
   onUserSwitched?: () => void;
 }
@@ -41,13 +49,88 @@ interface UserSettingsMenuProps {
 export function UserSettingsMenu({
   visible,
   onClose,
-  anchor,
   onSignOut,
   onUserSwitched,
 }: UserSettingsMenuProps) {
   const navigation = useNavigation<Nav>();
   const { accounts, hasAccountLimit, loading } = useDeviceAccounts(visible);
   const [switchingUserId, setSwitchingUserId] = useState<string | null>(null);
+  const { width: windowWidth } = useWindowDimensions();
+
+  const panelWidth = useMemo(
+    () => Math.min(320, windowWidth * 0.82),
+    [windowWidth],
+  );
+
+  const translateX = useRef(new Animated.Value(-panelWidth)).current;
+  const scrimOpacity = useRef(new Animated.Value(0)).current;
+  const [isMounted, setIsMounted] = useState(visible);
+
+  useEffect(() => {
+    if (visible) {
+      setIsMounted(true);
+      translateX.setValue(-panelWidth);
+      scrimOpacity.setValue(0);
+      Animated.parallel([
+        Animated.timing(translateX, {
+          toValue: 0,
+          duration: OPEN_ANIM_DURATION,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scrimOpacity, {
+          toValue: 1,
+          duration: OPEN_ANIM_DURATION,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else if (isMounted) {
+      Animated.parallel([
+        Animated.timing(translateX, {
+          toValue: -panelWidth,
+          duration: CLOSE_ANIM_DURATION,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scrimOpacity, {
+          toValue: 0,
+          duration: CLOSE_ANIM_DURATION,
+          useNativeDriver: true,
+        }),
+      ]).start(({ finished }) => {
+        if (finished) setIsMounted(false);
+      });
+    }
+  }, [visible, panelWidth, isMounted, translateX, scrimOpacity]);
+
+  const panGesture = Gesture.Pan()
+    .activeOffsetX(-10)
+    .failOffsetY([-15, 15])
+    .onUpdate(event => {
+      const next = Math.min(0, event.translationX);
+      translateX.setValue(next);
+      scrimOpacity.setValue(1 - Math.min(1, Math.abs(next) / panelWidth));
+    })
+    .onEnd(event => {
+      const shouldClose =
+        event.translationX < -panelWidth * SWIPE_CLOSE_RATIO ||
+        event.velocityX < -SWIPE_VELOCITY_THRESHOLD;
+
+      if (shouldClose) {
+        onClose();
+      } else {
+        Animated.parallel([
+          Animated.spring(translateX, {
+            toValue: 0,
+            useNativeDriver: true,
+            bounciness: 4,
+          }),
+          Animated.timing(scrimOpacity, {
+            toValue: 1,
+            duration: 150,
+            useNativeDriver: true,
+          }),
+        ]).start();
+      }
+    });
 
   const handleOpenSettings = () => {
     onClose();
@@ -106,153 +189,200 @@ export function UserSettingsMenu({
   return (
     <Modal
       transparent
-      visible={visible}
-      animationType="fade"
+      visible={isMounted}
+      animationType="none"
       onRequestClose={onClose}
     >
-      <Pressable style={appStyles.modalOverlay} onPress={onClose}>
-        <View
-          style={[appStyles.dropdown, { top: anchor.top, left: anchor.left }]}
+      <View style={styles.container}>
+        <Animated.View
+          style={[StyleSheet.absoluteFill, { opacity: scrimOpacity }]}
+          pointerEvents={visible ? 'auto' : 'none'}
         >
-          <TouchableOpacity
-            style={appStyles.menuItem}
-            onPress={handleOpenSettings}
-            activeOpacity={0.7}
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={onClose}
             accessibilityRole="button"
+            accessibilityLabel="Close menu"
+          />
+        </Animated.View>
+
+        <GestureDetector gesture={panGesture}>
+          <Animated.View
+            style={[
+              styles.panel,
+              { width: panelWidth, transform: [{ translateX }] },
+            ]}
           >
-            <Ionicons
-              name="settings-outline"
-              size={18}
-              color={MENU_ICON_COLOR}
-            />
-            <Text style={appStyles.menuItemText}>More Settings</Text>
-          </TouchableOpacity>
+            <View style={styles.panelContent}>
+              <TouchableOpacity
+                style={appStyles.menuItem}
+                onPress={handleOpenSettings}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="settings-outline"
+                  size={18}
+                  color={MENU_ICON_COLOR}
+                />
+                <Text style={appStyles.menuItemText}>More Settings</Text>
+              </TouchableOpacity>
 
-          <TouchableOpacity
-            style={appStyles.menuItem}
-            onPress={handleOpenPrivacy}
-            activeOpacity={0.7}
-            accessibilityRole="button"
-            testID="settings-menu-privacy-policy"
-          >
-            <Ionicons
-              name="document-text-outline"
-              size={18}
-              color={MENU_ICON_COLOR}
-            />
-            <Text style={appStyles.menuItemText}>Privacy Policy</Text>
-          </TouchableOpacity>
+              <View style={[appStyles.menuDivider, styles.panelDivider]} />
 
-          <TouchableOpacity
-            style={appStyles.menuItem}
-            onPress={handleOpenTerms}
-            activeOpacity={0.7}
-            accessibilityRole="button"
-            testID="settings-menu-terms-of-use"
-          >
-            <Ionicons
-              name="shield-checkmark-outline"
-              size={18}
-              color={MENU_ICON_COLOR}
-            />
-            <Text style={appStyles.menuItemText}>Terms of Use</Text>
-          </TouchableOpacity>
+              <TouchableOpacity
+                style={appStyles.menuItem}
+                onPress={handleOpenPrivacy}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                testID="settings-menu-privacy-policy"
+              >
+                <Ionicons
+                  name="document-text-outline"
+                  size={18}
+                  color={MENU_ICON_COLOR}
+                />
+                <Text style={appStyles.menuItemText}>Privacy Policy</Text>
+              </TouchableOpacity>
 
-          <View style={appStyles.menuDivider} />
-          <Text style={appStyles.menuSectionLabel}>Accounts</Text>
+              <TouchableOpacity
+                style={appStyles.menuItem}
+                onPress={handleOpenTerms}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                testID="settings-menu-terms-of-use"
+              >
+                <Ionicons
+                  name="shield-checkmark-outline"
+                  size={18}
+                  color={MENU_ICON_COLOR}
+                />
+                <Text style={appStyles.menuItemText}>Terms of Use</Text>
+              </TouchableOpacity>
 
-          {loading ? (
-            <View
-              style={styles.loadingRow}
-              testID="settings-menu-accounts-loading"
-            >
-              <ActivityIndicator size="small" color={MENU_ICON_ACTIVE} />
-            </View>
-          ) : (
-            accounts.map(account => {
-              // Mockup (#193) labels accounts by email; fall back to displayName.
-              const accountLabel = account.email || account.displayName;
-              return (
+              <View style={[appStyles.menuDivider, styles.panelDivider]} />
+              <Text style={appStyles.menuSectionLabel}>Accounts</Text>
+
+              {loading ? (
+                <View
+                  style={styles.loadingRow}
+                  testID="settings-menu-accounts-loading"
+                >
+                  <ActivityIndicator size="small" color={MENU_ICON_ACTIVE} />
+                </View>
+              ) : (
+                accounts.map(account => {
+                  // Mockup (#193) labels accounts by email; fall back to displayName.
+                  const accountLabel = account.email || account.displayName;
+                  return (
+                    <TouchableOpacity
+                      key={account.userId}
+                      style={appStyles.menuItem}
+                      onPress={() => {
+                        void handleSwitchUser(account.userId);
+                      }}
+                      activeOpacity={0.7}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Switch to ${accountLabel}`}
+                      accessibilityState={{ selected: account.isActive }}
+                      disabled={switchingUserId !== null}
+                      testID={`settings-menu-account-${account.userId}`}
+                    >
+                      <Ionicons
+                        name={
+                          account.isActive
+                            ? 'checkmark-circle'
+                            : 'person-outline'
+                        }
+                        size={18}
+                        color={
+                          account.isActive ? MENU_ICON_ACTIVE : MENU_ICON_COLOR
+                        }
+                        testID={
+                          account.isActive
+                            ? `settings-menu-active-${account.userId}`
+                            : `settings-menu-inactive-${account.userId}`
+                        }
+                      />
+                      <Text
+                        style={[
+                          appStyles.menuItemText,
+                          account.isActive && appStyles.menuItemActive,
+                        ]}
+                        numberOfLines={1}
+                      >
+                        {accountLabel}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })
+              )}
+
+              {hasAccountLimit ? (
+                <Text
+                  style={styles.limitText}
+                  testID="settings-menu-account-limit"
+                >
+                  You&apos;ve reached the 3-account limit.
+                </Text>
+              ) : (
                 <TouchableOpacity
-                  key={account.userId}
                   style={appStyles.menuItem}
-                  onPress={() => {
-                    void handleSwitchUser(account.userId);
-                  }}
+                  onPress={handleAddUser}
                   activeOpacity={0.7}
                   accessibilityRole="button"
-                  accessibilityLabel={`Switch to ${accountLabel}`}
-                  accessibilityState={{ selected: account.isActive }}
-                  disabled={switchingUserId !== null}
-                  testID={`settings-menu-account-${account.userId}`}
+                  accessibilityLabel="Add User"
+                  testID="settings-menu-add-user"
                 >
-                  <Ionicons
-                    name={
-                      account.isActive ? 'checkmark-circle' : 'person-outline'
-                    }
-                    size={18}
-                    color={
-                      account.isActive ? MENU_ICON_ACTIVE : MENU_ICON_COLOR
-                    }
-                    testID={
-                      account.isActive
-                        ? `settings-menu-active-${account.userId}`
-                        : `settings-menu-inactive-${account.userId}`
-                    }
-                  />
-                  <Text
-                    style={[
-                      appStyles.menuItemText,
-                      account.isActive && appStyles.menuItemActive,
-                    ]}
-                    numberOfLines={1}
-                  >
-                    {accountLabel}
-                  </Text>
+                  <UserPlus size={18} color={MENU_ICON_COLOR} />
+                  <Text style={appStyles.menuItemText}>Add User</Text>
                 </TouchableOpacity>
-              );
-            })
-          )}
+              )}
+            </View>
 
-          {hasAccountLimit ? (
-            <Text style={styles.limitText} testID="settings-menu-account-limit">
-              You&apos;ve reached the 3-account limit.
-            </Text>
-          ) : (
+            <View style={[appStyles.menuDivider, styles.panelDivider]} />
             <TouchableOpacity
               style={appStyles.menuItem}
-              onPress={handleAddUser}
+              onPress={() => {
+                void handleSignOut();
+              }}
               activeOpacity={0.7}
               accessibilityRole="button"
-              accessibilityLabel="Add User"
-              testID="settings-menu-add-user"
             >
-              <UserPlus size={18} color={MENU_ICON_COLOR} />
-              <Text style={appStyles.menuItemText}>Add User</Text>
+              <Ionicons name="log-out-outline" size={18} color="#d32f2f" />
+              <Text style={[appStyles.menuItemText, appStyles.menuItemDanger]}>
+                Sign Out
+              </Text>
             </TouchableOpacity>
-          )}
-
-          <View style={appStyles.menuDivider} />
-          <TouchableOpacity
-            style={appStyles.menuItem}
-            onPress={() => {
-              void handleSignOut();
-            }}
-            activeOpacity={0.7}
-            accessibilityRole="button"
-          >
-            <Ionicons name="log-out-outline" size={18} color="#d32f2f" />
-            <Text style={[appStyles.menuItemText, appStyles.menuItemDanger]}>
-              Sign Out
-            </Text>
-          </TouchableOpacity>
-        </View>
-      </Pressable>
+          </Animated.View>
+        </GestureDetector>
+      </View>
     </Modal>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  panel: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    backgroundColor: theme.colors.cardBackground,
+    elevation: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 2, height: 0 },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+  },
+  panelContent: {
+    paddingTop: 24,
+  },
+  panelDivider: {
+    backgroundColor: theme.colors.border,
+  },
   loadingRow: {
     minHeight: 44,
     alignItems: 'center',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Redesigned the user settings menu as a swipeable side panel (drawer) instead of an anchored dropdown.
  * Added smooth slide-in/out animations and a dimmed background overlay.
  * Enabled drag gestures to dismiss the panel or snap it back.

* **Bug Fixes**
  * Improved settings menu interaction behavior across different screen sizes.

* **Tests**
  * Updated unit tests to reflect the new gesture-based drawer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



ScreenShot:
<img width="388" height="867" alt="image" src="https://github.com/user-attachments/assets/29f3e5aa-f57c-4f4f-8153-01848752755c" />

- Also handled the prepare for offline screen appearing during sync.
