### PR TITLE
[#289]: Preview-build binary APKs, ticket comments, and In QA handoff

### DIFF
--- a/.eas/README.md
+++ b/.eas/README.md
@@ -50,8 +50,10 @@ Monitor:
 
 Add the **`preview-build`** label to a pull request. GitHub Actions (`.github/workflows/preview-build.yml`) will:
 
-- **JS-only changes** → find or build a matching **Install Fluent** preview APK, then publish an OTA to the `preview` channel (PR comment: install + open app — not Expo Go)
-- **Native changes** (`app.config.ts` plugins, `eas.json`, `plugins/`) → start an Android `preview` internal APK on EAS (no `developmentClient`; channel `preview`)
+- Start a **fresh Android `preview` internal APK** for that PR commit (binary only — no `eas update` / shared OTA channel)
+- Post the same install comment on the **PR and linked issue**; best-effort move Project 4 Status to **`In QA`** (from `In PR Review` / `In Progress (Dev)`). Optional secret: `PROJECT_BOARD_TOKEN`.
+
+Each labeled PR forces a new build so multiple QA APKs can exist at once. Preview profile has Expo Updates **disabled** (same idea as nightly).
 
 **QA testers:** [`docs/guides/qa-preview-testing.md`](../docs/guides/qa-preview-testing.md)
 
@@ -64,7 +66,7 @@ GitHub Actions [`.github/workflows/nightly-preview.yml`](../.github/workflows/ni
 - Bakes `EXPO_PUBLIC_API_BASE_URL=https://dev.api.fluent.bible`
 - **No Updates channel** and **no `eas update`** — what you install is what you run
 - Does **not** require the Expo GitHub App (uses `EXPO_TOKEN`, same as PR preview)
-- Distinct from PR `preview` (which may OTA to channel `preview`)
+- Distinct from PR `preview` (also binary-only APKs; no shared OTA channel)
 
 See [`.github/README.md`](../.github/README.md) for secrets and skip / force behavior.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,10 +10,10 @@ Workflows for Fluent Mobile (**Android-only**).
 | `test.yml` | push, PR | Jest unit tests |
 | `quality-gates.yml` | push, PR | TypeScript, `expo-doctor`, `expo install --check` |
 | `eas-build.yml` | push tag `v*` | Sync `APP_VERSION_FALLBACK` in `app.config.ts` with tag; hand off to EAS |
-| `preview-build.yml` | PR label `preview-build` | Android preview OTA or native APK for QA |
+| `preview-build.yml` | PR label `preview-build` | Fresh Android preview APK for QA (binary only — no OTA) |
 | `nightly-preview.yml` | cron (06:00 UTC) + `workflow_dispatch` | Nightly **binary-only** Android internal APK (dev API) |
 
-Native Android compile is **not** run on every PR. Use the **`preview-build`** label for EAS preview APKs (native/config changes) and tag releases for production builds.
+Native Android compile is **not** run on every PR. Use the **`preview-build`** label for a fresh EAS preview APK when ready for QA, and tag releases for production builds.
 
 ## Release flow
 
@@ -30,19 +30,19 @@ See [`.eas/README.md`](../.eas/README.md) for Expo GitHub app and Play Store set
 ## PR preview (QA)
 
 1. Create a `preview-build` label on the repo (if missing).
-2. Add the label to a PR when ready for QA.
-3. Workflow posts a comment with **Install Fluent** + open-the-app steps (JS-only OTA on `preview` channel), or an Android **preview APK** (native changes).
+2. Add the label to a PR when ready for QA (PR should reference its ticket with `Closes #NNN`).
+3. Workflow starts a **fresh Android preview APK** (binary only — no OTA / `eas update`), posts the same install comment on the **PR** and each **linked GitHub issue**, and best-effort moves Project 4 cards from `In PR Review` / `In Progress (Dev)` → **`In QA`**.
 
 **QA guide (non-technical):** [`docs/guides/qa-preview-testing.md`](../docs/guides/qa-preview-testing.md)
 
-Requires `EXPO_TOKEN` in repository secrets. For JS-only PRs, `.github/scripts/eas-resolve-android-build.sh` **reuses** a matching EAS preview APK (fingerprint) or starts one — avoiding duplicate compiles. `eas.json` enables **`EAS_USE_CACHE`** (ccache) on all profiles. Preview profile is internal distribution on channel `preview` (not `developmentClient`).
+Requires `EXPO_TOKEN` in repository secrets. Optional: `PROJECT_BOARD_TOKEN` (PAT with org **project** write) so Status updates on Project 4 succeed — without it, issue comments still post but the board move may be skipped. Each labeled PR forces a new EAS build (`FORCE_NEW_BUILD`) so concurrent QA previews are not collapsed by fingerprint reuse. `eas.json` profile `preview` is internal distribution with Expo Updates **disabled** (same idea as nightly). `EAS_USE_CACHE` (ccache) stays enabled on non-production profiles.
 
 ## Nightly preview (internal APK)
 
 Scheduled (and manually dispatchable) workflow [`.github/workflows/nightly-preview.yml`](workflows/nightly-preview.yml):
 
 - Always starts a **new** EAS Android build with profile **`nightly`** (internal APK, baked `https://dev.api.fluent.bible`).
-- **No OTA** (`eas update` is not used). Expo Updates stay disabled for `nightly` so the APK cannot pull PR `preview` channel updates.
+- **No OTA** (`eas update` is not used). Expo Updates stay disabled for `nightly` so the APK is self-contained.
 - Skips when `main` HEAD matches the last successful nightly unless `force_build` is set.
 - Posts a GitHub Actions job summary and optional Slack notification.
 
@@ -50,8 +50,9 @@ Scheduled (and manually dispatchable) workflow [`.github/workflows/nightly-previ
 
 | Secret | Purpose |
 |--------|---------|
-| `EXPO_TOKEN` | EAS CLI auth (same as PR preview) |
-| `SLACK_WEBHOOK_URL` | Incoming webhook for success / failure / skip notices |
+| `EXPO_TOKEN` | EAS CLI auth (required for PR preview + nightly) |
+| `PROJECT_BOARD_TOKEN` | Optional PAT for Project 4 Status → `In QA` after preview (issue comments work without it) |
+| `SLACK_WEBHOOK_URL` | Incoming webhook for nightly success / failure / skip notices |
 
 Does **not** require the Expo GitHub App — only `EXPO_TOKEN`. Manual run: **Actions → Nightly Preview → Run workflow** (available after this workflow exists on `main`).
 

--- a/.github/scripts/eas-resolve-android-build.sh
+++ b/.github/scripts/eas-resolve-android-build.sh
@@ -6,8 +6,9 @@
 #   PROFILE          — eas.json build profile (required)
 #   MESSAGE          — eas build message (required)
 #   BAKE_VERSION     — optional APP_VERSION_FALLBACK to bake before fingerprint
-#   RUNTIME_VERSION  — optional runtime match fallback (js-only QA install)
+#   RUNTIME_VERSION  — optional runtime match fallback (legacy QA install)
 #   ALLOW_RUNTIME_MATCH — "true" to reuse by runtime when fingerprint differs
+#   FORCE_NEW_BUILD  — "true" to always start a new build (skip fingerprint reuse)
 #   WAIT_FOR_BUILD   — "true" to pass --wait when starting a new build
 #   POLL_IN_PROGRESS — "true" to wait for matching in-progress builds
 
@@ -25,6 +26,7 @@ MESSAGE="${MESSAGE:?MESSAGE is required}"
 BAKE_VERSION="${BAKE_VERSION:-}"
 RUNTIME_VERSION="${RUNTIME_VERSION:-}"
 ALLOW_RUNTIME_MATCH="${ALLOW_RUNTIME_MATCH:-false}"
+FORCE_NEW_BUILD="${FORCE_NEW_BUILD:-false}"
 WAIT_FOR_BUILD="${WAIT_FOR_BUILD:-true}"
 POLL_IN_PROGRESS="${POLL_IN_PROGRESS:-true}"
 MAX_WAIT_IN_PROGRESS_SEC="${MAX_WAIT_IN_PROGRESS_SEC:-1800}"
@@ -75,36 +77,40 @@ match_build() {
 BUILD_ID=""
 INSTALL_SOURCE=""
 
-if [ "${POLL_IN_PROGRESS}" = "true" ]; then
-  IN_PROGRESS_JSON=$(list_builds "in-progress" || echo "[]")
-  IP_BUILD_ID=$(match_build "${IN_PROGRESS_JSON}")
-  if [ -n "${IP_BUILD_ID}" ]; then
-    echo "⏳ Matching build already in progress: ${IP_BUILD_ID}"
-    deadline=$((SECONDS + MAX_WAIT_IN_PROGRESS_SEC))
-    while [ "${SECONDS}" -lt "${deadline}" ]; do
-      status=$(list_builds "in-progress" | jq -r --arg id "${IP_BUILD_ID}" '.[] | select(.id == $id) | .status' | head -n 1)
-      finished=$(list_builds "finished" | jq -r --arg id "${IP_BUILD_ID}" '.[] | select(.id == $id) | .id' | head -n 1)
-      if [ -n "${finished}" ]; then
-        BUILD_ID="${IP_BUILD_ID}"
-        INSTALL_SOURCE="waited"
-        echo "✅ In-progress build finished: ${BUILD_ID}"
-        break
-      fi
-      if [ "${status}" = "ERRORED" ] || [ "${status}" = "CANCELED" ]; then
-        echo "In-progress build ${status}; will start a new one if needed"
-        break
-      fi
-      sleep 30
-    done
+if [ "${FORCE_NEW_BUILD}" = "true" ]; then
+  echo "FORCE_NEW_BUILD=true — skipping fingerprint reuse / in-progress poll"
+else
+  if [ "${POLL_IN_PROGRESS}" = "true" ]; then
+    IN_PROGRESS_JSON=$(list_builds "in-progress" || echo "[]")
+    IP_BUILD_ID=$(match_build "${IN_PROGRESS_JSON}")
+    if [ -n "${IP_BUILD_ID}" ]; then
+      echo "⏳ Matching build already in progress: ${IP_BUILD_ID}"
+      deadline=$((SECONDS + MAX_WAIT_IN_PROGRESS_SEC))
+      while [ "${SECONDS}" -lt "${deadline}" ]; do
+        status=$(list_builds "in-progress" | jq -r --arg id "${IP_BUILD_ID}" '.[] | select(.id == $id) | .status' | head -n 1)
+        finished=$(list_builds "finished" | jq -r --arg id "${IP_BUILD_ID}" '.[] | select(.id == $id) | .id' | head -n 1)
+        if [ -n "${finished}" ]; then
+          BUILD_ID="${IP_BUILD_ID}"
+          INSTALL_SOURCE="waited"
+          echo "✅ In-progress build finished: ${BUILD_ID}"
+          break
+        fi
+        if [ "${status}" = "ERRORED" ] || [ "${status}" = "CANCELED" ]; then
+          echo "In-progress build ${status}; will start a new one if needed"
+          break
+        fi
+        sleep 30
+      done
+    fi
   fi
-fi
 
-if [ -z "${BUILD_ID}" ]; then
-  FINISHED_JSON=$(list_builds "finished" || echo "[]")
-  BUILD_ID=$(match_build "${FINISHED_JSON}")
-  if [ -n "${BUILD_ID}" ]; then
-    INSTALL_SOURCE="existing"
-    echo "✅ Reusing finished build: ${BUILD_ID}"
+  if [ -z "${BUILD_ID}" ]; then
+    FINISHED_JSON=$(list_builds "finished" || echo "[]")
+    BUILD_ID=$(match_build "${FINISHED_JSON}")
+    if [ -n "${BUILD_ID}" ]; then
+      INSTALL_SOURCE="existing"
+      echo "✅ Reusing finished build: ${BUILD_ID}"
+    fi
   fi
 fi
 

--- a/.github/scripts/preview-notify-linked-issues.js
+++ b/.github/scripts/preview-notify-linked-issues.js
@@ -1,0 +1,307 @@
+/**
+ * After a preview-build PR comment is posted, mirror it onto linked GitHub
+ * issues and (best-effort) move those cards to Project 4 Status "In QA".
+ *
+ * Soft-fails: preview success must not fail if issue/board side effects fail.
+ *
+ * Env (optional):
+ *   PROJECT_BOARD_TOKEN — PAT with org project write (preferred for Project 4)
+ *   FLUENT_PROJECT_ID — Projects V2 node id (default: Fluent Project 4)
+ *   FLUENT_STATUS_FIELD_ID — Status field node id
+ *   FLUENT_IN_QA_OPTION_ID — "In QA" single-select option id
+ *
+ * @param {object} args
+ * @param {import('@octokit/rest').Octokit} args.github
+ * @param {import('@actions/github').Context} args.context
+ * @param {{ warning: Function, info: Function }} args.core
+ * @param {string} args.body — same markdown posted on the PR
+ * @param {string[]} args.commentMarkers — substrings that identify prior bot preview comments
+ * @param {typeof import('@actions/github').getOctokit} [args.getOctokit]
+ */
+module.exports = async function notifyLinkedIssues({
+  github,
+  context,
+  core,
+  body,
+  commentMarkers,
+  getOctokit,
+}) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const prNumber = context.payload.pull_request?.number ?? context.issue.number;
+
+  if (!body || typeof body !== 'string') {
+    core.warning('preview-notify-linked-issues: empty body — skipping');
+    return;
+  }
+
+  const issueNumbers = await resolveLinkedIssueNumbers(
+    github,
+    owner,
+    repo,
+    prNumber,
+  );
+  if (issueNumbers.length === 0) {
+    core.info(
+      'No linked issues on this PR — skipping ticket comments / board move',
+    );
+    return;
+  }
+
+  core.info(`Linked issues: ${issueNumbers.map(n => `#${n}`).join(', ')}`);
+
+  for (const issueNumber of issueNumbers) {
+    try {
+      await upsertIssueComment(
+        github,
+        owner,
+        repo,
+        issueNumber,
+        body,
+        commentMarkers,
+      );
+      core.info(`Upserted preview comment on #${issueNumber}`);
+    } catch (error) {
+      core.warning(`Could not comment on #${issueNumber}: ${error.message}`);
+    }
+  }
+
+  try {
+    await moveIssuesToInQa({
+      github,
+      core,
+      getOctokit,
+      owner,
+      repo,
+      issueNumbers,
+    });
+  } catch (error) {
+    core.warning(`Could not update Project 4 Status: ${error.message}`);
+  }
+};
+
+const CLOSING_KEYWORD_RE =
+  /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+
+async function resolveLinkedIssueNumbers(github, owner, repo, prNumber) {
+  const numbers = new Set();
+
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  for (const match of `${pr.title}\n${pr.body || ''}`.matchAll(
+    CLOSING_KEYWORD_RE,
+  )) {
+    numbers.add(Number(match[1]));
+  }
+
+  try {
+    const result = await github.graphql(
+      `
+      query ($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            closingIssuesReferences(first: 50) {
+              nodes { number }
+            }
+          }
+        }
+      }
+    `,
+      { owner, repo, number: prNumber },
+    );
+    for (const node of result.repository?.pullRequest?.closingIssuesReferences
+      ?.nodes || []) {
+      if (node?.number) numbers.add(node.number);
+    }
+  } catch (error) {
+    // closingIssuesReferences may be unavailable; body parse is enough
+    console.log(`closingIssuesReferences lookup failed: ${error.message}`);
+  }
+
+  // Never treat the PR itself as a ticket (same number space)
+  numbers.delete(prNumber);
+  return [...numbers].sort((a, b) => a - b);
+}
+
+async function upsertIssueComment(
+  github,
+  owner,
+  repo,
+  issueNumber,
+  body,
+  commentMarkers,
+) {
+  const { data: comments } = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+
+  const botComments = comments.filter(
+    comment =>
+      comment.user?.login === 'github-actions[bot]' &&
+      commentMarkers.some(marker => comment.body?.includes(marker)),
+  );
+
+  for (const comment of botComments) {
+    try {
+      await github.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: comment.id,
+      });
+    } catch (error) {
+      console.log(
+        `⚠️ Could not delete comment ${comment.id} on #${issueNumber}: ${error.message}`,
+      );
+    }
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+}
+
+const DEFAULT_PROJECT_ID = 'PVT_kwDOB8vK1s4A34c5'; // eten-tech-foundation Project 4 (Fluent)
+const DEFAULT_STATUS_FIELD_ID = 'PVTSSF_lADOB8vK1s4A34c5zgs8akY';
+const DEFAULT_IN_QA_OPTION_ID = 'bb3c3d02';
+
+/** Only move from eng handoff statuses — never Product / terminal columns. */
+const ALLOWED_FROM_STATUS_NAMES = new Set([
+  'In Progress (Dev)',
+  'In PR Review',
+]);
+
+async function moveIssuesToInQa({
+  github,
+  core,
+  getOctokit,
+  owner,
+  repo,
+  issueNumbers,
+}) {
+  const projectId = process.env.FLUENT_PROJECT_ID || DEFAULT_PROJECT_ID;
+  const statusFieldId =
+    process.env.FLUENT_STATUS_FIELD_ID || DEFAULT_STATUS_FIELD_ID;
+  const inQaOptionId =
+    process.env.FLUENT_IN_QA_OPTION_ID || DEFAULT_IN_QA_OPTION_ID;
+
+  const boardGithub = await resolveBoardClient(github, getOctokit, core);
+  if (!boardGithub) return;
+
+  for (const issueNumber of issueNumbers) {
+    try {
+      const item = await findProjectItem(
+        boardGithub,
+        projectId,
+        owner,
+        repo,
+        issueNumber,
+      );
+      if (!item) {
+        core.info(`#${issueNumber} is not on Project 4 — skipping board move`);
+        continue;
+      }
+
+      const currentStatus = item.statusName || '';
+      if (currentStatus === 'In QA') {
+        core.info(`#${issueNumber} already In QA`);
+        continue;
+      }
+      if (!ALLOWED_FROM_STATUS_NAMES.has(currentStatus)) {
+        core.info(
+          `#${issueNumber} Status is "${
+            currentStatus || '(none)'
+          }" — not moving to In QA (allowlist: ${[
+            ...ALLOWED_FROM_STATUS_NAMES,
+          ].join(', ')})`,
+        );
+        continue;
+      }
+
+      await boardGithub.graphql(
+        `
+        mutation ($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+          updateProjectV2ItemFieldValue(
+            input: {
+              projectId: $project
+              itemId: $item
+              fieldId: $field
+              value: { singleSelectOptionId: $option }
+            }
+          ) {
+            projectV2Item { id }
+          }
+        }
+      `,
+        {
+          project: projectId,
+          item: item.itemId,
+          field: statusFieldId,
+          option: inQaOptionId,
+        },
+      );
+      core.info(`Moved #${issueNumber} → In QA (was ${currentStatus})`);
+    } catch (error) {
+      core.warning(`Board move failed for #${issueNumber}: ${error.message}`);
+    }
+  }
+}
+
+async function resolveBoardClient(github, getOctokit, core) {
+  const projectToken = process.env.PROJECT_BOARD_TOKEN;
+  if (projectToken && typeof getOctokit === 'function') {
+    core.info('Using PROJECT_BOARD_TOKEN for Project 4 updates');
+    return getOctokit(projectToken);
+  }
+  if (projectToken) {
+    core.warning(
+      'PROJECT_BOARD_TOKEN is set but getOctokit was not provided — falling back to GITHUB_TOKEN',
+    );
+  } else {
+    core.info(
+      'PROJECT_BOARD_TOKEN unset — attempting Project 4 update with GITHUB_TOKEN (org projects often need a PAT)',
+    );
+  }
+  return github;
+}
+
+async function findProjectItem(github, projectId, owner, repo, issueNumber) {
+  const result = await github.graphql(
+    `
+    query ($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          projectItems(first: 20) {
+            nodes {
+              id
+              project { id }
+              fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+    { owner, repo, number: issueNumber },
+  );
+
+  const match = (result.repository?.issue?.projectItems?.nodes || []).find(
+    node => node.project?.id === projectId,
+  );
+  if (!match) return null;
+  return {
+    itemId: match.id,
+    statusName: match.fieldValueByName?.name || '',
+  };
+}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -10,7 +10,6 @@ concurrency:
 
 env:
   EAS_PROJECT_ID: 'b0919574-f268-4768-b3bd-7cfa5172bbab'
-  EAS_CHANNEL: 'preview'
   APP_SLUG: 'fluent-mobile'
   EXPO_ACCOUNT: 'teamgloo'
   EXPO_PUBLIC_API_BASE_URL: https://dev.api.fluent.bible
@@ -25,6 +24,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      # Project 4 Status updates: prefer secrets.PROJECT_BOARD_TOKEN (org projects)
 
     steps:
       - name: 📋 Checkout repository
@@ -47,59 +47,6 @@ jobs:
 
       - name: 📦 Install dependencies
         run: npm ci
-
-      - name: 🔍 Detect change type
-        id: change-detection
-        run: |
-          set -euo pipefail
-          BASE_REF="origin/${GITHUB_BASE_REF}"
-          CHANGED_FILES=$(git diff --name-only "${BASE_REF}"...HEAD)
-
-          # Config/plugins that require a new Android binary for preview
-          HARD_NATIVE_PATTERNS="(^plugins/|eas\.json)"
-          SOFT_DEP_PATTERNS="(package\.json|package-lock\.json)"
-          NATIVE_DEP_PATTERN='^\+.*"(react-native-|@react-native-|expo-build-properties|expo-dev-client|expo-updates|@op-engineering/)'
-
-          APP_CONFIG_CHANGED=0
-          if echo "$CHANGED_FILES" | grep -q "app\.config\.\(js\|ts\)"; then
-            APP_CONFIG_DIFF=$(git diff "${BASE_REF}"...HEAD app.config.js app.config.ts 2>/dev/null || echo "")
-
-            if echo "$APP_CONFIG_DIFF" | grep -vE "^[+-]const APP_VERSION_FALLBACK" | grep -q "^[+-][^+-]"; then
-              APP_CONFIG_CHANGED=1
-              echo "📝 app.config has native changes (not just version)"
-            else
-              echo "📝 app.config has version-only changes (safe for OTA)"
-            fi
-          fi
-
-          HARD_NATIVE_FILES=$(echo "$CHANGED_FILES" | { grep -E "$HARD_NATIVE_PATTERNS" || true; } | wc -l | tr -d ' ')
-          SOFT_DEP_FILES=$(echo "$CHANGED_FILES" | { grep -E "$SOFT_DEP_PATTERNS" || true; } | wc -l | tr -d ' ')
-
-          CHANGE_TYPE="js-only"
-          if [ "$HARD_NATIVE_FILES" -gt 0 ] || [ "$APP_CONFIG_CHANGED" -eq 1 ]; then
-            CHANGE_TYPE="native"
-          elif [ "$SOFT_DEP_FILES" -gt 0 ]; then
-            PKG_DIFF=$(git diff "${BASE_REF}"...HEAD package.json 2>/dev/null || echo "")
-            if echo "$PKG_DIFF" | grep -qE "$NATIVE_DEP_PATTERN"; then
-              CHANGE_TYPE="native"
-              echo "🔧 Native dependency changes in package.json - Android build required"
-            fi
-          fi
-
-          echo "change_type=${CHANGE_TYPE}" >> $GITHUB_OUTPUT
-          if [ "$CHANGE_TYPE" = "native" ]; then
-            echo "🔧 Native changes detected - Android build required"
-            echo "$CHANGED_FILES" | { grep -E "$HARD_NATIVE_PATTERNS" || true; }
-            if [ "$APP_CONFIG_CHANGED" -eq 1 ]; then
-              echo "  - app.config.ts (native changes)"
-            fi
-          else
-            echo "📱 JS-only changes - OTA update possible"
-            if [ "$SOFT_DEP_FILES" -gt 0 ]; then
-              echo "ℹ️ package.json / package-lock.json changed — using OTA preview"
-              echo "$CHANGED_FILES" | { grep -E "$SOFT_DEP_PATTERNS" || true; }
-            fi
-          fi
 
       - name: 📊 Resolve preview version
         id: preview-version
@@ -128,197 +75,23 @@ jobs:
           echo "PREVIEW_ID=$PREVIEW_ID" >> $GITHUB_OUTPUT
           echo "✅ Preview base version: $BASE_VERSION (ID: $PREVIEW_ID, source: $VERSION_SOURCE)"
 
-      - name: 📥 Ensure QA install app exists (js-only)
-        if: steps.change-detection.outputs.change_type == 'js-only'
-        id: qa-install
-        env:
-          PROFILE: preview
-          MESSAGE: QA install app for runtime ${{ steps.preview-version.outputs.BASE_VERSION }}
-          BAKE_VERSION: ${{ steps.preview-version.outputs.BASE_VERSION }}
-          ALLOW_RUNTIME_MATCH: 'false'
-          WAIT_FOR_BUILD: 'true'
-          POLL_IN_PROGRESS: 'true'
-        run: bash .github/scripts/eas-resolve-android-build.sh
-
-      - name: 🚀 Create Preview OTA Update
-        if: steps.change-detection.outputs.change_type == 'js-only'
-        id: ota-update
-        env:
-          APP_VERSION: ${{ steps.preview-version.outputs.BASE_VERSION }}
-          EAS_UPDATE_CHANNEL: preview
-          PREVIEW_ID: ${{ steps.preview-version.outputs.PREVIEW_ID }}
-          BASE_VERSION: ${{ steps.preview-version.outputs.BASE_VERSION }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          UPDATE_MESSAGE="Preview ${BASE_VERSION} (PR #${PR_NUMBER}): ${PR_TITLE}"
-
-          echo "Creating preview update: $UPDATE_MESSAGE"
-
-          UPDATE_OUTPUT=$(eas update \
-            --branch preview \
-            --message "$UPDATE_MESSAGE" \
-            --json \
-            --non-interactive)
-
-          JSON_ARRAY=$(echo "$UPDATE_OUTPUT" | sed -n '/^\[/,/^\]/p')
-
-          if echo "$JSON_ARRAY" | jq empty 2>/dev/null; then
-            UPDATE_GROUP_ID=$(echo "$JSON_ARRAY" | jq -r '.[0].group')
-            ACTUAL_RUNTIME_VERSION=$(echo "$JSON_ARRAY" | jq -r '.[0].runtimeVersion // empty')
-            echo "✅ Successfully parsed JSON - Group ID: $UPDATE_GROUP_ID"
-          else
-            echo "❌ JSON parsing failed, using fallback method"
-            JSON_ARRAY=$(echo "$UPDATE_OUTPUT" | grep -A 50 '^\[' | grep -B 50 '^\]' | head -n -1)
-            UPDATE_GROUP_ID=$(echo "$JSON_ARRAY" | jq -r '.[0].group // empty')
-            ACTUAL_RUNTIME_VERSION=$(echo "$JSON_ARRAY" | jq -r '.[0].runtimeVersion // empty')
-          fi
-
-          BASE_VERSION="${{ steps.preview-version.outputs.BASE_VERSION }}"
-          RUNTIME_VERSION=${ACTUAL_RUNTIME_VERSION:-$BASE_VERSION}
-
-          echo "UPDATE_GROUP_ID=$UPDATE_GROUP_ID" >> $GITHUB_OUTPUT
-          echo "PREVIEW_ID=${{ steps.preview-version.outputs.PREVIEW_ID }}" >> $GITHUB_OUTPUT
-          echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_OUTPUT
-          echo "RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_OUTPUT
-
-          echo "✅ Preview update completed (Group ID: $UPDATE_GROUP_ID)"
-          sleep 10
-
-      - name: 💬 Post Preview Comment
-        if: steps.change-detection.outputs.change_type == 'js-only'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const updateGroupId = ${{ toJson(steps.ota-update.outputs.UPDATE_GROUP_ID) }};
-            const previewId = ${{ toJson(steps.ota-update.outputs.PREVIEW_ID) }};
-            const baseVersion = ${{ toJson(steps.ota-update.outputs.BASE_VERSION) }};
-            const runtimeVersion = ${{ toJson(steps.ota-update.outputs.RUNTIME_VERSION) }};
-            const projectId = ${{ toJson(env.EAS_PROJECT_ID) }};
-
-            const qaGuideUrl = ${{ toJson(env.QA_GUIDE_URL) }};
-            const installUrl = ${{ toJson(steps.qa-install.outputs.install_url) }};
-            const installSource = ${{ toJson(steps.qa-install.outputs.install_source) }};
-            const fingerprint = ${{ toJson(steps.qa-install.outputs.fingerprint_hash) }};
-            let installNote = '_Already have Fluent on your phone? Skip to Step 2._';
-            if (installSource === 'created') {
-              installNote =
-                '_We built the Fluent install app for you (first time for this version). Step 1 used that build._';
-            } else if (installSource === 'existing' || installSource === 'waited') {
-              installNote =
-                '_Reused an existing Fluent install app from EAS (no new native build needed)._';
-            } else if (!installSource) {
-              installNote =
-                '_Could not auto-resolve an install build — use the link below or ask your team for help._';
-            }
-
-            const body = [
-              '## 📲 Test this PR on your Android phone',
-              '',
-              '**Not Expo Go.** Install the **Fluent preview app** from the link below (internal APK — not a dev/Metro build).',
-              '',
-              `**Preview ID:** \`${previewId}\` · **Runtime version:** \`${runtimeVersion}\``,
-              '',
-              `**Need help?** [Step-by-step guide for non-technical testers](${qaGuideUrl})`,
-              '',
-              '---',
-              '',
-              '### Step 1 — Install Fluent (first time only)',
-              '',
-              installNote,
-              '',
-              'On your **Android phone**, tap:',
-              '',
-              `### 👉 [Install Fluent](${installUrl})`,
-              '',
-              '1. Sign in to [expo.dev](https://expo.dev) if asked (your team lead can invite you).',
-              '2. Tap **Download** or **Install** when the build page opens.',
-              '3. If Android blocks it: **Settings → Install unknown apps** → allow your browser.',
-              '4. Open **Fluent** from your home screen — it should open the app normally (not a Metro/dev launcher).',
-              '',
-              '---',
-              '',
-              '### Step 2 — Open this PR preview',
-              '',
-              'After Step 1 (or if Fluent is already installed), open **Fluent** from your home screen.',
-              '',
-              'The preview app downloads this PR\'s update from the `preview` channel over Wi‑Fi (may take a minute).',
-              '',
-              '### After the preview loads',
-              '',
-              '- Sign in and test this PR.',
-              '- If nothing changed, fully close Fluent (swipe it away) and reopen it.',
-              '',
-              '### Details',
-              '',
-              '| | |',
-              '|---|---|',
-              `| Preview ID | \`${previewId}\` |`,
-              `| Base version | \`${baseVersion}\` |`,
-              '| Channel | `preview` |',
-              `| Runtime version | \`${runtimeVersion}\` |`,
-              `| Install build | \`${installSource || 'unknown'}\` |`,
-              ...(fingerprint
-                ? [`| Fingerprint | \`${fingerprint.slice(0, 12)}…\` |`]
-                : []),
-              `| Commit | \`${{ github.event.pull_request.head.sha }}\` |`,
-              '',
-              '### Links',
-              '',
-              `- [Expo update dashboard](https://expo.dev/projects/${projectId}/updates/${updateGroupId})`,
-              `- [PR #${{ github.event.pull_request.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }})`,
-              '',
-              '---',
-              '*OTA preview only — not a Play Store release. If this PR changed native code (`app.config.ts`, plugins, or native dependencies), use the **Android preview APK** comment instead.*',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComments = comments.filter(comment =>
-              comment.user.login === 'github-actions[bot]' &&
-              (comment.body.includes('📲 Test this PR on your Android phone') ||
-               comment.body.includes('📲 Preview update ready') ||
-               comment.body.includes('📲 Preview Build Ready!'))
-            );
-
-            for (const comment of botComments) {
-              try {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: comment.id,
-                });
-              } catch (error) {
-                console.log(`⚠️ Could not delete comment ${comment.id}: ${error.message}`);
-              }
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
-            });
-
-      - name: 🚀 Resolve or start Android preview build
-        if: steps.change-detection.outputs.change_type == 'native'
+      # Always a fresh binary APK (no OTA). Fingerprint reuse would miss JS-only PR
+      # diffs, and a shared Updates channel would overwrite concurrent QA builds.
+      - name: 🚀 Start Android preview build
         id: native-builds
         env:
           PROFILE: preview
           MESSAGE: Preview ${{ steps.preview-version.outputs.BASE_VERSION }} - PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
           BAKE_VERSION: ${{ steps.preview-version.outputs.BASE_VERSION }}
