### PR TITLE
[#51]: Enable prepare offline mock data in release builds

### DIFF
--- a/src/mocks/prepareOffline/index.ts
+++ b/src/mocks/prepareOffline/index.ts
@@ -11,7 +11,7 @@
  *
  * Data flow: catalog + inventory (status) → `prepareOfflineCatalog.ts` → UI.
  *
- * Gate: `prepareOfflineResources.ts` service (`__DEV__` → mock modules below).
+ * Consumed via `prepareOfflineResources.ts` until FluentAPI manifest lands.
  */
 export {
   MOCK_PREPARE_OFFLINE_RESOURCE_MANIFEST,

--- a/src/mocks/prepareOffline/mockDownloadSources.ts
+++ b/src/mocks/prepareOffline/mockDownloadSources.ts
@@ -1,11 +1,9 @@
 /**
- * Prepare for Offline — dev-only download URLs (#52 wiring until manifest API).
+ * Prepare for Offline — mock download URLs until manifest API (#201).
  *
  * **Security:** URLs are hardcoded public test fixtures (not user/API input).
- * Used only when `__DEV__` is true; production returns empty `sourceUrl`.
  * Files land in the app sandbox (`downloadStorage.ts`) and are not executed.
- * Review any URL change in PR — prefer team-owned fixtures if external hosts
- * are a concern. Replaced in production by per-resource `sourceUrl` from manifest.
+ * Replaced when per-resource `sourceUrl` comes from FluentAPI manifest.
  *
  * `DEV_MOCK_FILE_BYTES` must match the on-disk size of each fixture URL so
  * catalog totals align with Manage Device Storage after download.
@@ -50,19 +48,11 @@ const DEV_MOCK_SOURCES: Record<PrepareOfflineResourceKind, MockDownloadSource> =
 export function getMockDownloadBytesForKind(
   kind: PrepareOfflineResourceKind,
 ): number {
-  if (__DEV__) {
-    return DEV_MOCK_FILE_BYTES[kind];
-  }
-
-  return 0;
+  return DEV_MOCK_FILE_BYTES[kind];
 }
 
 export function getMockDownloadSource(
   kind: PrepareOfflineResourceKind,
 ): MockDownloadSource {
-  if (__DEV__) {
-    return DEV_MOCK_SOURCES[kind];
-  }
-
-  return { sourceUrl: '', fileExt: 'bin', bytesTotal: 0 };
+  return DEV_MOCK_SOURCES[kind];
 }

--- a/src/mocks/prepareOffline/offlineDownloadInventoryRuntime.ts
+++ b/src/mocks/prepareOffline/offlineDownloadInventoryRuntime.ts
@@ -134,10 +134,6 @@ export function simulateMockPrepareOfflineDownload(
   projectId: number,
   resourceIdsInTierOrder: string[],
 ): void {
-  if (!__DEV__) {
-    return;
-  }
-
   stopMockDownloadSimulation();
 
   const pendingIds = resourceIdsInTierOrder.filter(

--- a/src/services/prepareOfflineDownload.ts
+++ b/src/services/prepareOfflineDownload.ts
@@ -40,19 +40,15 @@ export async function enqueuePrepareOfflineDownload(
     return ids;
   } catch (error) {
     log.error(
-      'Failed to enqueue prepare offline download; falling back to dev mock',
+      'Failed to enqueue prepare offline download; falling back to mock simulation',
       {
         error,
         projectId: input.projectId,
       },
     );
 
-    if (__DEV__) {
-      const tierOrderedIds = input.items.map(item => item.id);
-      simulatePrepareOfflineDownloadProgress(input.projectId, tierOrderedIds);
-      return [];
-    }
-
-    throw error;
+    const tierOrderedIds = input.items.map(item => item.id);
+    simulatePrepareOfflineDownloadProgress(input.projectId, tierOrderedIds);
+    return [];
   }
 }

--- a/src/services/prepareOfflineResources.ts
+++ b/src/services/prepareOfflineResources.ts
@@ -4,12 +4,8 @@
  * Single entry point for manifest and on-device inventory. UI, catalog builder,
  * and download service import from here — never from `src/mocks/prepareOffline/`.
  *
- * Today: async "fetch" resolves to mock data in `__DEV__`.
- * #201: replace internals with FluentAPI + SQLite inventory without changing callers.
- *
- * Bundle note: mock modules are imported statically but all call sites are
- * guarded by `__DEV__`; production runtime never executes mock code. #201 removes
- * mock imports entirely when FluentAPI replaces this layer.
+ * Today: mock catalog + inventory until FluentAPI manifest is wired (#201 follow-up).
+ * Replace internals here when the API contract lands; callers stay unchanged.
  */
 import {
   clearMockPrepareOfflineRuntimeInventory,
@@ -24,26 +20,16 @@ import {
   PrepareOfflineResourceManifestEntry,
   PrepareOfflineResourceStatus,
 } from '../types/prepareOffline/types';
-import { logger } from '../utils/logger';
 import { unscopedPrepareOfflineResourceId } from '../utils/prepareOfflineResourceId';
-
-const log = logger.create('prepareOfflineResources');
 
 export type PrepareOfflineInventoryListener = () => void;
 
-/** Simulates FluentAPI manifest fetch. Dev: mock manifest; prod: empty until #201. */
+/** Mock manifest until FluentAPI resource manifest is available. */
 export async function fetchPrepareOfflineManifest(
   projectId: number,
 ): Promise<PrepareOfflineResourceManifestEntry[]> {
-  if (__DEV__) {
-    void projectId;
-    return MOCK_PREPARE_OFFLINE_RESOURCE_MANIFEST;
-  }
-
-  log.warn('Prepare offline manifest unavailable — #201 not implemented', {
-    projectId,
-  });
-  return [];
+  void projectId;
+  return MOCK_PREPARE_OFFLINE_RESOURCE_MANIFEST;
 }
 
 /** On-device / in-flight status for one resource row. */
@@ -51,57 +37,41 @@ export function getPrepareOfflineResourceStatus(
   projectId: number,
   resourceId: string,
 ): PrepareOfflineResourceStatus {
-  if (__DEV__) {
-    return getMockPrepareOfflineResourceStatus(
-      projectId,
-      unscopedPrepareOfflineResourceId(projectId, resourceId),
-    );
-  }
-
-  return 'selected';
+  return getMockPrepareOfflineResourceStatus(
+    projectId,
+    unscopedPrepareOfflineResourceId(projectId, resourceId),
+  );
 }
 
-/** Subscribe to inventory changes (mock pub/sub in dev; queue events in #201). */
+/** Subscribe to inventory changes (mock pub/sub today; queue events when API lands). */
 export function subscribePrepareOfflineInventory(
   listener: PrepareOfflineInventoryListener,
 ): () => void {
-  if (__DEV__) {
-    return subscribeMockPrepareOfflineInventory(listener);
-  }
-
-  return () => {};
+  return subscribeMockPrepareOfflineInventory(listener);
 }
 
 /** Reset runtime inventory overrides when project/user session changes. */
 export function clearPrepareOfflineSessionInventory(): void {
-  if (__DEV__) {
-    clearMockPrepareOfflineRuntimeInventory();
-  }
+  clearMockPrepareOfflineRuntimeInventory();
 }
 
-/** Tier 2/3 ids deselected by default for the active dev scenario package. */
+/** Tier 2/3 ids deselected by default for the active mock scenario package. */
 export function getDefaultPrepareOfflinePackageDeselects(
   projectId: number | null = null,
 ): Set<string> {
-  if (__DEV__) {
-    const ids = getDefaultDeselectedItemIdsForScenario(
-      getPrepareOfflineMockInventoryScenario(),
-    );
-    if (projectId === null) {
-      return ids;
-    }
-    return new Set([...ids].map(id => `${projectId}-${id}`));
+  const ids = getDefaultDeselectedItemIdsForScenario(
+    getPrepareOfflineMockInventoryScenario(),
+  );
+  if (projectId === null) {
+    return ids;
   }
-
-  return new Set();
+  return new Set([...ids].map(id => `${projectId}-${id}`));
 }
 
-/** Dev-only stand-in for #201 worker progress after enqueue. */
+/** Stand-in for worker progress when enqueue falls back to mock simulation. */
 export function simulatePrepareOfflineDownloadProgress(
   projectId: number,
   resourceIdsInTierOrder: string[],
 ): void {
-  if (__DEV__) {
-    simulateMockPrepareOfflineDownload(projectId, resourceIdsInTierOrder);
-  }
+  simulateMockPrepareOfflineDownload(projectId, resourceIdsInTierOrder);
 }

--- a/src/utils/prepareOfflineQueueMapping.test.ts
+++ b/src/utils/prepareOfflineQueueMapping.test.ts
@@ -73,7 +73,7 @@ describe('prepareOfflineQueueMapping', () => {
     expect(items.every(item => item.userId === TEST_USER_ID)).toBe(true);
   });
 
-  it('includes dev mock sourceUrl and fileExt', () => {
+  it('includes mock sourceUrl and fileExt', () => {
     const input = prepareOfflineItemToEnqueueInput(baseItem, 1, TEST_USER_ID);
 
     expect(input.sourceUrl).toEqual(expect.any(String));

--- a/src/utils/prepareOfflineQueueMapping.ts
+++ b/src/utils/prepareOfflineQueueMapping.ts
@@ -27,9 +27,9 @@ export function prepareOfflineItemToEnqueueInput(
     kind: queueKindForResource(item.kind),
     resourceName: item.groupName,
     label: item.label,
-    sourceUrl: __DEV__ ? sourceUrl : undefined,
-    fileExt: __DEV__ ? fileExt : undefined,
-    bytesTotal: __DEV__ ? bytesTotal : item.bytes,
+    sourceUrl,
+    fileExt,
+    bytesTotal,
   };
 }
 


### PR DESCRIPTION
### TLDR

Follow-up to QA on [#296](https://github.com/eten-tech-foundation/fluent-mobile/pull/296) ([issue #51 comment](https://github.com/eten-tech-foundation/fluent-mobile/issues/51#issuecomment-5264994622)): preview APKs did not show **Resources to download** because Prepare for Offline mocks were gated behind `__DEV__`.

We removed the `__DEV__` gate from the Prepare for Offline mock pipeline only: manifest/inventory (`prepareOfflineResources.ts`), fixture download URLs (`mockDownloadSources.ts`), queue enqueue mapping (`prepareOfflineQueueMapping.ts`), download simulation (`offlineDownloadInventoryRuntime.ts`), and enqueue fallback (`prepareOfflineDownload.ts`). Mock data now runs in release/preview builds until FluentAPI manifest lands (#201). No changes to sync, auth, Resources tab, or other app areas.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Refs #51`)
- [ ] How to verify steps completed or valid waiver noted below
- [ ] Acceptance criteria met for the QA regression (Resources section visible on preview APK), **or** unmet AC waived **in the issue** with linked follow-up
- [x] Scope limited to this issue — only Prepare for Offline mock pipeline (7 files); no adjacent tickets
- [ ] Android device tested — **required**: new preview APK build needed to confirm fix vs [#296](https://github.com/eten-tech-foundation/fluent-mobile/pull/296) QA report

### Details

Refs #51

QA reported on [issue #51 comment](https://github.com/eten-tech-foundation/fluent-mobile/issues/51#issuecomment-5264994622) that after installing the #296 APK, **Resources to download** did not appear for assigned or unassigned chapters. Root cause: mock catalog and download URLs were disabled when `__DEV__` is false. Fix: open the gate so mocks work in release until the real API manifest is wired.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintee / refactor

#### Technical changes

- `src/services/prepareOfflineResources.ts` — always serve mock manifest/inventory
- `src/mocks/prepareOffline/mockDownloadSources.ts` — always return fixture URLs and byte sizes
- `src/utils/prepareOfflineQueueMapping.ts` — always pass `sourceUrl` / `fileExt` on enqueue
- `src/mocks/prepareOffline/offlineDownloadInventoryRuntime.ts` — download simulation enabled in release
- `src/services/prepareOfflineDownload.ts` — mock fallback no longer dev-only

#### Testing

- `npm test -- --ci --testPathPattern="prepareOffline|PrepareForOffline"` — 117 passed
- Full CI gates — pending PR checks

### How to verify

1. Build/install a new **preview APK** from this branch (`eas build --profile preview --platform android`)
2. Open **Prepare for Offline** → select project and chapter(s) (assigned and unassigned)
3. Confirm **RESOURCES TO DOWNLOAD** appears with grouped resources and sizes
4. Tap **Download** → Pause/Cancel controls; per-item progress

**Expected:** section from [QA comment](https://github.com/eten-tech-foundation/fluent-mobile/issues/51#issuecomment-5264994622); matches Metro dev behavior.

### Follow-ups

- Replace mock layer with FluentAPI manifest when #201 API contract is ready