### PR TITLE
[#52]: Build Prepare for Offline download controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,10 @@ import {
   startUploadOrchestrator,
   stopUploadOrchestrator,
 } from './src/services/uploadOrchestrator';
+import {
+  startDownloadQueueAutoResume,
+  stopDownloadQueueAutoResume,
+} from './src/services/downloadQueueAutoResume';
 import { registerRecordingUploadWorker } from './src/services/recordingSync';
 import { queryClient } from './src/services/queryClient';
 import { appStyles } from './src/app/appStyles';
@@ -87,8 +91,10 @@ function App() {
     }
 
     startUploadOrchestrator();
+    const stopAutoResume = startDownloadQueueAutoResume();
     return () => {
       stopUploadOrchestrator();
+      stopDownloadQueueAutoResume(stopAutoResume);
     };
   }, [dbReady, isAuthenticated]);
 

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -99,6 +99,11 @@ jest.mock('../src/services/uploadOrchestrator', () => ({
   setChapterUploadWorker: jest.fn(),
 }));
 
+jest.mock('../src/services/downloadQueueAutoResume', () => ({
+  startDownloadQueueAutoResume: jest.fn(() => jest.fn()),
+  stopDownloadQueueAutoResume: jest.fn(),
+}));
+
 jest.mock('../src/services/recordingSync', () => ({
   registerRecordingUploadWorker: jest.fn(),
 }));

