### PR TITLE
[#319]: Add pr-demo-video agent skill for Cursor and Claude Code

### DIFF
--- a/.claude/skills/pr-demo-video/SKILL.md
+++ b/.claude/skills/pr-demo-video/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pr-demo-video
+description: >-
+  Record a VIDEO / screencast demo of a PR or feature (not static screenshots).
+  Use when asked to make a video of this working, record a demo for the PR, show
+  the agent doing X on video, or add a voiceover to the demo. Covers browser UI
+  flows and AI-agent/CLI flows. Works in Cursor Agent and Claude Code. Example
+  scripts target SkyPortal; adapt CONFIG/FLOW per app/PR.
+---
+
+# PR demo videos
+
+## Agent environments (Cursor + Claude Code)
+
+This skill is discoverable from either agent:
+
+| Agent | Project path | Personal path |
+|-------|--------------|---------------|
+| **Cursor** | `.cursor/skills/pr-demo-video/` | `~/.cursor/skills/pr-demo-video/` |
+| **Claude Code** | `.claude/skills/pr-demo-video/` | `~/.claude/skills/pr-demo-video/` |
+
+Trigger phrases: "record a video demo of this PR", "make a screencast of this working", "add a voiceover to the demo".
+
+**Fluent Mobile note:** this app is Android-native (Expo). Playwright records a **browser** page. Use the UI-flow script for web surfaces or local HTML/dev tools under test; adapt CONFIG, selectors, cookies, and app boot steps at usage time. Do not rewrite the shared gotchas/scripts prophylactically.
+
+Record a polished screencast of a PR working — a browser UI flow or an AI-agent/CLI flow — with an on-screen cursor, step captions, and an optional voiceover, then attach it to the PR. Sibling of `pr-screenshots` (that one is for static images; this is for motion).
+
+Playwright records the page as native video (webm); ffmpeg converts to mp4. Everything visual is **injected into the page** (`overlay.js`) because Playwright video does **not** render the OS cursor.
+
+## Two flavors
+
+| Flavor | Script | Determinism | Infra |
+|--------|--------|-------------|-------|
+| **UI flow** (modals, forms, list changes) | `record_ui_flow.py` | Deterministic — scripted clicks | sqlite scratch DB is fine |
+| **Agent/CLI flow** (chat → command → real output) | `record_agent_flow.py` | Non-deterministic — real LLM call | needs Postgres + uvicorn + a live target |
+
+## Pipeline
+
+1. Start the app in a worktree on the PR branch (see infra below); seed data; mint a session cookie.
+2. Copy `record_*_flow.py` + `overlay.js` next to your scratch dir (or run in place); edit CONFIG + the FLOW section for the PR.
+3. `cd <worktree> && <venv>/bin/python record_..._flow.py` → prints `VIDEO_WEBM=...`.
+4. `./postprocess.sh <webm> <out.mp4> ["optional narration"]` → mp4 + verification frames (+ voiced mp4).
+5. **Read the emitted `frames/*.png`** to confirm the flow looks right before delivering. Retake if not.
+6. Deliver to `.playwright-mcp/pr-<N>-v<N>/` (gitignored). Attach to the PR via `gh api ... -X PATCH` (NOT `gh pr edit`, which no-ops on body-rewriting repos) or drag-drop; videos upload through GitHub's web UI (<10 MB).
+
+## Gotchas (each cost real time — bake the fix in)
+
+| Symptom | Fix |
+|---------|-----|
+| No cursor in the video | Inject one (`overlay.js`); drive with `page.mouse.move(x,y,steps=28)` before clicking so it glides |
+| `wait_for_selector('#modal.hidden')` times out | A `.hidden` node isn't "visible". Use `state='hidden'` to wait for CLOSED |
+| Clicking a checkbox → "tick-span intercepts pointer events" | Custom checkboxes are 0-size inputs under a visible tick. `el.evaluate('e=>e.click()')` or set state directly |
+| Guided tour overlay eats clicks | Set the tour localStorage keys before load + remove `[id*=tour]` overlays (in `overlay.js`) |
+| Agent recording hangs, assistant reply empty | sqlite: `NotSupportedError: contains lookup` in the chat message store. **Run the agent flow on Postgres** |
+| Chat WebSocket never connects | `runserver` isn't ASGI enough here. Serve with **uvicorn** (`skyportal.asgi:application`) |
+| Agent refuses kube command `ns='!'`/out-of-scope | Namespace not in scope. Set it at the source (WS `set_servers`, `'__all__'` sentinel) — the popover is racy |
+| Approve button not found by text `✓` | The checkmark is an icon. Locate in JS (`textContent.trim()==='✓'`), glide, click |
+| Agent picks the wrong command / stalls | LLM non-determinism. Use an imperative prompt ("Run kubectl get pods -A …"), 90s timeouts, retake |
+
+## SkyPortal local infra
+
+Stand the app up in a git worktree on the PR branch. Specifics for video:
+
+- **Worktree** on the PR branch; use the **main checkout's poetry venv** (`poetry env info -p`) — fresh worktree venvs are empty.
+- **UI flow → sqlite**: copy `.env` minus `DATABASE_URL`; run `migrate` and fake the ~12 Postgres-only migrations it chokes on (repository/pgvector + FK-fix migrations).
+- **Agent flow → Postgres**: create an isolated DB (`createdb`, `CREATE EXTENSION vector`), point `.env`'s `DATABASE_URL` at it, `migrate` (clean, no faking), seed, drop it in teardown. sqlite cannot run the chat agent.
+- **Serve**: UI flow works under `runserver`; agent flow needs `uvicorn skyportal.asgi:application --port 9137`.
+- **Session cookie**: mint with `SessionStore()` in the Django shell (login form rejects shell-created users) — set `_auth_user_id/_auth_user_backend/_auth_user_hash`, `.create()`, use `.session_key`.
+- **Kube target**: the SSRF guard blocks loopback/RFC1918, so a local `kind` cluster must be reached via a **public tunnel** — `ngrok tcp <api-port>`, rewrite the kubeconfig's `server:` to the ngrok host + add `tls-server-name: kubernetes` (cert SAN, keeps TLS real). Seed pods so `get pods` returns something real.
+- **Teardown**: kill ngrok + app, `kind delete cluster`, drop the demo Postgres DB, revert `.env`. A public tunnel to a local API server should never be left running.
+
+## Voiceover
+
+`postprocess.sh` generates it from OpenAI TTS (`gpt-4o-mini-tts`, key from `.env`) and muxes with ffmpeg. Write the narration to match the captions/timing. Offline fallback: `espeak-ng` (robotic). Or hand the narration script to a human to record.
+
+## Delivery & don'ts
+
+- Videos live in `.playwright-mcp/pr-<N>-v<N>/` — **gitignored, never `git add`**.
+- New round of takes → new `-v<N+1>/` dir; don't overwrite prior ones.
+- Be honest in the PR/Slack note about what's real vs a stand-in (e.g. "local kind cluster, not prod"). All commands/API calls shown are genuinely executed.

--- a/.claude/skills/pr-demo-video/overlay.js
+++ b/.claude/skills/pr-demo-video/overlay.js
@@ -1,0 +1,82 @@
+// Injected via Playwright context.add_init_script — runs before page scripts on every navigation.
+// Provides: a synthetic cursor (Playwright video has NO OS cursor), a step caption,
+// an optional API-call log panel, and app-tour suppression.
+//
+// Public API on window:
+//   window.__caption(text)      -> update the bottom-center caption
+//   window.__logOn = true|false -> enable/disable the API-call panel (start false to hide bootstrap noise)
+//   window.__logFilter          -> substring a request URL must contain to be logged (default '/agent/api/')
+(() => {
+  try {
+    // App-tour suppression (SkyPortal keys; change per app). Prevents overlays intercepting clicks.
+    localStorage.setItem('hasAlreadySeenAgentOnboarding', 'true');
+    localStorage.setItem('skyportal_tour_state', JSON.stringify({ completed: true, skipped: true }));
+  } catch (e) {}
+
+  const boot = () => {
+    if (!document.body) return setTimeout(boot, 15);
+    if (document.getElementById('__cursor')) return;
+    window.__logOn = false;
+    window.__logFilter = window.__logFilter || '/agent/api/';
+
+    // ---- step caption (bottom center) ----
+    const cap = document.createElement('div');
+    cap.id = '__caption';
+    cap.style.cssText = ['position:fixed', 'bottom:26px', 'left:50%', 'transform:translateX(-50%)', 'z-index:2147483647',
+      'background:rgba(9,12,18,0.94)', 'color:#eaf2ff', 'border:1px solid #2b3a4f', 'border-radius:999px',
+      'padding:11px 22px', 'font-family:ui-sans-serif,system-ui,sans-serif', 'font-size:15px', 'font-weight:600',
+      'box-shadow:0 8px 30px rgba(0,0,0,0.5)', 'max-width:76vw', 'text-align:center'].join(';');
+    document.body.appendChild(cap);
+    window.__caption = (t) => { cap.textContent = t; };
+
+    // ---- synthetic cursor + click ripple ----
+    const cur = document.createElement('div');
+    cur.id = '__cursor';
+    cur.style.cssText = ['position:fixed', 'left:0', 'top:0', 'z-index:2147483647', 'pointer-events:none',
+      'width:24px', 'height:24px', 'margin-left:-3px', 'margin-top:-2px', 'filter:drop-shadow(0 2px 3px rgba(0,0,0,0.55))'].join(';');
+    cur.innerHTML = '<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M5 3 L5 19 L9.2 15.2 L12 21 L14.4 20 L11.6 14.2 L17 14 Z" fill="#ffffff" stroke="#111827" stroke-width="1.3" stroke-linejoin="round"/></svg>';
+    document.body.appendChild(cur);
+    let cx = window.innerWidth / 2, cy = window.innerHeight / 2;
+    cur.style.transform = 'translate(' + cx + 'px,' + cy + 'px)';
+    document.addEventListener('mousemove', (e) => { cx = e.clientX; cy = e.clientY; cur.style.transform = 'translate(' + cx + 'px,' + cy + 'px)'; }, true);
+    document.addEventListener('mousedown', () => {
+      const r = document.createElement('div');
+      r.style.cssText = 'position:fixed;z-index:2147483646;pointer-events:none;border-radius:50%;border:2px solid #38bdf8;left:0;top:0;transform:translate(' + cx + 'px,' + cy + 'px)';
+      document.body.appendChild(r);
+      r.animate([{ opacity: 0.9, width: '10px', height: '10px', marginLeft: '-5px', marginTop: '-5px' },
+                 { opacity: 0, width: '40px', height: '40px', marginLeft: '-20px', marginTop: '-20px' }], { duration: 420, easing: 'ease-out' });
+      setTimeout(() => r.remove(), 460);
+    }, true);
+
+    // ---- optional API-call log panel (top-right) ----
+    const panel = document.createElement('div');
+    panel.id = '__apilog';
+    panel.style.cssText = ['position:fixed', 'top:14px', 'right:14px', 'width:432px', 'z-index:2147483647',
+      'background:rgba(9,12,18,0.95)', 'border:1px solid #2b3a4f', 'border-radius:10px', 'overflow:hidden',
+      'font-family:ui-monospace,Menlo,monospace', 'box-shadow:0 8px 30px rgba(0,0,0,0.5)', 'display:none'].join(';');
+    panel.innerHTML = '<div style="padding:9px 12px;background:#12203a;color:#8fd0ff;font-size:12px;font-weight:700;border-bottom:1px solid #2b3a4f">API CALLS → BACKEND</div><div id="__apirows" style="padding:6px 8px;display:flex;flex-direction:column;gap:5px;max-height:74vh;overflow:auto"></div>';
+    document.body.appendChild(panel);
+    const addRow = (m, p, s, ms) => {
+      panel.style.display = 'block';
+      const ok = s >= 200 && s < 300, color = ok ? '#4ade80' : (s ? '#f87171' : '#fbbf24');
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:8px;font-size:11.5px;color:#cdd9e6;background:rgba(255,255,255,0.02);border-radius:6px;padding:5px 7px';
+      row.innerHTML = '<span style="color:#7aa2c8;font-weight:700;min-width:52px">' + m + '</span><span style="flex:1;color:#e6eef7;word-break:break-all">' + p + '</span><span style="color:' + color + ';font-weight:700;min-width:30px;text-align:right">' + (s || 'ERR') + '</span><span style="color:#6b7a8c;min-width:44px;text-align:right">' + ms + 'ms</span>';
+      document.getElementById('__apirows').prepend(row);
+    };
+    const of = window.fetch;
+    window.fetch = function (input, init) {
+      const url = (typeof input === 'string') ? input : (input && input.url) || '';
+      const method = ((init && init.method) || (input && input.method) || 'GET').toUpperCase();
+      const t0 = performance.now();
+      const pr = of.apply(this, arguments);
+      if (window.__logOn && url.indexOf(window.__logFilter) !== -1) {
+        let path = url; try { path = new URL(url, location.origin).pathname; } catch (e) {}
+        pr.then(r => addRow(method, path, r.status, Math.round(performance.now() - t0)))
+          .catch(() => addRow(method, path, 0, Math.round(performance.now() - t0)));
+      }
+      return pr;
+    };
+  };
+  boot();
+})();

--- a/.claude/skills/pr-demo-video/postprocess.sh
+++ b/.claude/skills/pr-demo-video/postprocess.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Post-process a recorded demo: webm -> mp4, extract verification frames, optionally add a voiceover.
+#
+#   ./postprocess.sh <input.webm> <output.mp4>                 # convert + extract frames
+#   ./postprocess.sh <input.webm> <output.mp4> "<narration>"   # + OpenAI TTS voiceover, muxed in
+#
+# After converting, ALWAYS Read a few of the emitted frames/*.png to verify the flow looks right.
+set -e
+IN="$1"; OUT="$2"; NARRATION="$3"
+FRAMES="$(dirname "$OUT")/frames"
+
+# webm -> mp4 (H.264, faststart for web/upload)
+ffmpeg -y -i "$IN" -movflags +faststart -pix_fmt yuv420p -c:v libx264 -crf 22 "$OUT" >/dev/null 2>&1
+DUR=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$OUT")
+printf "mp4: %s  (%.0fs, %s)\n" "$OUT" "$DUR" "$(du -h "$OUT" | cut -f1)"
+
+# verification frames at 20% / 50% / 80% / 95%
+mkdir -p "$FRAMES"; rm -f "$FRAMES"/*.png
+for f in 0.20 0.50 0.80 0.95; do
+  T=$(python3 -c "print(int($DUR*$f))")
+  ffmpeg -y -ss "$T" -i "$OUT" -frames:v 1 "$FRAMES/f_${T}s.png" >/dev/null 2>&1
+done
+echo "frames: $FRAMES  (Read these to verify)"
+
+# optional voiceover via OpenAI TTS (needs OPENAI_API_KEY in the environment/.env)
+if [ -n "$NARRATION" ]; then
+  VOICE_MP3="$(dirname "$OUT")/voice.mp3"
+  python3 - "$NARRATION" "$VOICE_MP3" <<'PY'
+import os, sys
+from openai import OpenAI
+text, out = sys.argv[1], sys.argv[2]
+# key from env or the repo .env
+if not os.environ.get("OPENAI_API_KEY"):
+    for line in open(".env"):
+        if line.startswith("OPENAI_API_KEY="):
+            os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip(); break
+r = OpenAI().audio.speech.create(model="gpt-4o-mini-tts", voice="alloy", input=text)
+r.stream_to_file(out)
+print("voice:", out)
+PY
+  WITH_VOICE="${OUT%.mp4}-voiced.mp4"
+  # mux; -shortest so video length wins if narration is shorter
+  ffmpeg -y -i "$OUT" -i "$VOICE_MP3" -c:v copy -c:a aac -shortest "$WITH_VOICE" >/dev/null 2>&1
+  echo "voiced: $WITH_VOICE"
+fi

--- a/.claude/skills/pr-demo-video/record_agent_flow.py
+++ b/.claude/skills/pr-demo-video/record_agent_flow.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""
+Record an AI-AGENT flow as a demo video: ask the SkyPortal chat agent to run a command,
+approve it, and show the real output. Worked example: "list the pods" -> kubectl get pods -A.
+
+REQUIRES (see SKILL.md "SkyPortal infra"): app on POSTGRES (sqlite breaks the chat message
+store), app served by UVICORN/ASGI (not runserver), a connected kube host whose kubeconfig
+reaches a real cluster, and ANTHROPIC_API_KEY/OPENAI_API_KEY in .env (real LLM call).
+
+The agent is LLM-driven => NON-DETERMINISTIC. Use an imperative prompt, generous timeouts,
+and expect occasional retakes.
+
+    cd <worktree> && <venv>/bin/python record_agent_flow.py
+"""
+import asyncio
+import os
+from playwright.async_api import async_playwright
+
+# ---- CONFIG (edit per PR) --------------------------------------------------
+APP = "http://localhost:9137"
+SESSION = "PUT_DJANGO_SESSIONID_HERE"
+PROMPT = "Run kubectl get pods -A and show me the output"   # imperative => reliable tool choice
+DONE_TEXT_JS = "document.body.textContent.includes('web-frontend') && document.body.textContent.includes('kube-system')"
+HERE = os.path.dirname(os.path.abspath(__file__))
+OVERLAY_JS = open(os.path.join(HERE, "overlay.js")).read()
+VIDEO_DIR = os.path.join(HERE, "video")
+VIEWPORT = {"width": 1440, "height": 900}
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        ctx = await browser.new_context(viewport=VIEWPORT, record_video_dir=VIDEO_DIR, record_video_size=VIEWPORT)
+        await ctx.add_cookies([{"name": "sessionid", "value": SESSION, "domain": "localhost", "path": "/"}])
+        await ctx.add_init_script(OVERLAY_JS)
+        page = await ctx.new_page()
+
+        async def cap(text, ms=0):
+            await page.evaluate("(t) => window.__caption && window.__caption(t)", text)
+            if ms:
+                await page.wait_for_timeout(ms)
+
+        async def glide(selector):
+            el = page.locator(selector).first
+            await el.wait_for(state="visible", timeout=15000)
+            box = await el.bounding_box()
+            await page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=28)
+            await page.wait_for_timeout(280)
+            return el
+
+        async def glide_click(selector):
+            el = await glide(selector)
+            await el.click()
+
+        await page.goto(APP + "/agent/", wait_until="domcontentloaded", timeout=60000)
+        await page.wait_for_timeout(2500)
+        await page.evaluate("() => window.loadUserServers && window.loadUserServers()")
+        await page.wait_for_timeout(800)
+        try:
+            await glide_click('#newChatButtonNormal')   # clean transcript
+            await page.wait_for_timeout(1500)
+        except Exception:
+            pass
+
+        # ---- SCOPE THE CLUSTER (the key breakthrough) -------------------------
+        # The scope popover's namespace section renders async and is RACY under automation.
+        # Set scope at the source instead: ChatState + a direct `set_servers` WS message.
+        # selected_namespaces uses the '__all__' sentinel for cluster-wide (needed for `-A`).
+        await cap("Scope the Kubernetes cluster into the chat", 500)
+        res = await page.evaluate("""async () => {
+            const s = window.ChatState || {};
+            const avail = s.availableServers || window.currentServers || [];
+            const host = avail.find(x => x.target_kind === 'kubernetes') || avail[0];
+            if (!host) return { ok:false };
+            s.selectedServers = [host];
+            s.activeServerId = host.id;
+            s.selectedNamespaces = { [host.id]: ['__all__'] };
+            if (typeof connectWebSocket === 'function' && (!s.websocket || s.websocket.readyState > 1)) connectWebSocket();
+            for (let i=0;i<60;i++){ if (s.websocket && s.websocket.readyState===1) break; await new Promise(r=>setTimeout(r,150)); }
+            const payload = { type:'set_servers', selected_server_ids:[host.id], active_server_id: host.id, selected_namespaces: { [host.id]: ['__all__'] } };
+            let sent=false; try { if (s.websocket && s.websocket.readyState===1){ s.websocket.send(JSON.stringify(payload)); sent=true; } } catch(e){}
+            if (window.renderChatScopePill) window.renderChatScopePill();
+            return { ok:true, host:host.hostname, ws:(s.websocket?s.websocket.readyState:'none'), sent, ns: s.selectedNamespaces[host.id] };
+        }""")
+        print("scope set:", res)   # expect ns: ['__all__'], sent: True
+        await page.wait_for_timeout(2200)   # let the backend process set_servers
+
+        # ---- ASK THE AGENT ----------------------------------------------------
+        await cap("Ask the agent to list the pods", 700)
+        el = await glide('#chatInput')
+        await el.click()
+        await page.keyboard.type(PROMPT, delay=42)
+        await page.wait_for_timeout(700)
+        await glide_click('#chatSend')
+
+        # ---- APPROVAL GATE (LLM latency -> long timeout) ----------------------
+        await cap("The agent chooses the command …", 300)
+        await page.wait_for_selector('button.approval-dialog-action-btn', timeout=90000)
+        await page.wait_for_timeout(1600)
+        await cap("Command approval gate — approve to run", 1200)
+        # Approve-once (✓). The checkmark is an icon, not literal text -> pick in JS, glide, click.
+        box = await page.evaluate("""() => {
+            const btns = Array.from(document.querySelectorAll('button.approval-dialog-action-btn')).filter(b=>b.offsetParent);
+            let b = btns.find(x => x.textContent.trim() === '✓') || btns[btns.length-1];
+            if (!b) return null; b.setAttribute('data-approve','1');
+            const r = b.getBoundingClientRect(); return { x:r.x+r.width/2, y:r.y+r.height/2 };
+        }""")
+        if box:
+            await page.mouse.move(box["x"], box["y"], steps=26)
+            await page.wait_for_timeout(300)
+            await page.evaluate("() => { const b=document.querySelector('[data-approve=\"1\"]'); if(b) b.click(); }")
+
+        # ---- REAL OUTPUT ------------------------------------------------------
+        await cap("Approved → agent runs the command on the live cluster", 500)
+        await page.wait_for_function("() => " + DONE_TEXT_JS, timeout=60000)
+        await page.wait_for_timeout(1500)
+        try:
+            await glide_click('#execution-log-panel-tab')   # show it in the Execution Log too
+            await page.wait_for_timeout(700)
+            await page.evaluate("() => { const es=document.querySelectorAll('.execution-log-entry'); if(es.length) es[es.length-1].scrollIntoView({block:'center'}); }")
+        except Exception:
+            pass
+        await cap("Command executed on the cluster — output shown in-app", 4000)
+
+        await ctx.close()
+        await browser.close()
+        import glob
+        vids = sorted(glob.glob(VIDEO_DIR + "/*.webm"), key=os.path.getmtime)
+        print("VIDEO_WEBM=" + (vids[-1] if vids else "NONE"))
+
+
+asyncio.run(main())

--- a/.claude/skills/pr-demo-video/record_ui_flow.py
+++ b/.claude/skills/pr-demo-video/record_ui_flow.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""
+Record a DETERMINISTIC UI flow as a demo video (Playwright native video + injected cursor/captions).
+Worked example: SkyPortal "edit a Kubernetes host + rotate credential" (PR #3087).
+
+Adapt the CONFIG block and the FLOW section for your PR. Run with the project venv's python
+from the worktree dir (so relative asset paths + .env resolve). Output: a .webm in VIDEO_DIR
+(post-process to mp4 with postprocess.sh).
+
+    cd <worktree> && <venv>/bin/python record_ui_flow.py
+"""
+import asyncio
+import os
+from playwright.async_api import async_playwright
+
+# ---- CONFIG (edit per PR) --------------------------------------------------
+APP = "http://localhost:9137"
+SESSION = "PUT_DJANGO_SESSIONID_HERE"          # mint via SessionStore (see SKILL.md)
+HERE = os.path.dirname(os.path.abspath(__file__))
+OVERLAY_JS = open(os.path.join(HERE, "overlay.js")).read()
+VIDEO_DIR = os.path.join(HERE, "video")
+VIEWPORT = {"width": 1440, "height": 900}
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)   # headless is fine; the injected cursor renders in-page
+        ctx = await browser.new_context(viewport=VIEWPORT, record_video_dir=VIDEO_DIR, record_video_size=VIEWPORT)
+        await ctx.add_cookies([{"name": "sessionid", "value": SESSION, "domain": "localhost", "path": "/"}])
+        await ctx.add_init_script(OVERLAY_JS)
+        page = await ctx.new_page()
+
+        async def cap(text, ms=0):
+            await page.evaluate("(t) => window.__caption && window.__caption(t)", text)
+            if ms:
+                await page.wait_for_timeout(ms)
+
+        async def glide(selector):
+            """Move the cursor smoothly to an element's centre and return the locator."""
+            el = page.locator(selector).first
+            await el.wait_for(state="visible", timeout=15000)
+            box = await el.bounding_box()
+            await page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=28)
+            await page.wait_for_timeout(280)
+            return el
+
+        async def glide_click(selector):
+            el = await glide(selector)
+            await el.click()
+
+        async def glide_type(selector, text, clear=True):
+            el = await glide(selector)
+            await el.click()
+            if clear:
+                await page.keyboard.press("Control+A")
+                await page.keyboard.press("Delete")
+            await page.keyboard.type(text, delay=50)   # visible typing
+
+        # ---- SETUP ----
+        await page.goto(APP + "/agent/", wait_until="domcontentloaded", timeout=60000)
+        await page.wait_for_timeout(2200)
+        await page.evaluate("""() => {   // belt-and-suspenders tour removal
+            document.querySelectorAll('[id*="tour"],[class*="tour"]').forEach(el => {
+                const s = (el.id || '') + ' ' + (el.className || '');
+                if (/overlay|backdrop|active/i.test(s)) el.remove();
+            });
+        }""")
+        await page.evaluate("() => window.loadUserServers && window.loadUserServers()")  # app-specific hydrate
+        await page.wait_for_timeout(900)
+        await page.mouse.move(700, 520, steps=8)   # park the cursor on-screen
+
+        # ==== FLOW (edit per PR) =================================================
+        # GOTCHAS baked in below:
+        #  - wait for a CLOSED modal with state='hidden' (default 'visible' never matches a .hidden node)
+        #  - custom checkboxes with a tick-span overlay intercept real clicks -> use el.evaluate('e=>e.click()')
+        await cap("Kubernetes host in the sidebar", 2400)
+
+        await cap("Open the edit modal", 700)
+        await glide_click('.server-item[data-server-name="gpu-cluster-01"] button[title="Edit Server"]')
+        await page.wait_for_selector('#serverDetailsModal:not(.hidden)', timeout=8000)
+        await page.wait_for_timeout(2200)
+
+        await cap("Rename, then Save", 700)
+        await glide_type('#modalHostName', 'gpu-cluster-01-west')
+        await page.wait_for_timeout(800)
+        await glide_click('#saveServerDetails')
+        await page.wait_for_selector('#serverDetailsModal', state='hidden', timeout=8000)  # closed, not visible
+        await page.wait_for_timeout(2500)
+        # ========================================================================
+
+        await ctx.close()
+        await browser.close()
+        import glob
+        vids = sorted(glob.glob(VIDEO_DIR + "/*.webm"), key=os.path.getmtime)
+        print("VIDEO_WEBM=" + (vids[-1] if vids else "NONE"))
+
+
+asyncio.run(main())

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -32,6 +32,11 @@ Cross-tool agents (Claude Code, Copilot, etc.) must still find the same contract
 - [AGENTS.md](../../AGENTS.md)
 - [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md)
 
+Project agent skills (keep Cursor + Claude twins in sync when adding/updating):
+
+- [`.cursor/skills/`](../skills/) — Cursor Agent skills
+- [`.claude/skills/`](../../.claude/skills/) — Claude Code skills (same content when dual-tool)
+
 ## README
 
 [README.md](../../README.md) — human-focused setup (Android emulator, env vars). Link to `docs/AGENT_ONBOARDING.md` for agents; do not duplicate full architecture there.

--- a/.cursor/skills/pr-demo-video/SKILL.md
+++ b/.cursor/skills/pr-demo-video/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pr-demo-video
+description: >-
+  Record a VIDEO / screencast demo of a PR or feature (not static screenshots).
+  Use when asked to make a video of this working, record a demo for the PR, show
+  the agent doing X on video, or add a voiceover to the demo. Covers browser UI
+  flows and AI-agent/CLI flows. Works in Cursor Agent and Claude Code. Example
+  scripts target SkyPortal; adapt CONFIG/FLOW per app/PR.
+---
+
+# PR demo videos
+
+## Agent environments (Cursor + Claude Code)
+
+This skill is discoverable from either agent:
+
+| Agent | Project path | Personal path |
+|-------|--------------|---------------|
+| **Cursor** | `.cursor/skills/pr-demo-video/` | `~/.cursor/skills/pr-demo-video/` |
+| **Claude Code** | `.claude/skills/pr-demo-video/` | `~/.claude/skills/pr-demo-video/` |
+
+Trigger phrases: "record a video demo of this PR", "make a screencast of this working", "add a voiceover to the demo".
+
+**Fluent Mobile note:** this app is Android-native (Expo). Playwright records a **browser** page. Use the UI-flow script for web surfaces or local HTML/dev tools under test; adapt CONFIG, selectors, cookies, and app boot steps at usage time. Do not rewrite the shared gotchas/scripts prophylactically.
+
+Record a polished screencast of a PR working — a browser UI flow or an AI-agent/CLI flow — with an on-screen cursor, step captions, and an optional voiceover, then attach it to the PR. Sibling of `pr-screenshots` (that one is for static images; this is for motion).
+
+Playwright records the page as native video (webm); ffmpeg converts to mp4. Everything visual is **injected into the page** (`overlay.js`) because Playwright video does **not** render the OS cursor.
+
+## Two flavors
+
+| Flavor | Script | Determinism | Infra |
+|--------|--------|-------------|-------|
+| **UI flow** (modals, forms, list changes) | `record_ui_flow.py` | Deterministic — scripted clicks | sqlite scratch DB is fine |
+| **Agent/CLI flow** (chat → command → real output) | `record_agent_flow.py` | Non-deterministic — real LLM call | needs Postgres + uvicorn + a live target |
+
+## Pipeline
+
+1. Start the app in a worktree on the PR branch (see infra below); seed data; mint a session cookie.
+2. Copy `record_*_flow.py` + `overlay.js` next to your scratch dir (or run in place); edit CONFIG + the FLOW section for the PR.
+3. `cd <worktree> && <venv>/bin/python record_..._flow.py` → prints `VIDEO_WEBM=...`.
+4. `./postprocess.sh <webm> <out.mp4> ["optional narration"]` → mp4 + verification frames (+ voiced mp4).
+5. **Read the emitted `frames/*.png`** to confirm the flow looks right before delivering. Retake if not.
+6. Deliver to `.playwright-mcp/pr-<N>-v<N>/` (gitignored). Attach to the PR via `gh api ... -X PATCH` (NOT `gh pr edit`, which no-ops on body-rewriting repos) or drag-drop; videos upload through GitHub's web UI (<10 MB).
+
+## Gotchas (each cost real time — bake the fix in)
+
+| Symptom | Fix |
+|---------|-----|
+| No cursor in the video | Inject one (`overlay.js`); drive with `page.mouse.move(x,y,steps=28)` before clicking so it glides |
+| `wait_for_selector('#modal.hidden')` times out | A `.hidden` node isn't "visible". Use `state='hidden'` to wait for CLOSED |
+| Clicking a checkbox → "tick-span intercepts pointer events" | Custom checkboxes are 0-size inputs under a visible tick. `el.evaluate('e=>e.click()')` or set state directly |
+| Guided tour overlay eats clicks | Set the tour localStorage keys before load + remove `[id*=tour]` overlays (in `overlay.js`) |
+| Agent recording hangs, assistant reply empty | sqlite: `NotSupportedError: contains lookup` in the chat message store. **Run the agent flow on Postgres** |
+| Chat WebSocket never connects | `runserver` isn't ASGI enough here. Serve with **uvicorn** (`skyportal.asgi:application`) |
+| Agent refuses kube command `ns='!'`/out-of-scope | Namespace not in scope. Set it at the source (WS `set_servers`, `'__all__'` sentinel) — the popover is racy |
+| Approve button not found by text `✓` | The checkmark is an icon. Locate in JS (`textContent.trim()==='✓'`), glide, click |
+| Agent picks the wrong command / stalls | LLM non-determinism. Use an imperative prompt ("Run kubectl get pods -A …"), 90s timeouts, retake |
+
+## SkyPortal local infra
+
+Stand the app up in a git worktree on the PR branch. Specifics for video:
+
+- **Worktree** on the PR branch; use the **main checkout's poetry venv** (`poetry env info -p`) — fresh worktree venvs are empty.
+- **UI flow → sqlite**: copy `.env` minus `DATABASE_URL`; run `migrate` and fake the ~12 Postgres-only migrations it chokes on (repository/pgvector + FK-fix migrations).
+- **Agent flow → Postgres**: create an isolated DB (`createdb`, `CREATE EXTENSION vector`), point `.env`'s `DATABASE_URL` at it, `migrate` (clean, no faking), seed, drop it in teardown. sqlite cannot run the chat agent.
+- **Serve**: UI flow works under `runserver`; agent flow needs `uvicorn skyportal.asgi:application --port 9137`.
+- **Session cookie**: mint with `SessionStore()` in the Django shell (login form rejects shell-created users) — set `_auth_user_id/_auth_user_backend/_auth_user_hash`, `.create()`, use `.session_key`.
+- **Kube target**: the SSRF guard blocks loopback/RFC1918, so a local `kind` cluster must be reached via a **public tunnel** — `ngrok tcp <api-port>`, rewrite the kubeconfig's `server:` to the ngrok host + add `tls-server-name: kubernetes` (cert SAN, keeps TLS real). Seed pods so `get pods` returns something real.
+- **Teardown**: kill ngrok + app, `kind delete cluster`, drop the demo Postgres DB, revert `.env`. A public tunnel to a local API server should never be left running.
+
+## Voiceover
+
+`postprocess.sh` generates it from OpenAI TTS (`gpt-4o-mini-tts`, key from `.env`) and muxes with ffmpeg. Write the narration to match the captions/timing. Offline fallback: `espeak-ng` (robotic). Or hand the narration script to a human to record.
+
+## Delivery & don'ts
+
+- Videos live in `.playwright-mcp/pr-<N>-v<N>/` — **gitignored, never `git add`**.
+- New round of takes → new `-v<N+1>/` dir; don't overwrite prior ones.
+- Be honest in the PR/Slack note about what's real vs a stand-in (e.g. "local kind cluster, not prod"). All commands/API calls shown are genuinely executed.

--- a/.cursor/skills/pr-demo-video/overlay.js
+++ b/.cursor/skills/pr-demo-video/overlay.js
@@ -1,0 +1,82 @@
+// Injected via Playwright context.add_init_script — runs before page scripts on every navigation.
+// Provides: a synthetic cursor (Playwright video has NO OS cursor), a step caption,
+// an optional API-call log panel, and app-tour suppression.
+//
+// Public API on window:
+//   window.__caption(text)      -> update the bottom-center caption
+//   window.__logOn = true|false -> enable/disable the API-call panel (start false to hide bootstrap noise)
+//   window.__logFilter          -> substring a request URL must contain to be logged (default '/agent/api/')
+(() => {
+  try {
+    // App-tour suppression (SkyPortal keys; change per app). Prevents overlays intercepting clicks.
+    localStorage.setItem('hasAlreadySeenAgentOnboarding', 'true');
+    localStorage.setItem('skyportal_tour_state', JSON.stringify({ completed: true, skipped: true }));
+  } catch (e) {}
+
+  const boot = () => {
+    if (!document.body) return setTimeout(boot, 15);
+    if (document.getElementById('__cursor')) return;
+    window.__logOn = false;
+    window.__logFilter = window.__logFilter || '/agent/api/';
+
+    // ---- step caption (bottom center) ----
+    const cap = document.createElement('div');
+    cap.id = '__caption';
+    cap.style.cssText = ['position:fixed', 'bottom:26px', 'left:50%', 'transform:translateX(-50%)', 'z-index:2147483647',
+      'background:rgba(9,12,18,0.94)', 'color:#eaf2ff', 'border:1px solid #2b3a4f', 'border-radius:999px',
+      'padding:11px 22px', 'font-family:ui-sans-serif,system-ui,sans-serif', 'font-size:15px', 'font-weight:600',
+      'box-shadow:0 8px 30px rgba(0,0,0,0.5)', 'max-width:76vw', 'text-align:center'].join(';');
+    document.body.appendChild(cap);
+    window.__caption = (t) => { cap.textContent = t; };
+
+    // ---- synthetic cursor + click ripple ----
+    const cur = document.createElement('div');
+    cur.id = '__cursor';
+    cur.style.cssText = ['position:fixed', 'left:0', 'top:0', 'z-index:2147483647', 'pointer-events:none',
+      'width:24px', 'height:24px', 'margin-left:-3px', 'margin-top:-2px', 'filter:drop-shadow(0 2px 3px rgba(0,0,0,0.55))'].join(';');
+    cur.innerHTML = '<svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M5 3 L5 19 L9.2 15.2 L12 21 L14.4 20 L11.6 14.2 L17 14 Z" fill="#ffffff" stroke="#111827" stroke-width="1.3" stroke-linejoin="round"/></svg>';
+    document.body.appendChild(cur);
+    let cx = window.innerWidth / 2, cy = window.innerHeight / 2;
+    cur.style.transform = 'translate(' + cx + 'px,' + cy + 'px)';
+    document.addEventListener('mousemove', (e) => { cx = e.clientX; cy = e.clientY; cur.style.transform = 'translate(' + cx + 'px,' + cy + 'px)'; }, true);
+    document.addEventListener('mousedown', () => {
+      const r = document.createElement('div');
+      r.style.cssText = 'position:fixed;z-index:2147483646;pointer-events:none;border-radius:50%;border:2px solid #38bdf8;left:0;top:0;transform:translate(' + cx + 'px,' + cy + 'px)';
+      document.body.appendChild(r);
+      r.animate([{ opacity: 0.9, width: '10px', height: '10px', marginLeft: '-5px', marginTop: '-5px' },
+                 { opacity: 0, width: '40px', height: '40px', marginLeft: '-20px', marginTop: '-20px' }], { duration: 420, easing: 'ease-out' });
+      setTimeout(() => r.remove(), 460);
+    }, true);
+
+    // ---- optional API-call log panel (top-right) ----
+    const panel = document.createElement('div');
+    panel.id = '__apilog';
+    panel.style.cssText = ['position:fixed', 'top:14px', 'right:14px', 'width:432px', 'z-index:2147483647',
+      'background:rgba(9,12,18,0.95)', 'border:1px solid #2b3a4f', 'border-radius:10px', 'overflow:hidden',
+      'font-family:ui-monospace,Menlo,monospace', 'box-shadow:0 8px 30px rgba(0,0,0,0.5)', 'display:none'].join(';');
+    panel.innerHTML = '<div style="padding:9px 12px;background:#12203a;color:#8fd0ff;font-size:12px;font-weight:700;border-bottom:1px solid #2b3a4f">API CALLS → BACKEND</div><div id="__apirows" style="padding:6px 8px;display:flex;flex-direction:column;gap:5px;max-height:74vh;overflow:auto"></div>';
+    document.body.appendChild(panel);
+    const addRow = (m, p, s, ms) => {
+      panel.style.display = 'block';
+      const ok = s >= 200 && s < 300, color = ok ? '#4ade80' : (s ? '#f87171' : '#fbbf24');
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:8px;font-size:11.5px;color:#cdd9e6;background:rgba(255,255,255,0.02);border-radius:6px;padding:5px 7px';
+      row.innerHTML = '<span style="color:#7aa2c8;font-weight:700;min-width:52px">' + m + '</span><span style="flex:1;color:#e6eef7;word-break:break-all">' + p + '</span><span style="color:' + color + ';font-weight:700;min-width:30px;text-align:right">' + (s || 'ERR') + '</span><span style="color:#6b7a8c;min-width:44px;text-align:right">' + ms + 'ms</span>';
+      document.getElementById('__apirows').prepend(row);
+    };
+    const of = window.fetch;
+    window.fetch = function (input, init) {
+      const url = (typeof input === 'string') ? input : (input && input.url) || '';
+      const method = ((init && init.method) || (input && input.method) || 'GET').toUpperCase();
+      const t0 = performance.now();
+      const pr = of.apply(this, arguments);
+      if (window.__logOn && url.indexOf(window.__logFilter) !== -1) {
+        let path = url; try { path = new URL(url, location.origin).pathname; } catch (e) {}
+        pr.then(r => addRow(method, path, r.status, Math.round(performance.now() - t0)))
+          .catch(() => addRow(method, path, 0, Math.round(performance.now() - t0)));
+      }
+      return pr;
+    };
+  };
+  boot();
+})();

--- a/.cursor/skills/pr-demo-video/postprocess.sh
+++ b/.cursor/skills/pr-demo-video/postprocess.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Post-process a recorded demo: webm -> mp4, extract verification frames, optionally add a voiceover.
+#
+#   ./postprocess.sh <input.webm> <output.mp4>                 # convert + extract frames
+#   ./postprocess.sh <input.webm> <output.mp4> "<narration>"   # + OpenAI TTS voiceover, muxed in
+#
+# After converting, ALWAYS Read a few of the emitted frames/*.png to verify the flow looks right.
+set -e
+IN="$1"; OUT="$2"; NARRATION="$3"
+FRAMES="$(dirname "$OUT")/frames"
+
+# webm -> mp4 (H.264, faststart for web/upload)
+ffmpeg -y -i "$IN" -movflags +faststart -pix_fmt yuv420p -c:v libx264 -crf 22 "$OUT" >/dev/null 2>&1
+DUR=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$OUT")
+printf "mp4: %s  (%.0fs, %s)\n" "$OUT" "$DUR" "$(du -h "$OUT" | cut -f1)"
+
+# verification frames at 20% / 50% / 80% / 95%
+mkdir -p "$FRAMES"; rm -f "$FRAMES"/*.png
+for f in 0.20 0.50 0.80 0.95; do
+  T=$(python3 -c "print(int($DUR*$f))")
+  ffmpeg -y -ss "$T" -i "$OUT" -frames:v 1 "$FRAMES/f_${T}s.png" >/dev/null 2>&1
+done
+echo "frames: $FRAMES  (Read these to verify)"
+
+# optional voiceover via OpenAI TTS (needs OPENAI_API_KEY in the environment/.env)
+if [ -n "$NARRATION" ]; then
+  VOICE_MP3="$(dirname "$OUT")/voice.mp3"
+  python3 - "$NARRATION" "$VOICE_MP3" <<'PY'
+import os, sys
+from openai import OpenAI
+text, out = sys.argv[1], sys.argv[2]
+# key from env or the repo .env
+if not os.environ.get("OPENAI_API_KEY"):
+    for line in open(".env"):
+        if line.startswith("OPENAI_API_KEY="):
+            os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip(); break
+r = OpenAI().audio.speech.create(model="gpt-4o-mini-tts", voice="alloy", input=text)
+r.stream_to_file(out)
+print("voice:", out)
+PY
+  WITH_VOICE="${OUT%.mp4}-voiced.mp4"
+  # mux; -shortest so video length wins if narration is shorter
+  ffmpeg -y -i "$OUT" -i "$VOICE_MP3" -c:v copy -c:a aac -shortest "$WITH_VOICE" >/dev/null 2>&1
+  echo "voiced: $WITH_VOICE"
+fi

--- a/.cursor/skills/pr-demo-video/record_agent_flow.py
+++ b/.cursor/skills/pr-demo-video/record_agent_flow.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""
+Record an AI-AGENT flow as a demo video: ask the SkyPortal chat agent to run a command,
+approve it, and show the real output. Worked example: "list the pods" -> kubectl get pods -A.
+
+REQUIRES (see SKILL.md "SkyPortal infra"): app on POSTGRES (sqlite breaks the chat message
+store), app served by UVICORN/ASGI (not runserver), a connected kube host whose kubeconfig
+reaches a real cluster, and ANTHROPIC_API_KEY/OPENAI_API_KEY in .env (real LLM call).
+
+The agent is LLM-driven => NON-DETERMINISTIC. Use an imperative prompt, generous timeouts,
+and expect occasional retakes.
+
+    cd <worktree> && <venv>/bin/python record_agent_flow.py
+"""
+import asyncio
+import os
+from playwright.async_api import async_playwright
+
+# ---- CONFIG (edit per PR) --------------------------------------------------
+APP = "http://localhost:9137"
+SESSION = "PUT_DJANGO_SESSIONID_HERE"
+PROMPT = "Run kubectl get pods -A and show me the output"   # imperative => reliable tool choice
+DONE_TEXT_JS = "document.body.textContent.includes('web-frontend') && document.body.textContent.includes('kube-system')"
+HERE = os.path.dirname(os.path.abspath(__file__))
+OVERLAY_JS = open(os.path.join(HERE, "overlay.js")).read()
+VIDEO_DIR = os.path.join(HERE, "video")
+VIEWPORT = {"width": 1440, "height": 900}
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        ctx = await browser.new_context(viewport=VIEWPORT, record_video_dir=VIDEO_DIR, record_video_size=VIEWPORT)
+        await ctx.add_cookies([{"name": "sessionid", "value": SESSION, "domain": "localhost", "path": "/"}])
+        await ctx.add_init_script(OVERLAY_JS)
+        page = await ctx.new_page()
+
+        async def cap(text, ms=0):
+            await page.evaluate("(t) => window.__caption && window.__caption(t)", text)
+            if ms:
+                await page.wait_for_timeout(ms)
+
+        async def glide(selector):
+            el = page.locator(selector).first
+            await el.wait_for(state="visible", timeout=15000)
+            box = await el.bounding_box()
+            await page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=28)
+            await page.wait_for_timeout(280)
+            return el
+
+        async def glide_click(selector):
+            el = await glide(selector)
+            await el.click()
+
+        await page.goto(APP + "/agent/", wait_until="domcontentloaded", timeout=60000)
+        await page.wait_for_timeout(2500)
+        await page.evaluate("() => window.loadUserServers && window.loadUserServers()")
+        await page.wait_for_timeout(800)
+        try:
+            await glide_click('#newChatButtonNormal')   # clean transcript
+            await page.wait_for_timeout(1500)
+        except Exception:
+            pass
+
+        # ---- SCOPE THE CLUSTER (the key breakthrough) -------------------------
+        # The scope popover's namespace section renders async and is RACY under automation.
+        # Set scope at the source instead: ChatState + a direct `set_servers` WS message.
+        # selected_namespaces uses the '__all__' sentinel for cluster-wide (needed for `-A`).
+        await cap("Scope the Kubernetes cluster into the chat", 500)
+        res = await page.evaluate("""async () => {
+            const s = window.ChatState || {};
+            const avail = s.availableServers || window.currentServers || [];
+            const host = avail.find(x => x.target_kind === 'kubernetes') || avail[0];
+            if (!host) return { ok:false };
+            s.selectedServers = [host];
+            s.activeServerId = host.id;
+            s.selectedNamespaces = { [host.id]: ['__all__'] };
+            if (typeof connectWebSocket === 'function' && (!s.websocket || s.websocket.readyState > 1)) connectWebSocket();
+            for (let i=0;i<60;i++){ if (s.websocket && s.websocket.readyState===1) break; await new Promise(r=>setTimeout(r,150)); }
+            const payload = { type:'set_servers', selected_server_ids:[host.id], active_server_id: host.id, selected_namespaces: { [host.id]: ['__all__'] } };
+            let sent=false; try { if (s.websocket && s.websocket.readyState===1){ s.websocket.send(JSON.stringify(payload)); sent=true; } } catch(e){}
+            if (window.renderChatScopePill) window.renderChatScopePill();
+            return { ok:true, host:host.hostname, ws:(s.websocket?s.websocket.readyState:'none'), sent, ns: s.selectedNamespaces[host.id] };
+        }""")
+        print("scope set:", res)   # expect ns: ['__all__'], sent: True
+        await page.wait_for_timeout(2200)   # let the backend process set_servers
+
+        # ---- ASK THE AGENT ----------------------------------------------------
+        await cap("Ask the agent to list the pods", 700)
+        el = await glide('#chatInput')
+        await el.click()
+        await page.keyboard.type(PROMPT, delay=42)
+        await page.wait_for_timeout(700)
+        await glide_click('#chatSend')
+
+        # ---- APPROVAL GATE (LLM latency -> long timeout) ----------------------
+        await cap("The agent chooses the command …", 300)
+        await page.wait_for_selector('button.approval-dialog-action-btn', timeout=90000)
+        await page.wait_for_timeout(1600)
+        await cap("Command approval gate — approve to run", 1200)
+        # Approve-once (✓). The checkmark is an icon, not literal text -> pick in JS, glide, click.
+        box = await page.evaluate("""() => {
+            const btns = Array.from(document.querySelectorAll('button.approval-dialog-action-btn')).filter(b=>b.offsetParent);
+            let b = btns.find(x => x.textContent.trim() === '✓') || btns[btns.length-1];
+            if (!b) return null; b.setAttribute('data-approve','1');
+            const r = b.getBoundingClientRect(); return { x:r.x+r.width/2, y:r.y+r.height/2 };
+        }""")
+        if box:
+            await page.mouse.move(box["x"], box["y"], steps=26)
+            await page.wait_for_timeout(300)
+            await page.evaluate("() => { const b=document.querySelector('[data-approve=\"1\"]'); if(b) b.click(); }")
+
+        # ---- REAL OUTPUT ------------------------------------------------------
+        await cap("Approved → agent runs the command on the live cluster", 500)
+        await page.wait_for_function("() => " + DONE_TEXT_JS, timeout=60000)
+        await page.wait_for_timeout(1500)
+        try:
+            await glide_click('#execution-log-panel-tab')   # show it in the Execution Log too
+            await page.wait_for_timeout(700)
+            await page.evaluate("() => { const es=document.querySelectorAll('.execution-log-entry'); if(es.length) es[es.length-1].scrollIntoView({block:'center'}); }")
+        except Exception:
+            pass
+        await cap("Command executed on the cluster — output shown in-app", 4000)
+
+        await ctx.close()
+        await browser.close()
+        import glob
+        vids = sorted(glob.glob(VIDEO_DIR + "/*.webm"), key=os.path.getmtime)
+        print("VIDEO_WEBM=" + (vids[-1] if vids else "NONE"))
+
+
+asyncio.run(main())

--- a/.cursor/skills/pr-demo-video/record_ui_flow.py
+++ b/.cursor/skills/pr-demo-video/record_ui_flow.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""
+Record a DETERMINISTIC UI flow as a demo video (Playwright native video + injected cursor/captions).
+Worked example: SkyPortal "edit a Kubernetes host + rotate credential" (PR #3087).
+
+Adapt the CONFIG block and the FLOW section for your PR. Run with the project venv's python
+from the worktree dir (so relative asset paths + .env resolve). Output: a .webm in VIDEO_DIR
+(post-process to mp4 with postprocess.sh).
+
+    cd <worktree> && <venv>/bin/python record_ui_flow.py
+"""
+import asyncio
+import os
+from playwright.async_api import async_playwright
+
+# ---- CONFIG (edit per PR) --------------------------------------------------
+APP = "http://localhost:9137"
+SESSION = "PUT_DJANGO_SESSIONID_HERE"          # mint via SessionStore (see SKILL.md)
+HERE = os.path.dirname(os.path.abspath(__file__))
+OVERLAY_JS = open(os.path.join(HERE, "overlay.js")).read()
+VIDEO_DIR = os.path.join(HERE, "video")
+VIEWPORT = {"width": 1440, "height": 900}
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)   # headless is fine; the injected cursor renders in-page
+        ctx = await browser.new_context(viewport=VIEWPORT, record_video_dir=VIDEO_DIR, record_video_size=VIEWPORT)
+        await ctx.add_cookies([{"name": "sessionid", "value": SESSION, "domain": "localhost", "path": "/"}])
+        await ctx.add_init_script(OVERLAY_JS)
+        page = await ctx.new_page()
+
+        async def cap(text, ms=0):
+            await page.evaluate("(t) => window.__caption && window.__caption(t)", text)
+            if ms:
+                await page.wait_for_timeout(ms)
+
+        async def glide(selector):
+            """Move the cursor smoothly to an element's centre and return the locator."""
+            el = page.locator(selector).first
+            await el.wait_for(state="visible", timeout=15000)
+            box = await el.bounding_box()
+            await page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=28)
+            await page.wait_for_timeout(280)
+            return el
+
+        async def glide_click(selector):
+            el = await glide(selector)
+            await el.click()
+
+        async def glide_type(selector, text, clear=True):
+            el = await glide(selector)
+            await el.click()
+            if clear:
+                await page.keyboard.press("Control+A")
+                await page.keyboard.press("Delete")
+            await page.keyboard.type(text, delay=50)   # visible typing
+
+        # ---- SETUP ----
+        await page.goto(APP + "/agent/", wait_until="domcontentloaded", timeout=60000)
+        await page.wait_for_timeout(2200)
+        await page.evaluate("""() => {   // belt-and-suspenders tour removal
+            document.querySelectorAll('[id*="tour"],[class*="tour"]').forEach(el => {
+                const s = (el.id || '') + ' ' + (el.className || '');
+                if (/overlay|backdrop|active/i.test(s)) el.remove();
+            });
+        }""")
+        await page.evaluate("() => window.loadUserServers && window.loadUserServers()")  # app-specific hydrate
+        await page.wait_for_timeout(900)
+        await page.mouse.move(700, 520, steps=8)   # park the cursor on-screen
+
+        # ==== FLOW (edit per PR) =================================================
+        # GOTCHAS baked in below:
+        #  - wait for a CLOSED modal with state='hidden' (default 'visible' never matches a .hidden node)
+        #  - custom checkboxes with a tick-span overlay intercept real clicks -> use el.evaluate('e=>e.click()')
+        await cap("Kubernetes host in the sidebar", 2400)
+
+        await cap("Open the edit modal", 700)
+        await glide_click('.server-item[data-server-name="gpu-cluster-01"] button[title="Edit Server"]')
+        await page.wait_for_selector('#serverDetailsModal:not(.hidden)', timeout=8000)
+        await page.wait_for_timeout(2200)
+
+        await cap("Rename, then Save", 700)
+        await glide_type('#modalHostName', 'gpu-cluster-01-west')
+        await page.wait_for_timeout(800)
+        await glide_click('#saveServerDetails')
+        await page.wait_for_selector('#serverDetailsModal', state='hidden', timeout=8000)  # closed, not visible
+        await page.wait_for_timeout(2500)
+        # ========================================================================
+
+        await ctx.close()
+        await browser.close()
+        import glob
+        vids = sorted(glob.glob(VIDEO_DIR + "/*.webm"), key=os.path.getmtime)
+        print("VIDEO_WEBM=" + (vids[-1] if vids else "NONE"))
+
+
+asyncio.run(main())

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ expo-env.d.ts
 
 # TypeScript
 *.tsbuildinfo
+
+# PR demo video takes (pr-demo-video skill) — never commit recordings
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ This file is the **entrypoint for non-Cursor agents** (Claude Code, Codex, Copil
 5. [`docs/guides/expo-first-dependencies.md`](docs/guides/expo-first-dependencies.md) — prefer Expo packages
 6. [`.cursor/rules/`](.cursor/rules/) — always-on + topic rules (`delivery`, `architecture`, `android-only`, `project-board`, `expo-first-dependencies`, …)
 
+## Agent skills
+
+- **PR demo videos** (`pr-demo-video`): record Playwright screencasts for PRs. Cursor: [`.cursor/skills/pr-demo-video/`](.cursor/skills/pr-demo-video/). Claude Code: [`.claude/skills/pr-demo-video/`](.claude/skills/pr-demo-video/). Needs `playwright` + `ffmpeg` only when recording.
+
 ## Precedence
 
 **This repository’s** `docs/`, `AGENTS.md`, and `.cursor/rules/` win over org-wide / umbrella agent playbooks. See [`.cursor/rules/rule-precedence.mdc`](.cursor/rules/rule-precedence.mdc).

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -54,6 +54,7 @@ Quick map for Cursor agents, other coding tools, and new contributors. Verified 
 | [`.github/workflows/`](../.github/workflows/) | CI + tag version sync (`eas-build.yml`) |
 | [`.github/dependabot.yml`](../.github/dependabot.yml) | Weekly dependency PRs (npm + GitHub Actions) |
 | [`.cursor/rules/`](../.cursor/rules/) | Cursor agent rules |
+| [`.cursor/skills/pr-demo-video/`](../.cursor/skills/pr-demo-video/) | PR demo screencast skill (Cursor); Claude Code twin: [`.claude/skills/pr-demo-video/`](../.claude/skills/pr-demo-video/) |
 | [`docs/guides/dependabot-process.md`](guides/dependabot-process.md) | Safe Dependabot merge process |
 | [`docs/guides/local-development-workflow.md`](guides/local-development-workflow.md) | Hosted dev + local Docker API paths |
 | [`docs/guides/recordings-sync-contract.md`](guides/recordings-sync-contract.md) | Verse audio upload contract (#102 / fluent-api #224) |


### PR DESCRIPTION
### TLDR

Adds the shared `pr-demo-video` agent skill so Cursor and Claude Code can record polished PR demo screencasts (Playwright + in-page cursor/captions + ffmpeg postprocess). Skill trees are kept in sync for both agents, demo takes are gitignored, and onboarding docs point agents at the skill.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Refs #NNN` — do **not** use `Closes` / `Fixes` / `Resolves`)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Refs #319

Installs the shared PR demo video skill for dual-agent discovery (Cursor + Claude Code). Example recorder scripts remain SkyPortal-oriented and are meant to be adapted per PR/app at usage time.

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Maintenance / refactor

#### Technical changes

- `.cursor/skills/pr-demo-video/` — Cursor skill (`SKILL.md`, `overlay.js`, `postprocess.sh`, `record_*_flow.py`)
- `.claude/skills/pr-demo-video/` — Claude Code twin (same content)
- `.gitignore` — ignore `.playwright-mcp/` demo takes
- `CLAUDE.md`, `docs/AGENT_ONBOARDING.md`, `.cursor/rules/docs.mdc` — discovery pointers

#### Testing

Docs/skill install only — no app runtime change. CI app gates (`format:check`, `lint`, `typecheck`, `npm test -- --ci`) not required for this change; waived as documentation/tooling-only.

### How to verify

1. Confirm both skill trees contain the five files and scripts are executable bits as committed.
2. In Cursor, ask to "record a video demo of this PR" and confirm the agent can discover/load `.cursor/skills/pr-demo-video/SKILL.md`.
3. In Claude Code, confirm `.claude/skills/pr-demo-video/` is discoverable the same way.
4. Optional recording deps (not needed to merge): `brew install ffmpeg`, `pip install playwright openai`, `playwright install chromium`.

**Expected:** Skill is present for both agents; `.playwright-mcp/` is ignored; onboarding docs link the skill. No app behavior change.

### Follow-ups

- None for this ticket. Adapting CONFIG/FLOW for Fluent Mobile Android surfaces is usage-time work when recording a concrete PR demo.