-          ALLOW_RUNTIME_MATCH: 'false'
+          FORCE_NEW_BUILD: 'true'
           WAIT_FOR_BUILD: 'true'
-          POLL_IN_PROGRESS: 'true'
+          POLL_IN_PROGRESS: 'false'
         run: bash .github/scripts/eas-resolve-android-build.sh
 
-      - name: 💬 Post Native Preview Comment
-        if: steps.change-detection.outputs.change_type == 'native'
+      - name: 💬 Post Preview Comment
         uses: actions/github-script@v9
+        env:
+          PROJECT_BOARD_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN }}
         with:
           script: |
             const androidId = ${{ toJson(steps.native-builds.outputs.build_id) }};
@@ -332,13 +105,10 @@ jobs:
             const installQrUrl = `https://quickchart.io/qr?size=256&margin=2&text=${encodeURIComponent(installUrl)}`;
 
             let buildNote =
-              '_A new Fluent preview app was built for this PR. Install it once, then test._';
-            if (installSource === 'existing') {
+              '_A new Fluent preview APK was built for this PR (binary only — no OTA). Install it, then test._';
+            if (installSource === 'created') {
               buildNote =
-                '_Reused an existing Fluent preview app from EAS (same native fingerprint — no new compile)._';
-            } else if (installSource === 'waited') {
-              buildNote =
-                '_Waited for an in-progress EAS build with the same fingerprint to finish._';
+                '_Fresh preview APK for this PR commit. Install it once, then open Fluent and test._';
             }
 
             const body = [
@@ -348,7 +118,7 @@ jobs:
               '',
               `**Preview ID:** \`${previewId}\` · **App version:** \`${baseVersion}\``,
               '',
-              'This PR changed **native** code (`app.config.ts`, plugins, or native dependencies), so you need this **preview APK** — not an OTA-only update.',
+              'This is a **standalone preview APK** for this PR (no over-the-air update). Each labeled PR gets its own build so multiple QA previews can exist at once.',
               '',
               buildNote,
               '',
@@ -366,7 +136,7 @@ jobs:
               '2. Tap **Download** or **Install** when the build page opens.',
               '3. If Android blocks it: **Settings → Install unknown apps** → allow your browser.',
               '4. Open **Fluent** from your home screen — it should open the app normally (not a Metro/dev launcher).',
-              '5. Sign in and test this PR. Future **JS-only** PR previews download over the air without reinstalling until the app version changes again.',
+              '5. Sign in and test this PR. Reinstall from a newer preview comment when testing a different PR (one Fluent install at a time).',
               '',
               '**Or scan this QR code** (opens the same install page):',
               '',
@@ -393,8 +163,18 @@ jobs:
               `- [PR #${{ github.event.pull_request.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }})`,
               '',
               '---',
-              `*Native preview APK (\`${baseVersion}\`, ID: \`${previewId}\`). Android only.*`,
+              `*Binary preview APK (\`${baseVersion}\`, ID: \`${previewId}\`). Android only — no OTA.*`,
             ].join('\n');
+
+            const commentMarkers = [
+              '📲 Test this PR on your Android phone',
+              '📲 Preview update ready',
+              '📲 Preview Build Ready!',
+              '🔧 Fluent preview app building',
+              '✅ Fluent preview app ready',
+              '🔧 Android Preview Build Started!',
+              'Android Preview Build Started!',
+            ];
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -404,13 +184,7 @@ jobs:
 
             const botComments = comments.filter(comment =>
               comment.user.login === 'github-actions[bot]' &&
-              (comment.body.includes('📲 Test this PR on your Android phone') ||
-               comment.body.includes('📲 Preview update ready') ||
-               comment.body.includes('📲 Preview Build Ready!') ||
-               comment.body.includes('🔧 Fluent preview app building') ||
-               comment.body.includes('✅ Fluent preview app ready') ||
-               comment.body.includes('🔧 Android Preview Build Started!') ||
-               comment.body.includes('Android Preview Build Started!'))
+              commentMarkers.some(marker => comment.body.includes(marker))
             );
 
             for (const comment of botComments) {
@@ -431,3 +205,6 @@ jobs:
               issue_number: context.issue.number,
               body: body
             });