--- a/src/app/prepare-offline/PrepareOfflineDownloadFooter.test.tsx
+++ b/src/app/prepare-offline/PrepareOfflineDownloadFooter.test.tsx
@@ -9,24 +9,29 @@ jest.mock('lucide-react-native', () => {
   return {
     CircleCheck: MockIcon,
     Download: MockIcon,
+    Pause: MockIcon,
+    Play: MockIcon,
+    X: MockIcon,
   };
 });
 
 describe('PrepareOfflineDownloadFooter', () => {
   const defaultProps = {
     totalBytes: 338 * 1024 * 1024,
-    pendingBytes: 164 * 1024 * 1024,
     canDownload: true,
     downloadButtonLabel: 'Download 164 MB',
-    downloadStarted: false,
+    session: 'idle' as const,
     onDownload: jest.fn(),
+    onPause: jest.fn(),
+    onResume: jest.fn(),
+    onCancel: jest.fn(),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('updates total row and download label', () => {
+  it('updates total row and download label in idle session', () => {
     render(
       <PrepareOfflineDownloadFooter
         {...defaultProps}
@@ -72,41 +77,57 @@ describe('PrepareOfflineDownloadFooter', () => {
     expect(onDownload).not.toHaveBeenCalled();
   });
 
-  it('shows started placeholder after download begins', () => {
+  it('shows pause and cancel controls while downloading', () => {
+    render(
+      <PrepareOfflineDownloadFooter {...defaultProps} session="downloading" />,
+    );
+
+    expect(
+      screen.getByTestId('prepare-offline-download-controls-downloading'),
+    ).toBeTruthy();
+    expect(screen.getByTestId('prepare-offline-download-pause')).toBeTruthy();
+    expect(screen.getByTestId('prepare-offline-download-cancel')).toBeTruthy();
+    expect(screen.queryByTestId('prepare-offline-download-button')).toBeNull();
+    expect(screen.getByTestId('prepare-offline-total-bytes')).toHaveTextContent(
+      '338 MB',
+    );
+    expect(screen.queryByTestId('prepare-offline-remaining-bytes')).toBeNull();
+  });
+
+  it('shows resume and cancel controls while paused', () => {
+    render(<PrepareOfflineDownloadFooter {...defaultProps} session="paused" />);
+
+    expect(
+      screen.getByTestId('prepare-offline-download-controls-paused'),
+    ).toBeTruthy();
+    expect(screen.getByTestId('prepare-offline-download-resume')).toBeTruthy();
+    expect(screen.getByTestId('prepare-offline-download-cancel')).toBeTruthy();
+  });
+
+  it('disables controls while busy', () => {
     render(
       <PrepareOfflineDownloadFooter
         {...defaultProps}
-        downloadStarted
-        pendingBytes={164 * 1024 * 1024}
+        session="downloading"
+        busy
       />,
     );
 
-    expect(screen.getByTestId('prepare-offline-download-started')).toBeTruthy();
     expect(
-      screen.getByText(
-        'Download started. Pause, resume, and cancel controls are coming soon.',
-      ),
-    ).toBeTruthy();
-    expect(screen.queryByTestId('prepare-offline-download-button')).toBeNull();
-    expect(
-      screen.queryByTestId('prepare-offline-download-complete'),
-    ).toBeNull();
+      screen.getByTestId('prepare-offline-download-pause').props
+        .accessibilityState?.disabled,
+    ).toBe(true);
   });
 
-  it('shows complete feedback when the simulated download finishes', () => {
+  it('shows complete feedback when session is complete', () => {
     render(
-      <PrepareOfflineDownloadFooter
-        {...defaultProps}
-        downloadStarted
-        pendingBytes={0}
-      />,
+      <PrepareOfflineDownloadFooter {...defaultProps} session="complete" />,
     );
 
     expect(
       screen.getByTestId('prepare-offline-download-complete'),
     ).toBeTruthy();
     expect(screen.getByText('Download complete')).toBeTruthy();
-    expect(screen.queryByTestId('prepare-offline-download-started')).toBeNull();
     expect(screen.queryByTestId('prepare-offline-download-button')).toBeNull();
   });
 });

--- a/src/app/prepare-offline/PrepareOfflineDownloadFooter.tsx
+++ b/src/app/prepare-offline/PrepareOfflineDownloadFooter.tsx
@@ -1,28 +1,48 @@
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { CircleCheck, Download } from 'lucide-react-native';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import {
+  CircleCheck,
+  Download,
+  Pause,
+  Play,
+  X,
+  type LucideIcon,
+} from 'lucide-react-native';
 import { formatByteSize } from '../../utils/formatByteSize';
 import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
+import type { PrepareOfflineDownloadSession } from '../../hooks/usePrepareOfflineDownload';
 
 interface PrepareOfflineDownloadFooterProps {
   totalBytes: number;
-  pendingBytes: number;
   canDownload: boolean;
   downloadButtonLabel: string;
-  downloadStarted: boolean;
+  session: PrepareOfflineDownloadSession;
+  busy?: boolean;
   onDownload: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onCancel: () => void;
 }
 
 export function PrepareOfflineDownloadFooter({
   totalBytes,
-  pendingBytes,
   canDownload,
   downloadButtonLabel,
-  downloadStarted,
+  session,
+  busy = false,
   onDownload,
+  onPause,
+  onResume,
+  onCancel,
 }: PrepareOfflineDownloadFooterProps) {
-  const downloadComplete = downloadStarted && pendingBytes === 0;
-  const downloadInProgress = downloadStarted && pendingBytes > 0;
+  const disabled = busy;
 
   return (
     <View style={styles.footer} testID="prepare-offline-download-footer">
@@ -33,7 +53,7 @@ export function PrepareOfflineDownloadFooter({
         </Text>
       </View>
 
-      {downloadComplete ? (
+      {session === 'complete' ? (
         <View
           style={styles.completeRow}
           testID="prepare-offline-download-complete"
@@ -45,13 +65,47 @@ export function PrepareOfflineDownloadFooter({
           />
           <Text style={styles.completeText}>Download complete</Text>
         </View>
-      ) : downloadInProgress ? (
-        <Text
-          style={styles.startedHint}
-          testID="prepare-offline-download-started"
+      ) : session === 'downloading' ? (
+        <View
+          style={styles.controlsColumn}
+          testID="prepare-offline-download-controls-downloading"
         >
-          Download started. Pause, resume, and cancel controls are coming soon.
-        </Text>
+          <FooterActionButton
+            label="Pause"
+            Icon={Pause}
+            disabled={disabled}
+            onPress={onPause}
+            testID="prepare-offline-download-pause"
+          />
+          <FooterActionButton
+            label="Cancel"
+            Icon={X}
+            disabled={disabled}
+            onPress={onCancel}
+            testID="prepare-offline-download-cancel"
+          />
+        </View>
+      ) : session === 'paused' ? (
+        <View
+          style={styles.controlsColumn}
+          testID="prepare-offline-download-controls-paused"
+        >
+          <FooterActionButton
+            label="Resume"
+            Icon={Play}
+            variant="primary"
+            disabled={disabled}
+            onPress={onResume}
+            testID="prepare-offline-download-resume"
+          />
+          <FooterActionButton
+            label="Cancel"
+            Icon={X}
+            disabled={disabled}
+            onPress={onCancel}
+            testID="prepare-offline-download-cancel"
+          />
+        </View>
       ) : (
         <TouchableOpacity
           style={[
@@ -59,9 +113,9 @@ export function PrepareOfflineDownloadFooter({
             !canDownload && styles.downloadButtonDisabled,
           ]}
           onPress={onDownload}
-          disabled={!canDownload}
+          disabled={!canDownload || disabled}
           accessibilityRole="button"
-          accessibilityState={{ disabled: !canDownload }}
+          accessibilityState={{ disabled: !canDownload || disabled }}
           testID="prepare-offline-download-button"
         >
           <Download
@@ -84,6 +138,58 @@ export function PrepareOfflineDownloadFooter({
         </TouchableOpacity>
       )}
     </View>
+  );
+}
+
+interface FooterActionButtonProps {
+  label: string;
+  Icon: LucideIcon;
+  variant?: 'primary' | 'secondary';
+  disabled?: boolean;
+  onPress: () => void;
+  testID?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+function FooterActionButton({
+  label,
+  Icon,
+  variant = 'secondary',
+  disabled,
+  onPress,
+  testID,
+}: FooterActionButtonProps) {
+  const isPrimary = variant === 'primary';
+  const iconColor = disabled
+    ? theme.colors.mutedForeground
+    : isPrimary
+    ? theme.colors.primaryForeground
+    : theme.colors.foreground;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: !!disabled }}
+      testID={testID}
+      style={[
+        styles.controlButton,
+        isPrimary && styles.controlButtonPrimary,
+        disabled && styles.controlButtonDisabled,
+      ]}
+    >
+      <Icon size={18} color={iconColor} strokeWidth={listIconStrokeWidth} />
+      <Text
+        style={[
+          styles.controlButtonLabel,
+          isPrimary && styles.controlButtonLabelPrimary,
+          disabled && styles.controlButtonLabelDisabled,
+        ]}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
   );
 }
 
@@ -116,7 +222,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: theme.spacing.xs,
     paddingVertical: theme.spacing.sm,
-    borderRadius: theme.radius.lg,
+    borderRadius: theme.radius.md,
     backgroundColor: theme.colors.primary,
     borderWidth: 1,
     borderColor: theme.colors.primary,
@@ -132,11 +238,39 @@ const styles = StyleSheet.create({
   downloadButtonLabelDisabled: {
     color: theme.colors.mutedForeground,
   },
-  startedHint: {
-    fontSize: theme.typography.sizes.sm,
-    color: theme.colors.mutedForeground,
-    textAlign: 'center',
+  controlsColumn: {
+    width: '100%',
+    gap: theme.spacing.sm,
+  },
+  controlButton: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing.xs,
     paddingVertical: theme.spacing.sm,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.md,
+    backgroundColor: theme.colors.cardBackground,
+  },
+  controlButtonPrimary: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  controlButtonDisabled: {
+    opacity: 0.5,
+  },
+  controlButtonLabel: {
+    fontSize: theme.typography.sizes.md,
+    fontWeight: theme.typography.weights.medium,
+    color: theme.colors.foreground,
+  },
+  controlButtonLabelPrimary: {
+    color: theme.colors.primaryForeground,
+  },
+  controlButtonLabelDisabled: {
+    color: theme.colors.mutedForeground,
   },
   completeRow: {
     flexDirection: 'row',

--- a/src/app/prepare-offline/PrepareOfflineResourcesSection.test.tsx
+++ b/src/app/prepare-offline/PrepareOfflineResourcesSection.test.tsx
@@ -120,10 +120,14 @@ describe('PrepareOfflineResourcesSection', () => {
   });
 
   it('always shows tier 1 in the summary regardless of deselect state', () => {
+    const tier1ItemIds = catalog.items
+      .filter(item => item.tier === 1)
+      .map(item => item.id);
+
     render(
       <PrepareOfflineResourcesSection
         {...defaultProps}
-        isItemSelected={itemId => !itemId.includes('tier-3')}
+        isItemSelected={itemId => !tier1ItemIds.includes(itemId)}
       />,
     );
 

--- a/src/app/prepare-offline/ResourceDownloadProgressRing.tsx
+++ b/src/app/prepare-offline/ResourceDownloadProgressRing.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import { Download } from 'lucide-react-native';
+import {
+  theme,
+  iconSizes,
+  listIconStrokeWidth,
+  progressRingStrokeWidth,
+} from '../../theme';
+
+interface ResourceDownloadProgressRingProps {
+  progress: number;
+}
+
+const SIZE = iconSizes.chapterProgress;
+const STROKE = progressRingStrokeWidth;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+/** Inner icon — sized to sit inside the progress ring without overlapping the stroke. */
+const ICON_SIZE = 10;
+
+export function ResourceDownloadProgressRing({
+  progress,
+}: ResourceDownloadProgressRingProps) {
+  const bounce = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(bounce, {
+          toValue: -2,
+          duration: 900,
+          useNativeDriver: true,
+        }),
+        Animated.timing(bounce, {
+          toValue: 0,
+          duration: 900,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    animation.start();
+    return () => {
+      animation.stop();
+    };
+  }, [bounce]);
+
+  const clampedProgress = Math.max(0, Math.min(1, progress));
+  const strokeDashoffset = CIRCUMFERENCE * (1 - clampedProgress);
+
+  return (
+    <View style={styles.wrap} testID="resource-download-progress-ring">
+      <Svg width={SIZE} height={SIZE}>
+        <Circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          stroke={theme.colors.mutedForeground}
+          strokeOpacity={0.3}
+          strokeWidth={STROKE}
+          fill="none"
+        />
+        {clampedProgress > 0 ? (
+          <Circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            stroke={theme.colors.syncDownloading}
+            strokeWidth={STROKE}
+            fill="none"
+            strokeDasharray={`${CIRCUMFERENCE} ${CIRCUMFERENCE}`}
+            strokeDashoffset={strokeDashoffset}
+            strokeLinecap="round"
+            rotation={-90}
+            origin={`${SIZE / 2}, ${SIZE / 2}`}
+          />
+        ) : null}
+      </Svg>
+      <Animated.View
+        style={[styles.iconWrap, { transform: [{ translateY: bounce }] }]}
+      >
+        <Download
+          size={ICON_SIZE}
+          color={theme.colors.syncDownloading}
+          strokeWidth={listIconStrokeWidth}
+          testID="resource-status-downloading"
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    width: SIZE,
+    height: SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconWrap: {
+    ...StyleSheet.absoluteFill,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/app/prepare-offline/ResourceDownloadProgressRing.tsx
+++ b/src/app/prepare-offline/ResourceDownloadProgressRing.tsx
@@ -11,6 +11,8 @@ import {
 
 interface ResourceDownloadProgressRingProps {
   progress: number;
+  /** When false, ring is static (e.g. paused row). Defaults to true. */
+  animate?: boolean;
 }
 
 const SIZE = iconSizes.chapterProgress;
@@ -22,10 +24,16 @@ const ICON_SIZE = 10;
 
 export function ResourceDownloadProgressRing({
   progress,
+  animate = true,
 }: ResourceDownloadProgressRingProps) {
   const bounce = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
+    if (!animate) {
+      bounce.setValue(0);
+      return;
+    }
+
     const animation = Animated.loop(
       Animated.sequence([
         Animated.timing(bounce, {
@@ -45,9 +53,11 @@ export function ResourceDownloadProgressRing({
     return () => {
       animation.stop();
     };
-  }, [bounce]);
+  }, [animate, bounce]);
 
-  const clampedProgress = Math.max(0, Math.min(1, progress));
+  const clampedProgress = Number.isFinite(progress)
+    ? Math.max(0, Math.min(1, progress))
+    : 0;
   const strokeDashoffset = CIRCUMFERENCE * (1 - clampedProgress);
 
   return (

--- a/src/app/prepare-offline/ResourceItemRow.test.tsx
+++ b/src/app/prepare-offline/ResourceItemRow.test.tsx
@@ -23,6 +23,18 @@ jest.mock('lucide-react-native', () => {
   };
 });
 
+jest.mock('./ResourceDownloadProgressRing', () => {
+  const MockReact = require('react');
+  const { View } = require('react-native');
+  return {
+    ResourceDownloadProgressRing: ({ progress }: { progress: number }) =>
+      MockReact.createElement(View, {
+        testID: 'resource-download-progress-ring',
+        accessibilityValue: { now: progress },
+      }),
+  };
+});
+
 const baseItem: PrepareOfflineResourceItem = {
   id: 'tier-1-source-bible-text',
   tier: 1,
@@ -73,15 +85,19 @@ describe('ResourceItemRow', () => {
     expect(screen.queryByTestId('resource-summary-tier-lock')).toBeNull();
   });
 
-  it('shows downloading status icon before the label in summary mode', () => {
+  it('shows progress ring while downloading in summary mode', () => {
     render(
       <ResourceItemRow
-        item={{ ...baseItem, status: 'downloading' }}
+        item={{ ...baseItem, status: 'downloading', progress: 0.67 }}
         mode="summary"
       />,
     );
 
-    expect(screen.getByTestId('resource-status-downloading')).toBeTruthy();
+    expect(screen.getByTestId('resource-download-progress-ring')).toBeTruthy();
+    expect(
+      screen.getByTestId('resource-download-progress-ring').props
+        .accessibilityValue?.now,
+    ).toBe(0.67);
   });
 
   it('shows tier lock in customize for required tier 1 rows', () => {
@@ -141,5 +157,30 @@ describe('ResourceItemRow', () => {
     expect(
       screen.getByTestId('resource-row-tier-2-translation-words-audio'),
     ).toBeTruthy();
+  });
+
+  it('shows full catalog size even when partial progress is saved on a row', () => {
+    render(
+      <ResourceItemRow
+        item={{
+          ...baseItem,
+          id: 'tier-3-bible-commentary-audio',
+          tier: 3,
+          kind: 'audio',
+          groupName: 'Bible Commentary',
+          label: 'Audio',
+          bytes: 24 * 1024 * 1024,
+          status: 'selected',
+          progress: 0.5,
+        }}
+        mode="customize"
+        selected
+        onToggle={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('resource-row-size-tier-3-bible-commentary-audio'),
+    ).toHaveTextContent('24 MB');
   });
 });

--- a/src/app/prepare-offline/ResourceItemRow.test.tsx
+++ b/src/app/prepare-offline/ResourceItemRow.test.tsx
@@ -90,6 +90,23 @@ describe('ResourceItemRow', () => {
       <ResourceItemRow
         item={{ ...baseItem, status: 'downloading', progress: 0.67 }}
         mode="summary"
+        showTierLock
+      />,
+    );
+
+    expect(screen.getByTestId('resource-summary-tier-lock')).toBeTruthy();
+    expect(screen.getByTestId('resource-download-progress-ring')).toBeTruthy();
+    expect(
+      screen.getByTestId('resource-download-progress-ring').props
+        .accessibilityValue?.now,
+    ).toBe(0.67);
+  });
+
+  it('shows static progress ring while paused in summary mode', () => {
+    render(
+      <ResourceItemRow
+        item={{ ...baseItem, status: 'paused', progress: 0.42 }}
+        mode="summary"
       />,
     );
 
@@ -97,7 +114,7 @@ describe('ResourceItemRow', () => {
     expect(
       screen.getByTestId('resource-download-progress-ring').props
         .accessibilityValue?.now,
-    ).toBe(0.67);
+    ).toBe(0.42);
   });
 
   it('shows tier lock in customize for required tier 1 rows', () => {

--- a/src/app/prepare-offline/ResourceItemRow.tsx
+++ b/src/app/prepare-offline/ResourceItemRow.tsx
@@ -105,6 +105,8 @@ export function ResourceItemRow({
 }: ResourceItemRowProps) {
   const showToggle = mode === 'customize';
   const isDownloading = item.status === 'downloading';
+  const isPaused = item.status === 'paused';
+  const showProgressRing = isDownloading || isPaused;
   const displayBytes = item.bytes;
 
   const rowContent = (
@@ -122,14 +124,14 @@ export function ResourceItemRow({
 
       {mode === 'summary' ? (
         <View style={styles.leadingIconWrap}>
-          {showTierLock && item.status !== 'completed' && !isDownloading ? (
+          {showTierLock && item.status !== 'completed' ? (
             <Lock
               size={iconSizes.chapterSync}
               color={theme.colors.mutedForeground}
               strokeWidth={listIconStrokeWidth}
               testID="resource-summary-tier-lock"
             />
-          ) : !isDownloading ? (
+          ) : !showProgressRing ? (
             <StatusIcon status={item.status} />
           ) : (
             <View style={styles.statusSpacer} />
@@ -140,8 +142,11 @@ export function ResourceItemRow({
       <Text style={styles.label}>{item.label}</Text>
 
       <View style={styles.trailingWrap}>
-        {isDownloading ? (
-          <ResourceDownloadProgressRing progress={item.progress ?? 0} />
+        {showProgressRing ? (
+          <ResourceDownloadProgressRing
+            progress={item.progress ?? 0}
+            animate={isDownloading}
+          />
         ) : null}
         <Text style={styles.size} testID={`resource-row-size-${item.id}`}>
           {formatByteSize(displayBytes)}

--- a/src/app/prepare-offline/ResourceItemRow.tsx
+++ b/src/app/prepare-offline/ResourceItemRow.tsx
@@ -8,6 +8,7 @@ import {
 import { formatByteSize } from '../../utils/formatByteSize';
 import { theme, iconSizes, listIconStrokeWidth } from '../../theme';
 import { SelectionCheckbox } from './SelectionCheckbox';
+import { ResourceDownloadProgressRing } from './ResourceDownloadProgressRing';
 
 interface ResourceItemRowProps {
   item: PrepareOfflineResourceItem;
@@ -44,19 +45,11 @@ function StatusIcon({ status }: { status: PrepareOfflineResourceStatus }) {
     );
   }
 
-  if (
-    status === 'downloading' ||
-    status === 'selected' ||
-    status === 'available'
-  ) {
+  if (status === 'selected' || status === 'available') {
     return (
       <Download
         size={iconSizes.chapterSync}
-        color={
-          status === 'downloading'
-            ? theme.colors.syncDownloading
-            : theme.colors.mutedForeground
-        }
+        color={theme.colors.mutedForeground}
         strokeWidth={listIconStrokeWidth}
         testID={statusTestId(status)}
       />
@@ -111,6 +104,8 @@ export function ResourceItemRow({
   onToggle,
 }: ResourceItemRowProps) {
   const showToggle = mode === 'customize';
+  const isDownloading = item.status === 'downloading';
+  const displayBytes = item.bytes;
 
   const rowContent = (
     <>
@@ -127,21 +122,31 @@ export function ResourceItemRow({
 
       {mode === 'summary' ? (
         <View style={styles.leadingIconWrap}>
-          {showTierLock && item.status !== 'completed' ? (
+          {showTierLock && item.status !== 'completed' && !isDownloading ? (
             <Lock
               size={iconSizes.chapterSync}
               color={theme.colors.mutedForeground}
               strokeWidth={listIconStrokeWidth}
               testID="resource-summary-tier-lock"
             />
-          ) : (
+          ) : !isDownloading ? (
             <StatusIcon status={item.status} />
+          ) : (
+            <View style={styles.statusSpacer} />
           )}
         </View>
       ) : null}
 
       <Text style={styles.label}>{item.label}</Text>
-      <Text style={styles.size}>{formatByteSize(item.bytes)}</Text>
+
+      <View style={styles.trailingWrap}>
+        {isDownloading ? (
+          <ResourceDownloadProgressRing progress={item.progress ?? 0} />
+        ) : null}
+        <Text style={styles.size} testID={`resource-row-size-${item.id}`}>
+          {formatByteSize(displayBytes)}
+        </Text>
+      </View>
     </>
   );
 
@@ -182,10 +187,15 @@ const styles = StyleSheet.create({
     fontSize: theme.typography.sizes.sm,
     color: theme.colors.foreground,
   },
+  trailingWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.xs,
+  },
   size: {
     fontSize: theme.typography.sizes.sm,
     color: theme.colors.mutedForeground,
-    minWidth: 56,
+    minWidth: 48,
     textAlign: 'right',
   },
   statusSpacer: {

--- a/src/app/screens/PrepareForOfflineScreen.test.tsx
+++ b/src/app/screens/PrepareForOfflineScreen.test.tsx
@@ -6,12 +6,12 @@ import {
   waitFor,
 } from '@testing-library/react-native';
 import PrepareForOfflineScreen from './PrepareForOfflineScreen';
-import { setPrepareOfflineDownloadStarted } from '../../services/storage';
-import { enqueuePrepareOfflineDownload } from '../../services/prepareOfflineDownload';
 import {
   resetMockPrepareOfflineInventory,
   setPrepareOfflineMockInventoryScenario,
 } from '../../mocks/prepareOffline';
+
+const mockHandleDownload = jest.fn();
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -45,12 +45,18 @@ jest.mock('../../hooks/usePrepareOfflineSelection', () => ({
   usePrepareOfflineSelection: jest.fn(),
 }));
 
-jest.mock('../../services/storage', () => ({
-  setPrepareOfflineDownloadStarted: jest.fn(),
-}));
-
-jest.mock('../../services/prepareOfflineDownload', () => ({
-  enqueuePrepareOfflineDownload: jest.fn(),
+jest.mock('../../hooks/usePrepareOfflineDownload', () => ({
+  usePrepareOfflineDownload: jest.fn(({ catalog }: { catalog: unknown }) => ({
+    session: 'idle',
+    busy: false,
+    catalogWithProgress: catalog,
+    downloadButtonLabel: 'Download 18 MB',
+    canDownload: true,
+    handleDownload: mockHandleDownload,
+    pause: jest.fn(),
+    resume: jest.fn(),
+    cancel: jest.fn(),
+  })),
 }));
 
 jest.mock('../../utils/parseUserId', () => ({
@@ -195,7 +201,7 @@ describe('PrepareForOfflineScreen', () => {
     expect(screen.getByTestId('prepare-offline-download-button')).toBeTruthy();
   });
 
-  it('starts download via storage and enqueue when Download is pressed', async () => {
+  it('calls handleDownload when Download is pressed', async () => {
     render(<PrepareForOfflineScreen />);
 
     fireEvent.press(screen.getByText('Luke'));
@@ -208,15 +214,8 @@ describe('PrepareForOfflineScreen', () => {
     fireEvent.press(screen.getByTestId('prepare-offline-download-button'));
 
     await waitFor(() => {
-      expect(setPrepareOfflineDownloadStarted).toHaveBeenCalledWith('42', 5);
+      expect(mockHandleDownload).toHaveBeenCalled();
     });
-    expect(enqueuePrepareOfflineDownload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: 42,
-        projectId: 5,
-        items: expect.any(Array),
-      }),
-    );
   });
 
   it('keeps download footer visible while customize panel is expanded', async () => {

--- a/src/app/screens/PrepareForOfflineScreen.tsx
+++ b/src/app/screens/PrepareForOfflineScreen.tsx
@@ -14,6 +14,7 @@ import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { usePrepareOfflineSelection } from '../../hooks/usePrepareOfflineSelection';
 import { usePrepareOfflineResources } from '../../hooks/usePrepareOfflineResources';
+import { usePrepareOfflineDownload } from '../../hooks/usePrepareOfflineDownload';
 import { ProjectSummary } from '../../types/db/types';
 import { RootStackParamList } from '../../types/navigation/types';
 import { parseUserId } from '../../utils/parseUserId';
@@ -62,15 +63,12 @@ export default function PrepareForOfflineScreen() {
   const {
     catalog,
     totalBytes,
-    pendingBytes,
+    selectedItems,
     canDownload,
-    downloadButtonLabel,
-    downloadStarted,
     manifestLoading,
     manifestError,
     isItemSelected,
     toggleItemSelected,
-    handleDownload,
   } = usePrepareOfflineResources({
     projectId,
     userId,
@@ -78,6 +76,24 @@ export default function PrepareForOfflineScreen() {
     selectedIds,
     selectedCount,
     isAssignedUser,
+  });
+
+  const {
+    session,
+    busy,
+    catalogWithProgress,
+    downloadButtonLabel,
+    canDownload: canDownloadNow,
+    handleDownload,
+    pause,
+    resume,
+    cancel,
+  } = usePrepareOfflineDownload({
+    projectId,
+    userId,
+    catalog,
+    selectedItems,
+    canDownload,
   });
 
   const goBack = useCallback(() => navigation.goBack(), [navigation]);
@@ -137,18 +153,21 @@ export default function PrepareForOfflineScreen() {
           isBookFullySelected={isBookFullySelected}
         />
         <PrepareOfflineResourcesSection
-          catalog={catalog}
+          catalog={catalogWithProgress}
           isItemSelected={isItemSelected}
           onToggleItem={toggleItemSelected}
         />
         {showDownloadFooter ? (
           <PrepareOfflineDownloadFooter
             totalBytes={totalBytes}
-            pendingBytes={pendingBytes}
-            canDownload={canDownload}
+            canDownload={canDownloadNow}
             downloadButtonLabel={downloadButtonLabel}
-            downloadStarted={downloadStarted}
-            onDownload={handleDownload}
+            session={session}
+            busy={busy}
+            onDownload={() => void handleDownload()}
+            onPause={() => void pause()}
+            onResume={() => void resume()}
+            onCancel={() => void cancel()}
           />
         ) : null}
       </ScrollView>

--- a/src/db/downloadQueueRepository.test.ts
+++ b/src/db/downloadQueueRepository.test.ts
@@ -148,6 +148,21 @@ async function mockExecute(
     return { rows: [] };
   }
 
+  if (
+    normalized.includes('project_id = ?') &&
+    normalized.includes("status IN ('downloading', 'paused')") &&
+    normalized.startsWith("UPDATE download_queue SET status = 'cancelled'")
+  ) {
+    const [updatedAt, projectId] = params as [string, number];
+    rows = rows.map(r =>
+      r.project_id === projectId &&
+      (r.status === 'downloading' || r.status === 'paused')
+        ? { ...r, status: 'cancelled', updated_at: updatedAt }
+        : r,
+    );
+    return { rows: [] };
+  }
+
   if (normalized.startsWith("UPDATE download_queue SET status = 'cancelled'")) {
     const [resumeData, updatedAt, id] = params as [
       string | null,
@@ -281,6 +296,7 @@ import {
   getResumableDownloadItems,
   markDownloadItemCompleted,
   markDownloadItemCancelled,
+  cancelProjectDownloadTransfers,
   markDownloadItemFailed,
   markDownloadItemPaused,
   updateDownloadItemProgress,
@@ -421,6 +437,42 @@ describe('downloadQueueRepository', () => {
     expect(rows.find(r => r.id === cancelledId)?.resume_data).toBe(
       '{"resumeData":"cancelled"}',
     );
+  });
+
+  it('cancelProjectDownloadTransfers marks downloading and paused rows cancelled', async () => {
+    const [downloadingId, pausedId, queuedId] = await enqueueDownloadItems([
+      {
+        projectId: 7,
+        tier: 1,
+        kind: 'text',
+        resourceName: 'Source Bible',
+        label: 'Text',
+      },
+      {
+        projectId: 7,
+        tier: 1,
+        kind: 'audio',
+        resourceName: 'Source Bible',
+        label: 'Audio',
+      },
+      {
+        projectId: 7,
+        tier: 2,
+        kind: 'text',
+        resourceName: 'Translation Words',
+        label: 'Words Text',
+      },
+    ]);
+
+    await markDownloadItemDownloading(downloadingId);
+    await markDownloadItemPaused(pausedId, '{"resumeData":"paused"}');
+
+    await cancelProjectDownloadTransfers(7);
+
+    const rows = __getDownloadQueueRows();
+    expect(rows.find(r => r.id === downloadingId)?.status).toBe('cancelled');
+    expect(rows.find(r => r.id === pausedId)?.status).toBe('cancelled');
+    expect(rows.find(r => r.id === queuedId)?.status).toBe('queued');
   });
 
   it('returns resumable queue items in queue order', async () => {

--- a/src/db/downloadQueueRepository.ts
+++ b/src/db/downloadQueueRepository.ts
@@ -53,6 +53,8 @@ function mapRow(row: DownloadQueueRow): DownloadQueueItem {
 }
 
 export type EnqueueDownloadItemInput = {
+  /** Stable catalog resource id (e.g. tier-1-source-bible-text). */
+  id?: string;
   projectId: number;
   tier: DownloadTier;
   kind: 'text' | 'audio';
@@ -85,7 +87,7 @@ export async function enqueueDownloadItems(
     const sorted = [...items].sort((a, b) => a.tier - b.tier);
 
     for (const item of sorted) {
-      const id = newDownloadQueueId();
+      const id = item.id ?? newDownloadQueueId();
 
       const result = await tx.execute(
         `INSERT INTO download_queue (
@@ -170,6 +172,20 @@ export async function markDownloadItemCancelled(
      SET status = 'cancelled', resume_data = COALESCE(?, resume_data), updated_at = ?
      WHERE id = ? AND status != 'completed'`,
     [resumeData ?? null, now, id],
+  );
+}
+
+/** Persist cancel for in-flight project rows when the worker lost its active handle. */
+export async function cancelProjectDownloadTransfers(
+  projectId: number,
+): Promise<void> {
+  const db = getDatabase();
+  const now = new Date().toISOString();
+  await db.execute(
+    `UPDATE download_queue
+     SET status = 'cancelled', updated_at = ?
+     WHERE project_id = ? AND status IN ('downloading', 'paused')`,
+    [now, projectId],
   );
 }
 

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -710,6 +710,7 @@ export {
   updateDownloadItemProgress,
   markDownloadItemPaused,
   markDownloadItemCancelled,
+  cancelProjectDownloadTransfers,
   markDownloadItemCompleted,
   markDownloadItemFailed,
   deleteDownloadItem,

--- a/src/hooks/useDownloadQueue.ts
+++ b/src/hooks/useDownloadQueue.ts
@@ -7,9 +7,9 @@ import {
   getDownloadQueueSnapshot,
   getResumableDownloadItems,
 } from '../db/repository';
-import { DownloadQueueWorker } from '../services/downloadQueueWorker';
+import type { WorkerSessionState } from '../services/downloadQueueWorker';
+import { getSharedDownloadQueueWorker } from '../services/downloadQueueWorkerSingleton';
 import { getConnectivitySnapshot } from '../services/connectivity';
-import { queuedResourceResolver } from '../services/downloadResourceResolver';
 import { logger } from '../utils/logger';
 import {
   getActiveUserId,
@@ -192,12 +192,16 @@ function hasActiveDownloads(snapshot: DownloadQueueSnapshot): boolean {
 // Single worker instance for the app's lifetime, mirroring other cross-screen
 // service singletons (e.g. authToken) rather than recreating in-memory queue
 // state per hook consumer.
-const worker = new DownloadQueueWorker(queuedResourceResolver);
+const worker = getSharedDownloadQueueWorker();
+
+export { getSharedDownloadQueueWorker } from '../services/downloadQueueWorkerSingleton';
 
 export function useDownloadQueue() {
   const [snapshot, setSnapshot] = useState<DownloadQueueSnapshot>(
     EMPTY_DOWNLOAD_SNAPSHOT,
   );
+  const [workerSessionState, setWorkerSessionState] =
+    useState<WorkerSessionState>(() => worker.getState());
 
   const refresh = useCallback(async () => {
     if (__DEV__ && DEV_PREVIEW_DOWNLOAD_QUEUE) {
@@ -207,6 +211,7 @@ export function useDownloadQueue() {
     try {
       const next = await getDownloadQueueSnapshot();
       setSnapshot(next);
+      setWorkerSessionState(worker.getState());
     } catch (error) {
       log.error('Failed to load download queue snapshot', { error });
     }
@@ -216,23 +221,24 @@ export function useDownloadQueue() {
     void refresh();
   }, [refresh]);
 
-  // Poll while a download is actively in flight so progress isn't frozen
-  // between action-triggered refreshes (start/pause/resume/cancel). Stops
-  // automatically once nothing is `downloading`.
+  // Poll while the worker or queue reports an active transfer so progress and
+  // footer controls update during long-running start() (not only after it returns).
   useEffect(() => {
-    const isActivelyDownloading = snapshot.items.some(
-      item => item.status === 'downloading',
-    );
-    if (!isActivelyDownloading) {
+    const shouldPoll =
+      workerSessionState === 'downloading' ||
+      workerSessionState === 'paused' ||
+      snapshot.items.some(item => item.status === 'downloading');
+
+    if (!shouldPoll) {
       return;
     }
 
     const intervalId = setInterval(() => {
       void refresh();
-    }, 1000);
+    }, 500);
 
     return () => clearInterval(intervalId);
-  }, [snapshot, refresh]);
+  }, [snapshot, workerSessionState, refresh]);
 
   const start = useCallback(
     async (items: DownloadQueueItem[]) => {
@@ -249,7 +255,13 @@ export function useDownloadQueue() {
           setPrepareOfflineDownloadStarted(userId, projectId);
         }
       }
-      await worker.start(items);
+
+      // Do not await the full queue — worker runs sequentially in the background
+      // so UI can refresh progress and expose pause/cancel while downloading.
+      void worker.start(items).finally(() => {
+        void refresh();
+      });
+
       await refresh();
     },
     [refresh],
@@ -262,7 +274,9 @@ export function useDownloadQueue() {
 
   const resume = useCallback(async () => {
     if (worker.getState() === 'paused') {
-      await worker.resume();
+      void worker.resume().finally(() => {
+        void refresh();
+      });
       await refresh();
       return;
     }
@@ -279,7 +293,9 @@ export function useDownloadQueue() {
     }
 
     const items = await getResumableDownloadItems(true);
-    await worker.start(items);
+    void worker.start(items).finally(() => {
+      void refresh();
+    });
     await refresh();
   }, [refresh]);
 
@@ -290,5 +306,14 @@ export function useDownloadQueue() {
 
   const hasDownloads = hasActiveDownloads(snapshot);
 
-  return { snapshot, hasDownloads, start, pause, resume, cancel, refresh };
+  return {
+    snapshot,
+    hasDownloads,
+    workerSessionState,
+    start,
+    pause,
+    resume,
+    cancel,
+    refresh,
+  };
 }

--- a/src/hooks/usePrepareOfflineDownload.test.ts
+++ b/src/hooks/usePrepareOfflineDownload.test.ts
@@ -212,6 +212,32 @@ describe('usePrepareOfflineDownload', () => {
     ).toHaveBeenCalledWith(1);
   });
 
+  it('stays idle when worker is paused for a different project', () => {
+    mockWorkerState = 'paused';
+    mockSnapshot.items = [
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'paused',
+        projectId: 99,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    expect(result.current.session).toBe('idle');
+  });
+
   it('stays idle with queued rows when worker is idle (no fake pause controls)', () => {
     mockWorkerState = 'idle';
     mockSnapshot.items = [

--- a/src/hooks/usePrepareOfflineDownload.test.ts
+++ b/src/hooks/usePrepareOfflineDownload.test.ts
@@ -1,0 +1,379 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { usePrepareOfflineDownload } from './usePrepareOfflineDownload';
+import { PrepareOfflineCatalog } from '../types/prepareOffline/types';
+
+const mockStart = jest.fn();
+const mockPause = jest.fn();
+const mockResume = jest.fn();
+const mockCancel = jest.fn();
+const mockRefresh = jest.fn();
+
+let mockSnapshot = {
+  items: [] as {
+    id: string;
+    tier: 1;
+    label: string;
+    progress: number;
+    status: string;
+    projectId: number;
+  }[],
+  completedCount: 0,
+  totalCount: 0,
+  aggregateProgress: 0,
+};
+
+let mockWorkerState: 'idle' | 'downloading' | 'paused' | 'cancelled' = 'idle';
+
+jest.mock('./useDownloadQueue', () => ({
+  useDownloadQueue: () => ({
+    snapshot: mockSnapshot,
+    workerSessionState: mockWorkerState,
+    start: mockStart,
+    pause: mockPause,
+    resume: mockResume,
+    cancel: mockCancel,
+    refresh: mockRefresh,
+  }),
+}));
+
+jest.mock('../services/prepareOfflineDownload', () => ({
+  enqueuePrepareOfflineDownload: jest.fn(() =>
+    Promise.resolve(['tier-1-source-bible-text']),
+  ),
+}));
+
+jest.mock('../services/storage', () => ({
+  setPrepareOfflineDownloadStarted: jest.fn(),
+  getPrepareOfflineDownloadStarted: jest.fn(() => false),
+}));
+
+jest.mock('../db/repository', () => ({
+  getResumableDownloadItems: jest.fn(() =>
+    Promise.resolve([
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0,
+        status: 'queued',
+        projectId: 1,
+      },
+    ]),
+  ),
+  getDownloadedResourcesByProject: jest.fn(() => Promise.resolve([])),
+  cancelProjectDownloadTransfers: jest.fn(() => Promise.resolve()),
+}));
+
+const catalog: PrepareOfflineCatalog = {
+  items: [
+    {
+      id: 'tier-1-source-bible-text',
+      tier: 1,
+      kind: 'text',
+      groupName: 'Source Bible',
+      label: 'Text',
+      bytes: 1024,
+      status: 'selected',
+    },
+  ],
+  groups: [],
+};
+
+describe('usePrepareOfflineDownload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSnapshot = {
+      items: [],
+      completedCount: 0,
+      totalCount: 0,
+      aggregateProgress: 0,
+    };
+    mockWorkerState = 'idle';
+    mockStart.mockResolvedValue(undefined);
+    mockPause.mockResolvedValue(undefined);
+    mockResume.mockResolvedValue(undefined);
+    mockCancel.mockResolvedValue(undefined);
+    mockRefresh.mockResolvedValue(undefined);
+  });
+
+  it('starts in idle session', () => {
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    expect(result.current.session).toBe('idle');
+  });
+
+  it('transitions to downloading after handleDownload', async () => {
+    mockWorkerState = 'downloading';
+    mockSnapshot.items = [
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.1,
+        status: 'queued',
+        projectId: 1,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleDownload();
+    });
+
+    await waitFor(() => {
+      expect(result.current.session).toBe('downloading');
+    });
+    expect(mockStart).toHaveBeenCalled();
+  });
+
+  it('transitions to paused when worker is paused', async () => {
+    mockWorkerState = 'paused';
+    mockSnapshot.items = [
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'paused',
+        projectId: 1,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.session).toBe('paused');
+    });
+  });
+
+  it('returns to idle after cancel without resetting forceIdle for queued rows', async () => {
+    mockSnapshot.items = [
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'cancelled',
+        projectId: 1,
+      },
+      {
+        id: 'tier-1-source-bible-audio',
+        tier: 1,
+        label: 'Audio',
+        progress: 0,
+        status: 'queued',
+        projectId: 1,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    expect(result.current.session).toBe('idle');
+    expect(mockCancel).toHaveBeenCalled();
+    expect(
+      jest.requireMock('../db/repository').cancelProjectDownloadTransfers,
+    ).toHaveBeenCalledWith(1);
+  });
+
+  it('stays idle with queued rows when worker is idle (no fake pause controls)', () => {
+    mockWorkerState = 'idle';
+    mockSnapshot.items = [
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0,
+        status: 'queued',
+        projectId: 1,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    expect(result.current.session).toBe('idle');
+  });
+
+  it('sets busy while pause is in flight', async () => {
+    let resolvePause: () => void = () => undefined;
+    mockPause.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolvePause = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    act(() => {
+      void result.current.pause();
+    });
+
+    await waitFor(() => {
+      expect(result.current.busy).toBe(true);
+    });
+
+    await act(async () => {
+      resolvePause();
+    });
+
+    await waitFor(() => {
+      expect(result.current.busy).toBe(false);
+    });
+  });
+
+  it('transitions to complete when session started and all selected items finish', async () => {
+    const { getDownloadedResourcesByProject } =
+      jest.requireMock('../db/repository');
+
+    getDownloadedResourcesByProject.mockResolvedValue([
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 1,
+        status: 'completed',
+        projectId: 1,
+      },
+    ]);
+
+    const { result, rerender } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleDownload();
+    });
+
+    mockSnapshot.items = [];
+    rerender(undefined);
+
+    await waitFor(() => {
+      expect(result.current.session).toBe('complete');
+    });
+  });
+
+  it('restores complete session on mount when download started and all items are on device', async () => {
+    const { getDownloadedResourcesByProject } =
+      jest.requireMock('../db/repository');
+    const { getPrepareOfflineDownloadStarted } = jest.requireMock(
+      '../services/storage',
+    );
+
+    getPrepareOfflineDownloadStarted.mockReturnValue(true);
+    getDownloadedResourcesByProject.mockResolvedValue([
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 1,
+        status: 'completed',
+        projectId: 1,
+      },
+    ]);
+
+    const completedCatalog: PrepareOfflineCatalog = {
+      items: [{ ...catalog.items[0], status: 'completed' }],
+      groups: [],
+    };
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog: completedCatalog,
+        selectedItems: completedCatalog.items,
+        canDownload: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.session).toBe('complete');
+    });
+  });
+
+  it('uses full catalog size for download button label after cancel', async () => {
+    mockSnapshot.items = [
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'cancelled',
+        projectId: 1,
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.downloadButtonLabel).toBe('Download 1 KB');
+    });
+  });
+});

--- a/src/hooks/usePrepareOfflineDownload.test.ts
+++ b/src/hooks/usePrepareOfflineDownload.test.ts
@@ -300,6 +300,44 @@ describe('usePrepareOfflineDownload', () => {
     });
   });
 
+  it('ignores concurrent pause invocations while one is in flight', async () => {
+    let resolvePause: () => void = () => undefined;
+    mockPause.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolvePause = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      usePrepareOfflineDownload({
+        projectId: 1,
+        userId: 42,
+        catalog,
+        selectedItems: catalog.items,
+        canDownload: true,
+      }),
+    );
+
+    act(() => {
+      void result.current.pause();
+      void result.current.pause();
+    });
+
+    await waitFor(() => {
+      expect(result.current.busy).toBe(true);
+    });
+    expect(mockPause).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvePause();
+    });
+
+    await waitFor(() => {
+      expect(result.current.busy).toBe(false);
+    });
+  });
+
   it('transitions to complete when session started and all selected items finish', async () => {
     const { getDownloadedResourcesByProject } =
       jest.requireMock('../db/repository');

--- a/src/hooks/usePrepareOfflineDownload.ts
+++ b/src/hooks/usePrepareOfflineDownload.ts
@@ -113,15 +113,31 @@ export function usePrepareOfflineDownload({
   >([]);
   const sessionKeyRef = useRef<string | null>(null);
   const userCancelledRef = useRef(false);
+  const sessionActionInFlightRef = useRef(false);
 
   const sessionKey =
     projectId !== null ? `${projectId}:${userId ?? 'none'}` : null;
+
+  const releaseSessionAction = useCallback(() => {
+    sessionActionInFlightRef.current = false;
+    setBusy(false);
+  }, []);
+
+  const tryAcquireSessionAction = useCallback((): boolean => {
+    if (sessionActionInFlightRef.current || busy) {
+      return false;
+    }
+    sessionActionInFlightRef.current = true;
+    setBusy(true);
+    return true;
+  }, [busy]);
 
   useEffect(() => {
     if (sessionKeyRef.current !== sessionKey) {
       setSessionStarted(false);
       setForceIdle(false);
       userCancelledRef.current = false;
+      sessionActionInFlightRef.current = false;
       sessionKeyRef.current = sessionKey;
     }
   }, [sessionKey]);
@@ -265,26 +281,25 @@ export function usePrepareOfflineDownload({
       return;
     }
 
-    if (busy) {
+    if (!tryAcquireSessionAction()) {
       return;
     }
 
-    const resumable = await getResumableDownloadItems(true);
-    const existingProjectItems = resumable.filter(
-      item => item.projectId === projectId,
-    );
-
-    if (!canDownloadNow && existingProjectItems.length === 0) {
-      return;
-    }
-
-    setForceIdle(false);
-    userCancelledRef.current = false;
-    setSessionStarted(true);
-    setPrepareOfflineDownloadStarted(String(userId), projectId);
-
-    setBusy(true);
     try {
+      const resumable = await getResumableDownloadItems(true);
+      const existingProjectItems = resumable.filter(
+        item => item.projectId === projectId,
+      );
+
+      if (!canDownloadNow && existingProjectItems.length === 0) {
+        return;
+      }
+
+      setForceIdle(false);
+      userCancelledRef.current = false;
+      setSessionStarted(true);
+      setPrepareOfflineDownloadStarted(String(userId), projectId);
+
       if (canDownload) {
         await enqueuePrepareOfflineDownload({
           userId,
@@ -306,52 +321,50 @@ export function usePrepareOfflineDownload({
         await start(projectItems);
       }
     } finally {
-      setBusy(false);
+      releaseSessionAction();
     }
   }, [
-    busy,
     canDownload,
     canDownloadNow,
     catalog.items,
     projectId,
     refresh,
+    releaseSessionAction,
     selectedItems,
     start,
+    tryAcquireSessionAction,
     userId,
   ]);
 
   const handlePause = useCallback(async () => {
-    if (busy) {
+    if (!tryAcquireSessionAction()) {
       return;
     }
-    setBusy(true);
     try {
       log.info('Prepare offline download paused', { projectId });
       await pause();
     } finally {
-      setBusy(false);
+      releaseSessionAction();
     }
-  }, [busy, pause, projectId]);
+  }, [pause, projectId, releaseSessionAction, tryAcquireSessionAction]);
 
   const handleResume = useCallback(async () => {
-    if (busy) {
+    if (!tryAcquireSessionAction()) {
       return;
     }
-    setBusy(true);
     try {
       log.info('Prepare offline download resumed', { projectId });
       setForceIdle(false);
       await resume();
     } finally {
-      setBusy(false);
+      releaseSessionAction();
     }
-  }, [busy, projectId, resume]);
+  }, [projectId, releaseSessionAction, resume, tryAcquireSessionAction]);
 
   const handleCancel = useCallback(async () => {
-    if (busy) {
+    if (!tryAcquireSessionAction()) {
       return;
     }
-    setBusy(true);
     try {
       log.info('Prepare offline download cancelled', { projectId });
       await cancel();
@@ -362,9 +375,15 @@ export function usePrepareOfflineDownload({
       userCancelledRef.current = true;
       setForceIdle(true);
     } finally {
-      setBusy(false);
+      releaseSessionAction();
     }
-  }, [busy, cancel, projectId, refresh]);
+  }, [
+    cancel,
+    projectId,
+    refresh,
+    releaseSessionAction,
+    tryAcquireSessionAction,
+  ]);
 
   return {
     session,

--- a/src/hooks/usePrepareOfflineDownload.ts
+++ b/src/hooks/usePrepareOfflineDownload.ts
@@ -62,17 +62,25 @@ function deriveSession(
     return 'complete';
   }
 
-  if (workerState === 'paused') {
+  const projectHasPaused = projectItems.some(item => item.status === 'paused');
+  const projectHasDownloading = projectItems.some(
+    item => item.status === 'downloading',
+  );
+  const projectHasActiveWork = projectItems.some(item =>
+    ['downloading', 'paused', 'queued'].includes(item.status),
+  );
+
+  if (projectHasPaused) {
     return 'paused';
   }
 
-  if (projectItems.some(item => item.status === 'paused')) {
+  if (workerState === 'paused' && projectHasActiveWork) {
     return 'paused';
   }
 
   if (
-    workerState === 'downloading' ||
-    projectItems.some(item => item.status === 'downloading')
+    projectHasDownloading ||
+    (workerState === 'downloading' && projectHasActiveWork)
   ) {
     return 'downloading';
   }
@@ -124,9 +132,20 @@ export function usePrepareOfflineDownload({
       return;
     }
 
-    void getDownloadedResourcesByProject(projectId).then(
-      setCompletedQueueItems,
-    );
+    let cancelled = false;
+    getDownloadedResourcesByProject(projectId)
+      .then(items => {
+        if (!cancelled) {
+          setCompletedQueueItems(items);
+        }
+      })
+      .catch(error => {
+        log.error('Failed to load downloaded resources', { error, projectId });
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [projectId, snapshot]);
 
   const allQueueItems = useMemo(

--- a/src/hooks/usePrepareOfflineDownload.ts
+++ b/src/hooks/usePrepareOfflineDownload.ts
@@ -1,0 +1,361 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getDownloadedResourcesByProject,
+  getResumableDownloadItems,
+  cancelProjectDownloadTransfers,
+} from '../db/repository';
+import { useDownloadQueue } from './useDownloadQueue';
+import { enqueuePrepareOfflineDownload } from '../services/prepareOfflineDownload';
+import {
+  getPrepareOfflineDownloadStarted,
+  setPrepareOfflineDownloadStarted,
+} from '../services/storage';
+import {
+  PrepareOfflineCatalog,
+  PrepareOfflineResourceItem,
+} from '../types/prepareOffline/types';
+import type { DownloadQueueItem } from '../types/download/types';
+import type { WorkerSessionState } from '../services/downloadQueueWorker';
+import { mergeQueueIntoPrepareOfflineCatalog } from '../utils/mergeQueueIntoPrepareOfflineCatalog';
+import {
+  computeRemainingBytes,
+  sortItemsForPrepareOfflineDownload,
+} from '../utils/prepareOfflineCatalog';
+import { formatByteSize } from '../utils/formatByteSize';
+import { logger } from '../utils/logger';
+
+const log = logger.create('usePrepareOfflineDownload');
+
+export type PrepareOfflineDownloadSession =
+  | 'idle'
+  | 'downloading'
+  | 'paused'
+  | 'complete';
+
+export interface UsePrepareOfflineDownloadInput {
+  projectId: number | null;
+  userId: number | null;
+  catalog: PrepareOfflineCatalog;
+  selectedItems: PrepareOfflineResourceItem[];
+  canDownload: boolean;
+}
+
+function deriveSession(
+  workerState: WorkerSessionState,
+  projectId: number | null,
+  queueItems: { projectId?: number; status: string }[],
+  sessionStarted: boolean,
+  selectedComplete: boolean,
+  forceIdle: boolean,
+): PrepareOfflineDownloadSession {
+  if (forceIdle) {
+    return 'idle';
+  }
+
+  if (projectId === null) {
+    return 'idle';
+  }
+
+  const projectItems = queueItems.filter(item => item.projectId === projectId);
+
+  if (sessionStarted && selectedComplete) {
+    return 'complete';
+  }
+
+  if (workerState === 'paused') {
+    return 'paused';
+  }
+
+  if (projectItems.some(item => item.status === 'paused')) {
+    return 'paused';
+  }
+
+  if (
+    workerState === 'downloading' ||
+    projectItems.some(item => item.status === 'downloading')
+  ) {
+    return 'downloading';
+  }
+
+  return 'idle';
+}
+
+export function usePrepareOfflineDownload({
+  projectId,
+  userId,
+  catalog,
+  selectedItems,
+  canDownload,
+}: UsePrepareOfflineDownloadInput) {
+  const {
+    snapshot,
+    start,
+    pause,
+    resume,
+    cancel,
+    refresh,
+    workerSessionState,
+  } = useDownloadQueue();
+
+  const [busy, setBusy] = useState(false);
+  const [sessionStarted, setSessionStarted] = useState(false);
+  const [forceIdle, setForceIdle] = useState(false);
+  const [completedQueueItems, setCompletedQueueItems] = useState<
+    DownloadQueueItem[]
+  >([]);
+  const sessionKeyRef = useRef<string | null>(null);
+  const userCancelledRef = useRef(false);
+
+  const sessionKey =
+    projectId !== null ? `${projectId}:${userId ?? 'none'}` : null;
+
+  useEffect(() => {
+    if (sessionKeyRef.current !== sessionKey) {
+      setSessionStarted(false);
+      setForceIdle(false);
+      userCancelledRef.current = false;
+      sessionKeyRef.current = sessionKey;
+    }
+  }, [sessionKey]);
+
+  useEffect(() => {
+    if (projectId === null) {
+      setCompletedQueueItems([]);
+      return;
+    }
+
+    void getDownloadedResourcesByProject(projectId).then(
+      setCompletedQueueItems,
+    );
+  }, [projectId, snapshot]);
+
+  const allQueueItems = useMemo(
+    () => [...snapshot.items, ...completedQueueItems],
+    [snapshot.items, completedQueueItems],
+  );
+
+  const catalogWithProgress = useMemo(
+    () =>
+      mergeQueueIntoPrepareOfflineCatalog(catalog, allQueueItems, projectId),
+    [catalog, allQueueItems, projectId],
+  );
+
+  const mergedSelectedItems = useMemo(
+    () =>
+      selectedItems.map(item => {
+        const merged = catalogWithProgress.items.find(
+          entry => entry.id === item.id,
+        );
+        return merged ?? item;
+      }),
+    [catalogWithProgress.items, selectedItems],
+  );
+
+  const selectedComplete = useMemo(
+    () =>
+      mergedSelectedItems.length > 0 &&
+      mergedSelectedItems.every(item => item.status === 'completed'),
+    [mergedSelectedItems],
+  );
+
+  useEffect(() => {
+    if (projectId === null || userId === null) {
+      return;
+    }
+
+    const projectItems = snapshot.items.filter(
+      item => item.projectId === projectId,
+    );
+
+    const hasLiveTransfer = projectItems.some(
+      item => item.status === 'downloading' || item.status === 'paused',
+    );
+
+    if (hasLiveTransfer) {
+      setSessionStarted(true);
+      if (!userCancelledRef.current) {
+        setForceIdle(false);
+      }
+      return;
+    }
+
+    if (
+      selectedComplete &&
+      getPrepareOfflineDownloadStarted(String(userId), projectId)
+    ) {
+      setSessionStarted(true);
+    }
+  }, [projectId, userId, snapshot.items, selectedComplete]);
+
+  const session = useMemo(
+    () =>
+      deriveSession(
+        workerSessionState,
+        projectId,
+        snapshot.items,
+        sessionStarted,
+        selectedComplete,
+        forceIdle,
+      ),
+    [
+      workerSessionState,
+      projectId,
+      snapshot.items,
+      sessionStarted,
+      selectedComplete,
+      forceIdle,
+    ],
+  );
+
+  const pendingBytes = useMemo(
+    () => computeRemainingBytes(mergedSelectedItems),
+    [mergedSelectedItems],
+  );
+
+  const downloadButtonLabel = useMemo(() => {
+    if (pendingBytes > 0) {
+      return `Download ${formatByteSize(pendingBytes)}`;
+    }
+
+    const totalSelectedBytes = mergedSelectedItems.reduce(
+      (sum, item) => sum + item.bytes,
+      0,
+    );
+
+    return totalSelectedBytes > 0
+      ? 'All on device'
+      : `Download ${formatByteSize(0)}`;
+  }, [mergedSelectedItems, pendingBytes]);
+
+  const hasResumableQueueWork = useMemo(
+    () =>
+      projectId !== null &&
+      snapshot.items.some(
+        item =>
+          item.projectId === projectId &&
+          ['queued', 'cancelled', 'failed', 'paused'].includes(item.status),
+      ),
+    [projectId, snapshot.items],
+  );
+
+  const canDownloadNow =
+    (canDownload && pendingBytes > 0) || hasResumableQueueWork;
+
+  const handleDownload = useCallback(async () => {
+    if (projectId === null || userId === null) {
+      return;
+    }
+
+    if (busy) {
+      return;
+    }
+
+    const resumable = await getResumableDownloadItems(true);
+    const existingProjectItems = resumable.filter(
+      item => item.projectId === projectId,
+    );
+
+    if (!canDownloadNow && existingProjectItems.length === 0) {
+      return;
+    }
+
+    setForceIdle(false);
+    userCancelledRef.current = false;
+    setSessionStarted(true);
+    setPrepareOfflineDownloadStarted(String(userId), projectId);
+
+    setBusy(true);
+    try {
+      if (canDownload) {
+        await enqueuePrepareOfflineDownload({
+          userId,
+          projectId,
+          items: sortItemsForPrepareOfflineDownload(
+            selectedItems,
+            catalog.items,
+          ),
+        });
+      }
+
+      await refresh();
+
+      const projectItems = (await getResumableDownloadItems(true)).filter(
+        item => item.projectId === projectId,
+      );
+
+      if (projectItems.length > 0) {
+        await start(projectItems);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    busy,
+    canDownload,
+    canDownloadNow,
+    catalog.items,
+    projectId,
+    refresh,
+    selectedItems,
+    start,
+    userId,
+  ]);
+
+  const handlePause = useCallback(async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      log.info('Prepare offline download paused', { projectId });
+      await pause();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, pause, projectId]);
+
+  const handleResume = useCallback(async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      log.info('Prepare offline download resumed', { projectId });
+      setForceIdle(false);
+      await resume();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, projectId, resume]);
+
+  const handleCancel = useCallback(async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      log.info('Prepare offline download cancelled', { projectId });
+      await cancel();
+      if (projectId !== null) {
+        await cancelProjectDownloadTransfers(projectId);
+      }
+      await refresh();
+      userCancelledRef.current = true;
+      setForceIdle(true);
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, cancel, projectId, refresh]);
+
+  return {
+    session,
+    busy,
+    catalogWithProgress,
+    downloadButtonLabel,
+    canDownload: canDownloadNow,
+    handleDownload,
+    pause: handlePause,
+    resume: handleResume,
+    cancel: handleCancel,
+  };
+}

--- a/src/hooks/usePrepareOfflineResources.test.ts
+++ b/src/hooks/usePrepareOfflineResources.test.ts
@@ -8,16 +8,6 @@ import {
   resetMockPrepareOfflineInventory,
   setPrepareOfflineMockInventoryScenario,
 } from '../mocks/prepareOffline';
-import { setPrepareOfflineDownloadStarted } from '../services/storage';
-import { enqueuePrepareOfflineDownload } from '../services/prepareOfflineDownload';
-
-jest.mock('../services/storage', () => ({
-  setPrepareOfflineDownloadStarted: jest.fn(),
-}));
-
-jest.mock('../services/prepareOfflineDownload', () => ({
-  enqueuePrepareOfflineDownload: jest.fn(),
-}));
 
 const MB = 1024 * 1024;
 
@@ -80,6 +70,7 @@ describe('usePrepareOfflineResources', () => {
     expect(result.current.canDownload).toBe(true);
     expect(result.current.pendingBytes).toBeGreaterThan(0);
     expect(result.current.downloadButtonLabel).toMatch(/^Download /);
+    expect(result.current.selectedItems.length).toBeGreaterThan(0);
   });
 
   it('enables download for unassigned users after selecting a chapter', async () => {
@@ -183,35 +174,6 @@ describe('usePrepareOfflineResources', () => {
     expect(result.current.isItemSelected('tier-3-bible-commentary-text')).toBe(
       true,
     );
-  });
-
-  it('starts download via storage and enqueue stub', async () => {
-    const { result } = renderHook(() =>
-      usePrepareOfflineResources({
-        projectId: 5,
-        userId: 42,
-        chapters: [chapter(1)],
-        selectedIds: new Set([1]),
-        selectedCount: 1,
-        isAssignedUser: true,
-      }),
-    );
-
-    await waitForCatalogItems(result);
-
-    act(() => {
-      result.current.handleDownload();
-    });
-
-    expect(setPrepareOfflineDownloadStarted).toHaveBeenCalledWith('42', 5);
-    expect(enqueuePrepareOfflineDownload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: 42,
-        projectId: 5,
-        items: expect.any(Array),
-      }),
-    );
-    expect(result.current.downloadStarted).toBe(true);
   });
 
   it('deselects tier 3 by default in tier1-tier2 mock scenario', async () => {

--- a/src/hooks/usePrepareOfflineResources.ts
+++ b/src/hooks/usePrepareOfflineResources.ts
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePrepareOfflineResourceData } from './usePrepareOfflineResourceData';
-import { enqueuePrepareOfflineDownload } from '../services/prepareOfflineDownload';
-import { setPrepareOfflineDownloadStarted } from '../services/storage';
 import { PrepareOfflineChapterRow } from '../types/prepareOffline/types';
 import { formatByteSize } from '../utils/formatByteSize';
 import {
@@ -11,7 +9,6 @@ import {
   computeTotalBytes,
   getEffectiveItems,
   isItemCustomizeLocked,
-  sortItemsForPrepareOfflineDownload,
 } from '../utils/prepareOfflineCatalog';
 
 export interface UsePrepareOfflineResourcesInput {
@@ -34,7 +31,6 @@ export function usePrepareOfflineResources({
   const [deselectedItemIds, setDeselectedItemIds] = useState<Set<string>>(
     new Set(),
   );
-  const [downloadStarted, setDownloadStarted] = useState(false);
   const sessionKeyRef = useRef<string | null>(null);
 
   const {
@@ -54,7 +50,6 @@ export function usePrepareOfflineResources({
     if (sessionKeyRef.current !== sessionKey) {
       clearSessionInventory();
       setDeselectedItemIds(getDefaultPackageDeselects());
-      setDownloadStarted(false);
       sessionKeyRef.current = sessionKey;
     }
   }, [sessionKey, clearSessionInventory, getDefaultPackageDeselects]);
@@ -133,33 +128,18 @@ export function usePrepareOfflineResources({
     [catalog.items],
   );
 
-  const handleDownload = useCallback(() => {
-    if (!canDownload || projectId === null || userId === null) {
-      return;
-    }
-
-    setPrepareOfflineDownloadStarted(String(userId), projectId);
-    enqueuePrepareOfflineDownload({
-      userId,
-      projectId,
-      items: sortItemsForPrepareOfflineDownload(selectedItems, catalog.items),
-    });
-    setDownloadStarted(true);
-  }, [canDownload, catalog.items, projectId, selectedItems, userId]);
-
   return {
     catalog,
     effectiveCatalog,
     deselectedItemIds,
     totalBytes,
     pendingBytes,
+    selectedItems,
     canDownload,
     downloadButtonLabel,
-    downloadStarted,
     manifestLoading,
     manifestError,
     isItemSelected,
     toggleItemSelected,
-    handleDownload,
   };
 }

--- a/src/mocks/prepareOffline/mockDownloadSources.ts
+++ b/src/mocks/prepareOffline/mockDownloadSources.ts
@@ -1,0 +1,44 @@
+/**
+ * Prepare for Offline — dev-only download URLs (#52 wiring until manifest API).
+ *
+ * **Security:** URLs are hardcoded public test fixtures (not user/API input).
+ * Used only when `__DEV__` is true; production returns empty `sourceUrl`.
+ * Files land in the app sandbox (`downloadStorage.ts`) and are not executed.
+ * Review any URL change in PR — prefer team-owned fixtures if external hosts
+ * are a concern. Replaced in production by per-resource `sourceUrl` from manifest.
+ */
+import { PrepareOfflineResourceKind } from '../../types/prepareOffline/types';
+
+export interface MockDownloadSource {
+  sourceUrl: string;
+  fileExt: string;
+}
+
+const DEV_MOCK_SOURCES: Record<PrepareOfflineResourceKind, MockDownloadSource> =
+  {
+    text: {
+      sourceUrl:
+        'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+      fileExt: 'pdf',
+    },
+    audio: {
+      sourceUrl:
+        'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+      fileExt: 'mp3',
+    },
+    image: {
+      sourceUrl:
+        'https://static.wixstatic.com/media/046448_76b4a2424bde4b43beb678785f075411~mv2.png/v1/fill/w_168,h_51,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/ETEN-Logo-onLight_2x.png',
+      fileExt: 'png',
+    },
+  };
+
+export function getMockDownloadSource(
+  kind: PrepareOfflineResourceKind,
+): MockDownloadSource {
+  if (__DEV__) {
+    return DEV_MOCK_SOURCES[kind];
+  }
+
+  return { sourceUrl: '', fileExt: 'bin' };
+}

--- a/src/services/downloadQueueAutoResume.test.ts
+++ b/src/services/downloadQueueAutoResume.test.ts
@@ -78,4 +78,36 @@ describe('downloadQueueAutoResume', () => {
     expect(mockGetResumable).not.toHaveBeenCalled();
     expect(mockWorkerStart).not.toHaveBeenCalled();
   });
+
+  it('does not start worker after unsubscribe while resumable fetch is pending', async () => {
+    let resolveResumable: (value: unknown[]) => void = () => undefined;
+    mockGetResumable.mockImplementation(
+      () =>
+        new Promise<unknown[]>(resolve => {
+          resolveResumable = resolve;
+        }),
+    );
+
+    const stop = startDownloadQueueAutoResume();
+    const listener = mockSubscribe.mock.calls[0][0];
+
+    void listener(true, true, false);
+    stop();
+
+    resolveResumable([
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'cancelled',
+        projectId: 1,
+      },
+    ]);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockWorkerStart).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/downloadQueueAutoResume.test.ts
+++ b/src/services/downloadQueueAutoResume.test.ts
@@ -1,0 +1,81 @@
+import { startDownloadQueueAutoResume } from './downloadQueueAutoResume';
+import { getSharedDownloadQueueWorker } from './downloadQueueWorkerSingleton';
+
+const mockSubscribe = jest.fn();
+const mockGetResumable = jest.fn();
+const mockWorkerStart = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('./connectivity', () => ({
+  subscribeToConnectivity: (...args: unknown[]) => mockSubscribe(...args),
+}));
+
+jest.mock('../db/repository', () => ({
+  getResumableDownloadItems: (...args: unknown[]) => mockGetResumable(...args),
+}));
+
+jest.mock('./downloadQueueWorkerSingleton', () => ({
+  getSharedDownloadQueueWorker: jest.fn(),
+}));
+
+describe('downloadQueueAutoResume', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubscribe.mockReturnValue(jest.fn());
+    mockGetResumable.mockResolvedValue([]);
+    mockWorkerStart.mockResolvedValue(undefined);
+    mockGetState.mockReturnValue('idle');
+    (getSharedDownloadQueueWorker as jest.Mock).mockReturnValue({
+      getState: mockGetState,
+      start: mockWorkerStart,
+    });
+  });
+
+  it('does not resume when not on Wi-Fi', async () => {
+    startDownloadQueueAutoResume();
+    const listener = mockSubscribe.mock.calls[0][0];
+
+    await listener(false, false, false);
+
+    expect(mockGetResumable).not.toHaveBeenCalled();
+    expect(mockWorkerStart).not.toHaveBeenCalled();
+  });
+
+  it('resumes cancelled queue items on Wi-Fi', async () => {
+    mockGetResumable.mockResolvedValue([
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'cancelled',
+        projectId: 1,
+      },
+    ]);
+
+    startDownloadQueueAutoResume();
+    const listener = mockSubscribe.mock.calls[0][0];
+
+    await listener(true, true, false);
+
+    await Promise.resolve();
+
+    expect(mockGetResumable).toHaveBeenCalledWith(true);
+    expect(mockWorkerStart).toHaveBeenCalledWith([
+      expect.objectContaining({ status: 'cancelled' }),
+    ]);
+  });
+
+  it('skips auto-resume while worker is actively downloading', async () => {
+    mockGetState.mockReturnValue('downloading');
+
+    startDownloadQueueAutoResume();
+    const listener = mockSubscribe.mock.calls[0][0];
+
+    await listener(true, true, false);
+    await Promise.resolve();
+
+    expect(mockGetResumable).not.toHaveBeenCalled();
+    expect(mockWorkerStart).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/downloadQueueAutoResume.ts
+++ b/src/services/downloadQueueAutoResume.ts
@@ -6,9 +6,11 @@ import { logger } from '../utils/logger';
 const log = logger.create('downloadQueueAutoResume');
 
 export function startDownloadQueueAutoResume(): () => void {
-  return subscribeToConnectivity((isOnline, isWifi) => {
+  let disposed = false;
+
+  const unsubscribe = subscribeToConnectivity((isOnline, isWifi) => {
     void (async () => {
-      if (!isOnline || !isWifi) {
+      if (disposed || !isOnline || !isWifi) {
         return;
       }
 
@@ -21,6 +23,10 @@ export function startDownloadQueueAutoResume(): () => void {
 
       try {
         const items = await getResumableDownloadItems(true);
+        if (disposed) {
+          return;
+        }
+
         const resumable = items.filter(item =>
           ['queued', 'paused', 'cancelled', 'failed'].includes(item.status),
         );
@@ -38,6 +44,11 @@ export function startDownloadQueueAutoResume(): () => void {
       }
     })();
   });
+
+  return () => {
+    disposed = true;
+    unsubscribe();
+  };
 }
 
 export function stopDownloadQueueAutoResume(unsubscribe: (() => void) | null) {

--- a/src/services/downloadQueueAutoResume.ts
+++ b/src/services/downloadQueueAutoResume.ts
@@ -1,0 +1,45 @@
+import { getResumableDownloadItems } from '../db/repository';
+import { subscribeToConnectivity } from './connectivity';
+import { getSharedDownloadQueueWorker } from './downloadQueueWorkerSingleton';
+import { logger } from '../utils/logger';
+
+const log = logger.create('downloadQueueAutoResume');
+
+export function startDownloadQueueAutoResume(): () => void {
+  return subscribeToConnectivity((isOnline, isWifi) => {
+    void (async () => {
+      if (!isOnline || !isWifi) {
+        return;
+      }
+
+      const worker = getSharedDownloadQueueWorker();
+      const workerState = worker.getState();
+
+      if (workerState === 'downloading' || workerState === 'paused') {
+        return;
+      }
+
+      try {
+        const items = await getResumableDownloadItems(true);
+        const resumable = items.filter(item =>
+          ['queued', 'paused', 'cancelled', 'failed'].includes(item.status),
+        );
+
+        if (resumable.length === 0) {
+          return;
+        }
+
+        log.info('Auto-resuming download queue on Wi-Fi', {
+          count: resumable.length,
+        });
+        await worker.start(resumable);
+      } catch (error) {
+        log.error('Download queue auto-resume failed', { error });
+      }
+    })();
+  });
+}
+
+export function stopDownloadQueueAutoResume(unsubscribe: (() => void) | null) {
+  unsubscribe?.();
+}

--- a/src/services/downloadQueueWorker.test.ts
+++ b/src/services/downloadQueueWorker.test.ts
@@ -340,16 +340,50 @@ describe('DownloadQueueWorker', () => {
         'item-1',
         expect.stringContaining('resume-token'),
       );
-      expect(worker.getState()).toBe('cancelled');
+      expect(worker.getState()).toBe('idle');
       expect(mockMarkDownloadItemFailed).not.toHaveBeenCalled();
     });
+
+    it('cancel after pause reuses saved pause state without calling pauseAsync again', async () => {
+      const pauseAsync = jest.fn().mockResolvedValue({
+        url: 'https://example.com/x.mp3',
+        fileUri: 'file:///docs/downloads/1/item-1.mp3',
+        options: {},
+        resumeData: 'resume-token',
+      });
+      spyResumable({
+        downloadAsync: jest.fn().mockReturnValue(new Promise(() => {})),
+        pauseAsync,
+      });
+      const resolver = jest
+        .fn()
+        .mockResolvedValue({ url: 'https://example.com/x.mp3', ext: 'mp3' });
+
+      const worker = new DownloadQueueWorker(resolver);
+      void worker.start([makeItem()]);
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      await worker.pause();
+      expect(pauseAsync).toHaveBeenCalledTimes(1);
+
+      await worker.cancel();
+
+      expect(pauseAsync).toHaveBeenCalledTimes(1);
+      expect(mockMarkDownloadItemCancelled).toHaveBeenCalledWith(
+        'item-1',
+        expect.stringContaining('resume-token'),
+      );
+      expect(worker.getState()).toBe('idle');
+    });
+
     it('cancel with nothing active still transitions state and clears the queue', async () => {
       const worker = new DownloadQueueWorker(async () => ({
         url: 'https://example.com/x.mp3',
         ext: 'mp3',
       }));
       await worker.cancel();
-      expect(worker.getState()).toBe('cancelled');
+      expect(worker.getState()).toBe('idle');
     });
   });
 

--- a/src/services/downloadQueueWorker.ts
+++ b/src/services/downloadQueueWorker.ts
@@ -26,6 +26,8 @@ export type ResourceResolver = (
 type ActiveDownload = {
   itemId: string;
   resumable: FileSystem.DownloadResumable;
+  /** Set when pauseAsync succeeds — reused on cancel to avoid double-pause. */
+  savedPauseState?: string;
 };
 
 type SavedDownloadState = {
@@ -91,10 +93,11 @@ export class DownloadQueueWorker {
     this.state = 'paused';
     try {
       const pauseState = await this.active.resumable.pauseAsync();
-      await markDownloadItemPaused(
-        this.active.itemId,
-        serializeDownloadState(pauseState),
-      );
+      const serialized = serializeDownloadState(pauseState);
+      if (serialized) {
+        this.active.savedPauseState = serialized;
+      }
+      await markDownloadItemPaused(this.active.itemId, serialized);
     } catch (error) {
       log.error('Failed to pause active download', { error });
       // The native transfer may still be running — don't report a paused
@@ -143,21 +146,35 @@ export class DownloadQueueWorker {
   }
 
   async cancel(): Promise<void> {
+    const wasPaused = this.state === 'paused';
+    const active = this.active;
+
     this.state = 'cancelled';
-    if (this.active) {
-      try {
-        const pauseState = await this.active.resumable.pauseAsync();
-        await markDownloadItemCancelled(
-          this.active.itemId,
-          serializeDownloadState(pauseState),
-        );
-      } catch (error) {
-        log.error('Failed to pause on cancel', { error });
-        await markDownloadItemCancelled(this.active.itemId);
+    this.queue = [];
+
+    if (active) {
+      const { itemId, resumable, savedPauseState } = active;
+
+      if (wasPaused) {
+        // Already paused — do not call pauseAsync again (native throws
+        // "No download object available"). Resume data was persisted on pause.
+        await markDownloadItemCancelled(itemId, savedPauseState);
+      } else {
+        try {
+          const pauseState = await resumable.pauseAsync();
+          await markDownloadItemCancelled(
+            itemId,
+            serializeDownloadState(pauseState),
+          );
+        } catch (error) {
+          log.error('Failed to pause on cancel', { error, itemId });
+          await markDownloadItemCancelled(itemId, savedPauseState);
+        }
       }
     }
+
     this.active = null;
-    this.queue = [];
+    this.state = 'idle';
   }
 
   private async processNext(): Promise<void> {

--- a/src/services/downloadQueueWorkerSingleton.ts
+++ b/src/services/downloadQueueWorkerSingleton.ts
@@ -1,0 +1,15 @@
+import { DownloadQueueWorker } from './downloadQueueWorker';
+import { queuedResourceResolver } from './downloadResourceResolver';
+
+let worker: DownloadQueueWorker | null = null;
+
+export function getSharedDownloadQueueWorker(): DownloadQueueWorker {
+  if (!worker) {
+    worker = new DownloadQueueWorker(queuedResourceResolver);
+  }
+  return worker;
+}
+
+export function resetSharedDownloadQueueWorkerForTests(): void {
+  worker = null;
+}

--- a/src/services/prepareOfflineDownload.ts
+++ b/src/services/prepareOfflineDownload.ts
@@ -1,6 +1,8 @@
+import { enqueueDownloadItems } from '../db/repository';
 import { simulatePrepareOfflineDownloadProgress } from './prepareOfflineResources';
 import { PrepareOfflineResourceItem } from '../types/prepareOffline/types';
 import { logger } from '../utils/logger';
+import { prepareOfflineItemsToEnqueueInputs } from '../utils/prepareOfflineQueueMapping';
 
 const log = logger.create('prepareOfflineDownload');
 
@@ -11,22 +13,44 @@ export interface EnqueuePrepareOfflineDownloadInput {
 }
 
 /**
- * Enqueue selected resources for tier-ordered download.
- * Items must be in manifest/catalog order (see sortItemsForPrepareOfflineDownload).
- * TODO(#201): persist queue rows and start the download worker.
- *
- * In dev, delegates progress simulation to prepareOfflineResources service.
+ * Enqueue selected resources for tier-ordered download using stable catalog ids.
+ * Returns enqueued queue row ids (may be fewer when rows already exist).
  */
-export function enqueuePrepareOfflineDownload(
+export async function enqueuePrepareOfflineDownload(
   input: EnqueuePrepareOfflineDownloadInput,
-): void {
-  log.info('Prepare offline download enqueue stub', {
+): Promise<string[]> {
+  log.info('Enqueue prepare offline download', {
     userId: input.userId,
     projectId: input.projectId,
     itemCount: input.items.length,
   });
 
-  const tierOrderedIds = input.items.map(item => item.id);
+  const enqueueInputs = prepareOfflineItemsToEnqueueInputs(
+    input.items,
+    input.projectId,
+  );
 
-  simulatePrepareOfflineDownloadProgress(input.projectId, tierOrderedIds);
+  try {
+    const ids = await enqueueDownloadItems(enqueueInputs);
+    log.info('Prepare offline items enqueued', {
+      projectId: input.projectId,
+      enqueuedCount: ids.length,
+    });
+    return ids;
+  } catch (error) {
+    log.error(
+      'Failed to enqueue prepare offline download; falling back to dev mock',
+      {
+        error,
+        projectId: input.projectId,
+      },
+    );
+
+    if (__DEV__) {
+      const tierOrderedIds = input.items.map(item => item.id);
+      simulatePrepareOfflineDownloadProgress(input.projectId, tierOrderedIds);
+    }
+
+    return [];
+  }
 }

--- a/src/services/prepareOfflineDownload.ts
+++ b/src/services/prepareOfflineDownload.ts
@@ -49,8 +49,9 @@ export async function enqueuePrepareOfflineDownload(
     if (__DEV__) {
       const tierOrderedIds = input.items.map(item => item.id);
       simulatePrepareOfflineDownloadProgress(input.projectId, tierOrderedIds);
+      return [];
     }
 
-    return [];
+    throw error;
   }
 }

--- a/src/types/prepareOffline/types.ts
+++ b/src/types/prepareOffline/types.ts
@@ -55,7 +55,8 @@ export type PrepareOfflineResourceStatus =
   | 'completed'
   | 'selected'
   | 'available'
-  | 'downloading';
+  | 'downloading'
+  | 'paused';
 
 export interface PrepareOfflineResourceItem {
   id: string;
@@ -65,7 +66,7 @@ export interface PrepareOfflineResourceItem {
   label: string;
   bytes: number;
   status: PrepareOfflineResourceStatus;
-  /** 0–1 while status is `downloading`. */
+  /** Partial progress (0–1) while queued, downloading, paused, cancelled, or failed. */
   progress?: number;
 }
 

--- a/src/types/prepareOffline/types.ts
+++ b/src/types/prepareOffline/types.ts
@@ -65,6 +65,8 @@ export interface PrepareOfflineResourceItem {
   label: string;
   bytes: number;
   status: PrepareOfflineResourceStatus;
+  /** 0–1 while status is `downloading`. */
+  progress?: number;
 }
 
 export interface PrepareOfflineResourceGroup {

--- a/src/utils/mergeQueueIntoPrepareOfflineCatalog.test.ts
+++ b/src/utils/mergeQueueIntoPrepareOfflineCatalog.test.ts
@@ -40,6 +40,25 @@ describe('mergeQueueIntoPrepareOfflineCatalog', () => {
     expect(item.progress).toBe(0.42);
   });
 
+  it('overlays paused status and progress', () => {
+    const queueItems: DownloadQueueItem[] = [
+      {
+        id: baseItem.id,
+        tier: 1,
+        label: 'Text',
+        progress: 0.42,
+        status: 'paused',
+        projectId: 1,
+      },
+    ];
+
+    const merged = mergeQueueIntoPrepareOfflineCatalog(catalog, queueItems, 1);
+    const item = merged.items[0];
+
+    expect(item.status).toBe('paused');
+    expect(item.progress).toBe(0.42);
+  });
+
   it('overlays completed status from queue', () => {
     const queueItems: DownloadQueueItem[] = [
       {

--- a/src/utils/mergeQueueIntoPrepareOfflineCatalog.test.ts
+++ b/src/utils/mergeQueueIntoPrepareOfflineCatalog.test.ts
@@ -1,0 +1,112 @@
+import { mergeQueueIntoPrepareOfflineCatalog } from './mergeQueueIntoPrepareOfflineCatalog';
+import {
+  PrepareOfflineCatalog,
+  PrepareOfflineResourceItem,
+} from '../types/prepareOffline/types';
+import type { DownloadQueueItem } from '../types/download/types';
+
+const baseItem: PrepareOfflineResourceItem = {
+  id: 'tier-1-source-bible-text',
+  tier: 1,
+  kind: 'text',
+  groupName: 'Source Bible',
+  label: 'Text',
+  bytes: 8 * 1024 * 1024,
+  status: 'selected',
+};
+
+const catalog: PrepareOfflineCatalog = {
+  items: [baseItem],
+  groups: [{ groupName: 'Source Bible', items: [baseItem] }],
+};
+
+describe('mergeQueueIntoPrepareOfflineCatalog', () => {
+  it('overlays downloading status and progress', () => {
+    const queueItems: DownloadQueueItem[] = [
+      {
+        id: baseItem.id,
+        tier: 1,
+        label: 'Text',
+        progress: 0.42,
+        status: 'downloading',
+        projectId: 1,
+      },
+    ];
+
+    const merged = mergeQueueIntoPrepareOfflineCatalog(catalog, queueItems, 1);
+    const item = merged.items[0];
+
+    expect(item.status).toBe('downloading');
+    expect(item.progress).toBe(0.42);
+  });
+
+  it('overlays completed status from queue', () => {
+    const queueItems: DownloadQueueItem[] = [
+      {
+        id: baseItem.id,
+        tier: 1,
+        label: 'Text',
+        progress: 1,
+        status: 'completed',
+        projectId: 1,
+      },
+    ];
+
+    const merged = mergeQueueIntoPrepareOfflineCatalog(catalog, queueItems, 1);
+
+    expect(merged.items[0].status).toBe('completed');
+  });
+
+  it('leaves queued items at catalog status', () => {
+    const queueItems: DownloadQueueItem[] = [
+      {
+        id: baseItem.id,
+        tier: 1,
+        label: 'Text',
+        progress: 0,
+        status: 'queued',
+        projectId: 1,
+      },
+    ];
+
+    const merged = mergeQueueIntoPrepareOfflineCatalog(catalog, queueItems, 1);
+
+    expect(merged.items[0].status).toBe('selected');
+    expect(merged.items[0].progress).toBeUndefined();
+  });
+
+  it('preserves partial progress on cancelled queue rows', () => {
+    const queueItems: DownloadQueueItem[] = [
+      {
+        id: baseItem.id,
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'cancelled',
+        projectId: 1,
+      },
+    ];
+
+    const merged = mergeQueueIntoPrepareOfflineCatalog(catalog, queueItems, 1);
+
+    expect(merged.items[0].status).toBe('selected');
+    expect(merged.items[0].progress).toBe(0.5);
+  });
+
+  it('ignores queue rows for other projects', () => {
+    const queueItems: DownloadQueueItem[] = [
+      {
+        id: baseItem.id,
+        tier: 1,
+        label: 'Text',
+        progress: 0.5,
+        status: 'downloading',
+        projectId: 99,
+      },
+    ];
+
+    const merged = mergeQueueIntoPrepareOfflineCatalog(catalog, queueItems, 1);
+
+    expect(merged.items[0].status).toBe('selected');
+  });
+});

--- a/src/utils/mergeQueueIntoPrepareOfflineCatalog.ts
+++ b/src/utils/mergeQueueIntoPrepareOfflineCatalog.ts
@@ -19,10 +19,14 @@ function overlayStatusFromQueue(
         status: 'downloading',
         progress: queueItem.progress,
       };
+    case 'paused':
+      return {
+        status: 'paused',
+        progress: queueItem.progress,
+      };
     case 'completed':
       return { status: 'completed' };
     case 'queued':
-    case 'paused':
     case 'cancelled':
     case 'failed': {
       const partialProgress =

--- a/src/utils/mergeQueueIntoPrepareOfflineCatalog.ts
+++ b/src/utils/mergeQueueIntoPrepareOfflineCatalog.ts
@@ -1,0 +1,87 @@
+import type { DownloadQueueItem } from '../types/download/types';
+import {
+  PrepareOfflineCatalog,
+  PrepareOfflineResourceItem,
+  PrepareOfflineResourceStatus,
+} from '../types/prepareOffline/types';
+
+function overlayStatusFromQueue(
+  catalogStatus: PrepareOfflineResourceStatus,
+  queueItem: DownloadQueueItem | undefined,
+): { status: PrepareOfflineResourceStatus; progress?: number } {
+  if (!queueItem) {
+    return { status: catalogStatus };
+  }
+
+  switch (queueItem.status) {
+    case 'downloading':
+      return {
+        status: 'downloading',
+        progress: queueItem.progress,
+      };
+    case 'completed':
+      return { status: 'completed' };
+    case 'queued':
+    case 'paused':
+    case 'cancelled':
+    case 'failed': {
+      const partialProgress =
+        queueItem.progress > 0 ? queueItem.progress : undefined;
+      return partialProgress !== undefined
+        ? { status: catalogStatus, progress: partialProgress }
+        : { status: catalogStatus };
+    }
+    default:
+      return { status: catalogStatus };
+  }
+}
+
+function overlayItem(
+  item: PrepareOfflineResourceItem,
+  queueById: Map<string, DownloadQueueItem>,
+): PrepareOfflineResourceItem {
+  const queueItem = queueById.get(item.id);
+  const { status, progress } = overlayStatusFromQueue(item.status, queueItem);
+
+  if (status === item.status && progress === undefined) {
+    return item;
+  }
+
+  return {
+    ...item,
+    status,
+    progress,
+  };
+}
+
+/**
+ * Overlays download_queue status and progress onto a Prepare for Offline catalog.
+ */
+export function mergeQueueIntoPrepareOfflineCatalog(
+  catalog: PrepareOfflineCatalog,
+  queueItems: DownloadQueueItem[],
+  projectId: number | null,
+): PrepareOfflineCatalog {
+  if (projectId === null) {
+    return catalog;
+  }
+
+  const queueById = new Map<string, DownloadQueueItem>();
+  for (const queueItem of queueItems) {
+    if (queueItem.projectId === projectId) {
+      queueById.set(queueItem.id, queueItem);
+    }
+  }
+
+  if (queueById.size === 0) {
+    return catalog;
+  }
+
+  const items = catalog.items.map(item => overlayItem(item, queueById));
+  const groups = catalog.groups.map(group => ({
+    ...group,
+    items: group.items.map(item => overlayItem(item, queueById)),
+  }));
+
+  return { items, groups };
+}

--- a/src/utils/prepareOfflineCatalog.test.ts
+++ b/src/utils/prepareOfflineCatalog.test.ts
@@ -2,10 +2,12 @@ import {
   buildPrepareOfflineCatalog,
   buildEffectiveCatalog,
   computePendingBytes,
+  computeRemainingBytes,
   computeTotalBytes,
   computeManifestBytesForScope,
   filterPrepareOfflineCatalogByTiers,
   getEffectiveItems,
+  getRemainingBytesForItem,
   isItemCustomizeLocked,
   isItemIncluded,
   isTierLocked,
@@ -255,6 +257,61 @@ describe('prepareOfflineCatalog', () => {
     expect(
       getEffectiveItems(catalog, new Set([questionsAudioId])),
     ).toHaveLength(catalog.items.length - 1);
+  });
+
+  it('computeRemainingBytes uses full catalog bytes for non-completed items', () => {
+    const remaining = computeRemainingBytes([
+      {
+        id: 'tier-1-source-bible-text',
+        tier: 1,
+        kind: 'text',
+        groupName: 'Source Bible',
+        label: 'Text',
+        bytes: 100,
+        status: 'downloading',
+        progress: 0.25,
+      },
+      {
+        id: 'tier-1-source-bible-audio',
+        tier: 1,
+        kind: 'audio',
+        groupName: 'Source Bible',
+        label: 'Audio',
+        bytes: 200,
+        status: 'selected',
+      },
+    ]);
+
+    expect(remaining).toBe(100 + 200);
+  });
+
+  it('getRemainingBytesForItem returns zero for completed rows', () => {
+    expect(
+      getRemainingBytesForItem({
+        id: 'tier-3-bible-commentary-text',
+        tier: 3,
+        kind: 'text',
+        groupName: 'Bible Commentary',
+        label: 'Text',
+        bytes: 12 * 1024 * 1024,
+        status: 'completed',
+      }),
+    ).toBe(0);
+  });
+
+  it('getRemainingBytesForItem returns full catalog bytes for non-completed rows', () => {
+    expect(
+      getRemainingBytesForItem({
+        id: 'tier-3-bible-commentary-audio',
+        tier: 3,
+        kind: 'audio',
+        groupName: 'Bible Commentary',
+        label: 'Audio',
+        bytes: 24 * 1024 * 1024,
+        status: 'selected',
+        progress: 0.5,
+      }),
+    ).toBe(24 * 1024 * 1024);
   });
 
   it('buildEffectiveCatalog omits deselected tier 2/3 from summary groups', () => {

--- a/src/utils/prepareOfflineCatalog.ts
+++ b/src/utils/prepareOfflineCatalog.ts
@@ -115,9 +115,25 @@ export function computePendingBytes(
   catalog: PrepareOfflineCatalog,
   deselectedItemIds: Set<string>,
 ): number {
-  return getEffectiveItems(catalog, deselectedItemIds)
-    .filter(item => item.status !== 'completed')
-    .reduce((sum, item) => sum + item.bytes, 0);
+  return computeRemainingBytes(getEffectiveItems(catalog, deselectedItemIds));
+}
+
+/** Pending bytes for one catalog row (full catalog size; not adjusted for partial download). */
+export function getRemainingBytesForItem(
+  item: PrepareOfflineResourceItem,
+): number {
+  if (item.status === 'completed') {
+    return 0;
+  }
+
+  return item.bytes;
+}
+
+/** Sum of pending bytes for a set of items (excludes completed; no partial-progress adjustment). */
+export function computeRemainingBytes(
+  items: PrepareOfflineResourceItem[],
+): number {
+  return items.reduce((sum, item) => sum + getRemainingBytesForItem(item), 0);
 }
 
 /** Pure catalog builder — manifest and status come from prepareOfflineResources service. */

--- a/src/utils/prepareOfflineQueueMapping.test.ts
+++ b/src/utils/prepareOfflineQueueMapping.test.ts
@@ -1,0 +1,75 @@
+import {
+  prepareOfflineItemToEnqueueInput,
+  prepareOfflineItemsToEnqueueInputs,
+} from './prepareOfflineQueueMapping';
+import { PrepareOfflineResourceItem } from '../types/prepareOffline/types';
+
+const baseItem: PrepareOfflineResourceItem = {
+  id: 'tier-1-source-bible-text',
+  tier: 1,
+  kind: 'text',
+  groupName: 'Source Bible',
+  label: 'Text',
+  bytes: 8 * 1024 * 1024,
+  status: 'selected',
+};
+
+describe('prepareOfflineQueueMapping', () => {
+  it('uses stable catalog id as queue primary key', () => {
+    const input = prepareOfflineItemToEnqueueInput(baseItem, 42);
+
+    expect(input.id).toBe('tier-1-source-bible-text');
+    expect(input.projectId).toBe(42);
+    expect(input.tier).toBe(1);
+    expect(input.resourceName).toBe('Source Bible');
+    expect(input.label).toBe('Text');
+    expect(input.bytesTotal).toBe(baseItem.bytes);
+  });
+
+  it('maps audio and image kinds to queue fields', () => {
+    const audio = prepareOfflineItemToEnqueueInput(
+      { ...baseItem, id: 'tier-1-source-bible-audio', kind: 'audio' },
+      1,
+    );
+    const image = prepareOfflineItemToEnqueueInput(
+      {
+        ...baseItem,
+        id: 'tier-3-reference-images-image',
+        tier: 3,
+        kind: 'image',
+        groupName: 'Reference Images',
+      },
+      1,
+    );
+
+    expect(audio.kind).toBe('audio');
+    expect(image.kind).toBe('text');
+    expect(image.fileExt).toBe('png');
+  });
+
+  it('preserves tier order when mapping multiple items', () => {
+    const items = prepareOfflineItemsToEnqueueInputs(
+      [
+        baseItem,
+        {
+          ...baseItem,
+          id: 'tier-2-translation-words-text',
+          tier: 2,
+          groupName: 'Translation Words',
+        },
+      ],
+      5,
+    );
+
+    expect(items.map(item => item.tier)).toEqual([1, 2]);
+    expect(items.every(item => item.projectId === 5)).toBe(true);
+  });
+
+  it('includes dev mock sourceUrl and fileExt', () => {
+    const input = prepareOfflineItemToEnqueueInput(baseItem, 1);
+
+    expect(input.sourceUrl).toEqual(expect.any(String));
+    expect(input.fileExt).toEqual(expect.any(String));
+    expect(input.sourceUrl?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/prepareOfflineQueueMapping.ts
+++ b/src/utils/prepareOfflineQueueMapping.ts
@@ -1,0 +1,39 @@
+import type { EnqueueDownloadItemInput } from '../db/downloadQueueRepository';
+import { getMockDownloadSource } from '../mocks/prepareOffline/mockDownloadSources';
+import { PrepareOfflineResourceItem } from '../types/prepareOffline/types';
+
+function queueKindForResource(
+  kind: PrepareOfflineResourceItem['kind'],
+): EnqueueDownloadItemInput['kind'] {
+  return kind === 'audio' ? 'audio' : 'text';
+}
+
+/**
+ * Maps a Prepare for Offline catalog row to a download_queue enqueue input.
+ * Uses stable `item.id` as the queue primary key.
+ */
+export function prepareOfflineItemToEnqueueInput(
+  item: PrepareOfflineResourceItem,
+  projectId: number,
+): EnqueueDownloadItemInput {
+  const { sourceUrl, fileExt } = getMockDownloadSource(item.kind);
+
+  return {
+    id: item.id,
+    projectId,
+    tier: item.tier,
+    kind: queueKindForResource(item.kind),
+    resourceName: item.groupName,
+    label: item.label,
+    sourceUrl: __DEV__ ? sourceUrl : undefined,
+    fileExt: __DEV__ ? fileExt : undefined,
+    bytesTotal: item.bytes,
+  };
+}
+
+export function prepareOfflineItemsToEnqueueInputs(
+  items: PrepareOfflineResourceItem[],
+  projectId: number,
+): EnqueueDownloadItemInput[] {
+  return items.map(item => prepareOfflineItemToEnqueueInput(item, projectId));
+}


### PR DESCRIPTION
### TLDR

Adds Pause / Resume / Cancel session controls and per-item circular download progress on Prepare for Offline (#52), wiring the #51 UI to the real SQLite download queue and worker. Introduces `usePrepareOfflineDownload` for session state and live progress overlay, plus Wi‑Fi auto-resume at app init.

### Reviewer checklist

- [ ] GitHub issue linked in Details (`Refs #52`)
- [ ] How to verify steps completed or valid waiver noted below
- [ ] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [ ] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Refs #52

Implements download session controls and per-resource progress rings after the user starts a download on Prepare for Offline. Replaces the #51 enqueue stub with real `download_queue` persistence, unifies footer controls (Pause / Resume / Cancel / Download complete) via a dedicated hook, and merges live queue progress into the resource catalog for row UI.

**Product validation needed — post-complete screen state (#51 carry-over)**  
Issue #51 introduced a **“Download complete”** footer label when all selected items finish. #52 keeps that label as an interim “session finished” state. There is no finalized spec for what the footer and screen should show **after the user leaves and returns**, or when selection changes later. **Please confirm** the desired long-term behavior. @chadw-eten

**Device QA (author)**  
Tested on Android: pause/resume/cancel, progress rings, and Cancel + Wi‑Fi reconnect / app restart — downloads resume per #52 AC (*partial progress kept; auto-resume on next Wi‑Fi*).

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/hooks/usePrepareOfflineDownload.ts`** — Session state; download/pause/resume/cancel; `catalogWithProgress`; remount restore
- **`src/hooks/useDownloadQueue.ts`** — Worker session state; poll during active transfers
- **`src/app/prepare-offline/PrepareOfflineDownloadFooter.tsx`** — Pause / Resume / Cancel / Download complete
- **`src/app/prepare-offline/ResourceDownloadProgressRing.tsx`** — Progress ring + animated Download icon
- **`src/app/prepare-offline/ResourceItemRow.tsx`** — Ring when downloading; remaining bytes aligned with footer
- **`src/app/screens/PrepareForOfflineScreen.tsx`** — Wire download hook + `catalogWithProgress`
- **`src/services/prepareOfflineDownload.ts`**, **`downloadQueueAutoResume.ts`**, **`downloadQueueWorkerSingleton.ts`** — Real enqueue, Wi‑Fi auto-resume, shared worker
- **`src/db/downloadQueueRepository.ts`** — Cancel without in-memory worker handle
- **`src/utils/prepareOfflineQueueMapping.ts`**, **`mergeQueueIntoPrepareOfflineCatalog.ts`**, **`prepareOfflineCatalog.ts`** — Catalog ↔ queue mapping and progress overlay
- Tests across hook, footer, rows, worker, mapper, merge, auto-resume, repository

#### Testing

```bash
npm run format:check
npm run lint
npm run typecheck
npm test -- --ci
```

_(Preencher pass/fail antes de marcar ready for review.)_

### How to verify

| Step | Action | Expected |
| --- | --- | --- |
| 1 | **Android device:** open Prepare for Offline → select a project | Resource list loads with Download footer |
| 2 | Tap **Download** | Footer shows **Pause + Cancel**; active row shows progress ring + download icon |
| 3 | Tap **Pause** | Footer shows **Resume + Cancel**; row progress freezes |
| 4 | Tap **Resume** | Download continues from the same progress; footer back to **Pause + Cancel** |
| 5 | Tap **Cancel** | Footer returns to **Download** CTA (not stuck on Pause/Cancel) |
| 6 | Tap **Download** again after cancel | Resumes from partial progress, not from zero |
| 7 | Let all selected items finish | Footer shows **Download complete**; completed rows show green check |

**Expected (overall):** Control states match #52 AC; pause/resume retains progress; cancel restores Download CTA; per-item rings and checkmarks behave as designed.

### Demo video

https://github.com/user-attachments/assets/d038853c-9b1c-41de-b8b8-f1188337bebb

- **Real downloads (`__DEV__`):** Prepare for Offline performs actual HTTP downloads to the app sandbox (SQLite queue + worker) — progress is not simulated. Until manifest API URLs ship, dev builds use three public test fixtures by resource kind (`src/mocks/prepareOffline/mockDownloadSources.ts`):
  - **text:** https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf
  - **audio:** https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3
  - **image:** https://static.wixstatic.com/media/046448_76b4a2424bde4b43beb678785f075411~mv2.png/v1/fill/w_168,h_51,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/ETEN-Logo-onLight_2x.png
- **Progress ring may flash quickly:** The catalog shows larger byte labels, but these fixture files are small, so transfers finish fast and the active-row loading/progress ring may appear only briefly — expected in dev, not a missing animation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause, resume, and cancel controls for offline downloads.
  * Added circular progress indicators and partial-progress details for resources.
  * Offline downloads now restore progress and resume automatically when connected over Wi‑Fi.
  * Download status and remaining size update more accurately across queued, paused, cancelled, and completed items.

* **Bug Fixes**
  * Improved cancellation behavior for paused and active downloads.
  * Preserved partial progress when downloads are interrupted or resumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->