+
+            const notifyLinkedIssues = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/preview-notify-linked-issues.js`);
+            await notifyLinkedIssues({ github, context, core, getOctokit, body, commentMarkers });

--- a/README.md
+++ b/README.md
@@ -354,8 +354,8 @@ One-time setup (Expo GitHub app, Play credentials, workflow permissions): see [`
 
 ## PR preview (QA)
 
-Add the **`preview-build`** label to a pull request to publish a preview OTA update (JS-only changes) or start an Android EAS preview APK (native/config changes). Requires `EXPO_TOKEN` in GitHub Actions secrets.
+Add the **`preview-build`** label to a pull request to start a **fresh Android preview APK** (binary only — no OTA). Requires `EXPO_TOKEN` in GitHub Actions secrets.
 
-**QA / non-technical testers:** [How to test a PR preview](docs/guides/qa-preview-testing.md) — install the **Fluent preview APK**, then open the app (not Expo Go or Metro dev builds).
+**QA / non-technical testers:** [How to test a PR preview](docs/guides/qa-preview-testing.md) — install the **Fluent preview APK** and open the app (not Expo Go or Metro dev builds).
 
 **Developers:** [`.github/README.md`](.github/README.md) · [`.eas/README.md`](.eas/README.md)

--- a/app.config.ts
+++ b/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from 'expo/config';
 
 const EAS_PROJECT_ID = 'b0919574-f268-4768-b3bd-7cfa5172bbab';
 
-// Bumped by release/preview CI before EAS builds; OTA may set APP_VERSION on the runner
+// Bumped by release/preview CI before EAS builds
 const APP_VERSION_FALLBACK = '1.0.0';
 
 function resolveAppVersion(): string {
@@ -17,11 +17,9 @@ const appVersion = resolveAppVersion();
 
 const buildProfile = process.env.EAS_BUILD_PROFILE;
 const usesCleartextTraffic = buildProfile !== 'production';
-// OTA updates apply to EAS preview/production only. Local, development, and
-// nightly builds keep updates disabled (nightly ships a self-contained APK).
-// Checking u.expo.dev on launch crashes when no bundle exists.
-const updatesEnabled =
-  buildProfile === 'preview' || buildProfile === 'production';
+// Expo Updates only for production. Preview / nightly / development ship
+// self-contained APKs so concurrent QA builds are not overwritten by a shared channel.
+const updatesEnabled = buildProfile === 'production';
 
 const config: ExpoConfig = {
   name: 'Fluent',
@@ -36,9 +34,6 @@ const config: ExpoConfig = {
   updates: {
     url: `https://u.expo.dev/${EAS_PROJECT_ID}`,
     enabled: updatesEnabled,
-    ...(buildProfile === 'preview'
-      ? { requestHeaders: { 'expo-channel-name': 'preview' } }
-      : {}),
   },
   runtimeVersion: {
     policy: 'appVersion',

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -98,7 +98,7 @@ Run from repo root after `npm install`:
 
 ## Production release (Android)
 
-Tag-driven production releases — no iOS. PR previews use OTA on the `preview` channel (see below).
+Tag-driven production releases — no iOS. PR previews are binary Android APKs (see below).
 
 1. Merge release changes to `main`.
 2. Tag and push: `git tag v1.0.1 && git push origin v1.0.1`
@@ -112,12 +112,12 @@ Setup and troubleshooting: [`.eas/README.md`](../.eas/README.md).
 1. Add the **`preview-build`** label to the PR (uses latest git tag, or `app.config.ts` version if none).
 2. Workflow and build resolution:
    - **`runtimeVersion`:** `app.config.ts` sets **`runtimeVersion: { policy: 'appVersion' }`**.
-   - **`preview-build.yml`:** [`.github/workflows/preview-build.yml`](../.github/workflows/preview-build.yml) publishes a preview OTA (JS-only) or starts an Android EAS `preview` internal APK (native/config); uses [`.github/scripts/eas-resolve-android-build.sh`](../.github/scripts/eas-resolve-android-build.sh) for fingerprint match, in-progress poll, and reuse.
+   - **`preview-build.yml`:** [`.github/workflows/preview-build.yml`](../.github/workflows/preview-build.yml) starts a **fresh** Android EAS `preview` internal APK for that PR (binary only — no OTA); uses [`.github/scripts/eas-resolve-android-build.sh`](../.github/scripts/eas-resolve-android-build.sh) with `FORCE_NEW_BUILD=true`.
    - **`.fingerprintignore`:** excludes `docs/**/*` and `.github/**/*` (among other non-native paths) from EAS build fingerprint hashing.
    - **`eas.json` / production skip:** `preview` and `development` set **`EAS_USE_CACHE: "1"`**; `production` sets **`EAS_SAVE_CACHE: "1"`** and **`EAS_RESTORE_CACHE: "0"`** (save cache only, no restore). [`.eas/workflows/create-production-builds.yml`](../.eas/workflows/create-production-builds.yml) skips rebuild when fingerprint matches (`if: !needs.get_android_build.outputs.build_id`).
 3. The bot comment links to **[`docs/guides/qa-preview-testing.md`](guides/qa-preview-testing.md)** for non-technical testers (Fluent preview app — **not Expo Go** or Metro dev builds).
 
-Requires `EXPO_TOKEN` in GitHub repository secrets. Preview builds use `eas.json` profile `preview` (internal distribution, channel `preview` — no `developmentClient`; `EXPO_PUBLIC_API_BASE_URL=https://dev.api.fluent.bible`). Local `.env` keeps emulator localhost; `dev.app.fluent.bible` is the web app, not the mobile API host. Local/engineering builds use profile `development` (`developmentClient: true`).
+Requires `EXPO_TOKEN` in GitHub repository secrets. Preview builds use `eas.json` profile `preview` (internal distribution, Expo Updates **disabled** — no `developmentClient`; `EXPO_PUBLIC_API_BASE_URL=https://dev.api.fluent.bible`). Local `.env` keeps emulator localhost; `dev.app.fluent.bible` is the web app, not the mobile API host. Local/engineering builds use profile `development` (`developmentClient: true`).
 
 ## Architecture and data flow
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,7 +9,7 @@ This repo runs GitHub Actions on pushes and pull requests. This doc maps what ru
 | `lint.yml` | `Lint & Format` | ESLint + Prettier (`format:check`) |
 | `test.yml` | `Unit Tests` | Jest (`npm test -- --ci`) |
 | `quality-gates.yml` | `TypeScript`, `expo-doctor`, `expo install --check` | Typecheck + Expo SDK / native-module alignment |
-| `preview-build.yml` | Preview OTA / Android EAS | On-demand when PR has label `preview-build` |
+| `preview-build.yml` | Android EAS preview APK | On-demand when PR has label `preview-build` — binary only (no OTA); comments PR **and** linked issues; best-effort Project 4 → `In QA` |
 | `nightly-preview.yml` | Nightly Android APK | Scheduled binary-only internal APK (dev API); also `workflow_dispatch` |
 | `eas-build.yml` | Tag → version sync | Production release path on `v*` tags |
 
@@ -40,7 +40,8 @@ Branch protection / required status checks may change over time. Treat the table
 
 ## Preview / native compile
 
-- JS-only preview OTA vs native Android APK is decided by `preview-build.yml` + [`.github/scripts/eas-resolve-android-build.sh`](../.github/scripts/eas-resolve-android-build.sh)
+- Preview APKs: `preview-build.yml` + [`.github/scripts/eas-resolve-android-build.sh`](../.github/scripts/eas-resolve-android-build.sh) with `FORCE_NEW_BUILD=true` (no fingerprint reuse; no OTA)
+- After a successful preview comment, [`.github/scripts/preview-notify-linked-issues.js`](../.github/scripts/preview-notify-linked-issues.js) upserts the same body on linked issues and may move Project 4 Status to `In QA` (optional `PROJECT_BOARD_TOKEN`)
 - Human QA steps: [guides/qa-preview-testing.md](guides/qa-preview-testing.md)
 - Nightly internal APK (no OTA): `nightly-preview.yml` + EAS profile `nightly` — see [`.github/README.md`](../.github/README.md)
 - Production: tag `v*` → `eas-build.yml` + [`.eas/README.md`](../.eas/README.md)

--- a/docs/guides/qa-preview-testing.md
+++ b/docs/guides/qa-preview-testing.md
@@ -1,29 +1,26 @@
 # How to test a Fluent Mobile PR preview (Android)
 
-Plain-language guide for QA and reviewers. **No developer tools** — just an Android phone and the GitHub PR comment.
+Plain-language guide for QA and reviewers. **No developer tools** — just an Android phone and the GitHub **PR or issue** comment.
 
-## Quick start (2 steps)
+## Quick start
 
-Every preview PR comment from GitHub Actions has **two steps**. Use them in order:
-
-| Step | What to do | Link in PR comment |
-|------|------------|-------------------|
-| **1** | Install **Fluent** on your phone (one-time per app version) | **Install Fluent** |
-| **2** | Open **Fluent** from your home screen to load the preview | _(no link — open the app)_ |
+1. Open the bot comment on the **pull request** or the **linked GitHub issue**.
+2. Tap **Install Fluent** (or scan the QR code).
+3. Open **Fluent** from your home screen and test.
 
 **Do not use Expo Go** from the Play Store — it will not work.
 
-The preview app is an **internal APK** (like a pre-release build). It is **not** a developer build that connects to Metro or localhost.
+The preview is a **standalone internal APK** for that PR (no over-the-air update). Each labeled PR gets its own build so multiple QA previews can exist at once. On one phone you can only have one Fluent install — reinstall when switching PRs.
+
+When the preview is ready, the ticket usually moves to **In QA** on the Fluent Mobile Board.
 
 ---
 
-## Step 1 — Install Fluent (first time only)
+## Install Fluent
 
-Skip this if **Fluent** is already on your phone and previews have worked before.
-
-1. On your **Android phone**, open the pull request on GitHub.
-2. Find the bot comment (starts with **“Test this PR on your Android phone”** or **“Fluent preview app ready”**).
-3. Tap **Install Fluent** (or scan the install QR code on native-preview comments).
+1. On your **Android phone**, open the pull request **or** the linked issue on GitHub.
+2. Find the bot comment (starts with **“Fluent preview app ready”**).
+3. Tap **Install Fluent** (or scan the install QR code).
 4. Sign in to [expo.dev](https://expo.dev) if asked — ask your team lead for an invite if needed.
 5. Tap **Download** or **Install** on the build page.
 6. If Android blocks the install:
@@ -31,21 +28,14 @@ Skip this if **Fluent** is already on your phone and previews have worked before
    - Allow your **browser** or **Files** app to install APKs
 7. Open **Fluent** from your home screen.
 8. The app should open normally (sign-in / home) — **not** a Metro dev launcher and **not** Expo Go.
+9. Sign in and test the PR.
 
-**First preview on a new version?** The workflow may build this install app for you automatically (~15 minutes). Refresh the PR comment when GitHub Actions finishes.
+Builds often take ~10–15 minutes. Refresh the bot comment when GitHub Actions finishes.
 
----
+If the app looks wrong after installing a different PR’s preview:
 
-## Step 2 — Open this PR’s preview
-
-1. Open **Fluent** from your home screen (use Wi‑Fi if possible).
-2. Wait for the preview update to download (often under a minute after Step 1).
-3. Sign in and test the PR.
-
-If the app looks unchanged:
-
-1. Fully close Fluent (swipe it away from recent apps).
-2. Reopen Fluent and wait on the home/splash screen.
+1. Uninstall Fluent (or install over it from the new **Install Fluent** link).
+2. Fully close Fluent (swipe it away from recent apps) and reopen.
 
 ---
 
@@ -53,25 +43,8 @@ If the app looks unchanged:
 
 | App | Works? |
 |-----|--------|
-| **Fluent** (from **Install Fluent** link in PR) | ✅ Yes |
+| **Fluent** (from **Install Fluent** link) | ✅ Yes |
 | **Expo Go** (Play Store) | ❌ No |
-
----
-
-## Two kinds of preview comments
-
-### 📲 “Test this PR on your Android phone” (most PRs)
-
-- **Step 1** installs the Fluent preview app (or reuses an existing install).
-- **Step 2** opens Fluent — the app pulls a small over-the-air (OTA) update from the `preview` channel.
-- Usually ready in a few minutes (longer the very first time if the install app had to be built).
-
-### ✅ “Fluent preview app ready” (native changes)
-
-- The PR changed something that needs a **new full app install**.
-- Use the **Install Fluent** link (or QR) in that comment.
-- Open Fluent and test — the APK already includes this PR’s native changes.
-- Later **JS-only** PRs can use OTA again until the app version changes.
 
 ---
 
@@ -79,24 +52,27 @@ If the app looks unchanged:
 
 | Problem | What to try |
 |--------|-------------|
-| I don’t have Fluent yet | Use **Step 1 — Install Fluent** in the PR comment first. |
-| App shows Metro / localhost / dev launcher | Wrong build type installed. Reinstall from the latest **Install Fluent** link on the PR (old dev-client APK). |
+| I don’t have Fluent yet | Tap **Install Fluent** in the bot comment. |
+| App shows Metro / localhost / dev launcher | Wrong build type. Reinstall from the latest **Install Fluent** link (old dev-client APK). |
 | Phone offers **Expo Go** | Cancel. Install **Fluent** from the **Install Fluent** link. |
-| “Unable to load update” | Your Fluent app may be the wrong version. Tap **Install Fluent** in the comment again (or wait for a **native preview** comment on the PR). |
-| Install blocked | Allow **Install unknown apps** for your browser (Step 1). |
-| No bot comment on PR | Ask a developer to add the **`preview-build`** label. |
+| Testing the wrong PR | Install again from that PR’s (or issue’s) latest bot comment. |
+| Install blocked | Allow **Install unknown apps** for your browser. |
+| No bot comment on PR or issue | Ask a developer to add the **`preview-build`** label (and ensure the PR has `Closes #NNN`). |
 | expo.dev asks me to log in | Request access to the Fluent project from your team lead. |
 
 ---
 
 ## For developers
 
-1. Add the **`preview-build`** label to the PR.
-2. Share this guide with QA: `docs/guides/qa-preview-testing.md`
-3. Preview APKs use the EAS `preview` profile (internal distribution, `preview` channel — **not** `developmentClient`).
+1. Link the ticket in the PR body (`Closes #NNN`).
+2. Add the **`preview-build`** label to the PR.
+3. Workflow starts a **fresh Android preview APK** (binary only — no OTA), comments on the **PR and linked issue**, and moves the ticket to **In QA** when Status was `In PR Review` or `In Progress (Dev)`.
+4. Share this guide with QA: `docs/guides/qa-preview-testing.md`
+5. Preview APKs use the EAS `preview` profile (internal distribution, Updates disabled — **not** `developmentClient`).
+6. Optional repo secret `PROJECT_BOARD_TOKEN` enables Project 4 Status updates (issue comments work without it).
 
 ### Nightly builds (optional)
 
-Separate from PR previews: GitHub Actions can publish a **nightly Android APK** (EAS profile `nightly`, development API). Install from the Slack message or the Actions job summary — **not** from a PR comment. Nightlies are **binary only** (no over-the-air update). See [`.github/README.md`](../../.github/README.md).
+Separate from PR previews: GitHub Actions can publish a **nightly Android APK** (EAS profile `nightly`, development API). Install from the Slack message or the Actions job summary — **not** from a PR comment. Nightlies are **binary only**. See [`.github/README.md`](../../.github/README.md).
 
 Technical details: [`.github/README.md`](../../.github/README.md) · [`.eas/README.md`](../../.eas/README.md)

--- a/eas.json
+++ b/eas.json
@@ -23,10 +23,8 @@
     "preview": {
       "extends": "base",
       "distribution": "internal",
-      "channel": "preview",
       "env": {
         "EAS_USE_CACHE": "1",
-        "EAS_UPDATE_CHANNEL": "preview",
         "EXPO_PUBLIC_API_BASE_URL": "https://dev.api.fluent.bible"
       },
       "android": {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -125,4 +125,12 @@ export default [
       'no-restricted-syntax': 'off',
     },
   },
+  {
+    // GitHub Actions / Node scripts — env secrets and console logging are intentional
+    files: ['.github/scripts/**/*.{js,cjs,mjs}'],
+    rules: {
+      'no-console': 'off',
+      'no-restricted-syntax': 'off',
+    },
+  },
 ];


### PR DESCRIPTION
### TLDR

PR preview builds are now **binary-only Android APKs** (no shared OTA channel), so multiple QA previews can exist at once. After a successful preview, the same install comment is posted on linked GitHub issues, and Project 4 cards in `In PR Review` / `In Progress (Dev)` move to **`In QA`**.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Closes #NNN` when this PR completes it)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Closes #289

Always start a fresh EAS `preview` APK (`FORCE_NEW_BUILD`), disable Expo Updates on the preview profile, mirror the bot install comment onto linked tickets, and best-effort move those cards to `In QA`.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Maintenance / refactor

#### Technical changes

- `.github/workflows/preview-build.yml` — remove JS-only OTA path; always native APK + comment + linked-issue notify
- `.github/scripts/preview-notify-linked-issues.js` — upsert issue comments; Project 4 Status → `In QA` allowlist
- `.github/scripts/eas-resolve-android-build.sh` — add `FORCE_NEW_BUILD` to skip fingerprint reuse
- `app.config.ts` / `eas.json` — Expo Updates only for production; drop preview channel / update env
- `docs/guides/qa-preview-testing.md`, `.github/README.md`, `.eas/README.md`, `docs/ci.md`, `docs/AGENT_ONBOARDING.md`, `README.md`
- `eslint.config.js` — allow `process.env` / console in `.github/scripts`

#### Testing

- `npm run format:check` — pass
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run typecheck` — pass
- `npm test -- --ci` — 417 passed, 1 skipped

### How to verify

1. Run `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`.
2. Open a test PR that has `Closes #<ticket>` in the body, add the `preview-build` label, and wait for the workflow.
3. Confirm the bot posts the same install comment on the **PR and the linked issue**.
4. Confirm the linked Project 4 card moves to **In QA** when it was `In PR Review` or `In Progress (Dev)` (needs `PROJECT_BOARD_TOKEN` for org project write; issue comments still work without it).
5. Confirm no `eas update` / OTA steps run in the Actions log — only a new Android APK.

**Expected:** Fresh binary preview APK per labeled PR; mirrored ticket comment; safe `In QA` board move; docs match binary-only flow.

### Follow-ups

- [ ] Add repo secret `PROJECT_BOARD_TOKEN` (PAT with org project write) if Project 4 Status updates fail with `GITHUB_TOKEN` alone