### PR TITLE
[#234]: Fix FK failure in chapter assignment sync for PM with no assigned work

### DIFF
--- a/src/db/repository.insertChapterAssignmentSyncData.test.ts
+++ b/src/db/repository.insertChapterAssignmentSyncData.test.ts
@@ -231,6 +231,15 @@ describe('resolveProjectUnitsForSync', () => {
     expect(units.get(10)).toEqual({ id: 10, projectId: 100 });
   });
 
+  it('falls back to local project_units when payload projectId is invalid', () => {
+    const units = resolveProjectUnitsForSync(
+      [validAssignment({ projectId: 999 })],
+      baseContext().knownProjectIds,
+      baseContext().projectUnitToProjectId,
+    );
+    expect(units.get(10)).toEqual({ id: 10, projectId: 100 });
+  });
+
   it('skips units when project is not local', () => {
     const units = resolveProjectUnitsForSync(
       [validAssignment({ projectId: 999 })],
@@ -386,5 +395,24 @@ describe('insertChapterAssignmentSyncData', () => {
 
     expect(db.table('project_units')).toHaveLength(1);
     expect(db.table('chapter_assignments')).toHaveLength(1);
+  });
+
+  it('inserts valid rows and skips orphan rows in the same batch', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+    db.seed({
+      projects: [{ id: 100, name: 'P' }],
+      bibles: [{ id: 4, language_id: 1, name: 'B', abbreviation: 'B' }],
+      books: [{ id: 12, code: 'GEN', eng_display_name: 'Genesis' }],
+      project_units: [{ id: 10, project_id: 100, status: 'not_started' }],
+    });
+
+    await insertChapterAssignmentSyncData([
+      validAssignment({ chapterAssignmentId: 1 }),
+      validAssignment({ chapterAssignmentId: 2, bibleId: 999 }),
+    ]);
+
+    expect(db.table('chapter_assignments')).toHaveLength(1);
+    expect(db.table('chapter_assignments')[0].id).toBe(1);
   });
 });

--- a/src/db/repository.insertChapterAssignmentSyncData.test.ts
+++ b/src/db/repository.insertChapterAssignmentSyncData.test.ts
@@ -332,6 +332,23 @@ describe('insertChapterAssignmentSyncData', () => {
     expect(db.table('chapter_assignments')).toHaveLength(0);
   });
 
+  it('does not upsert project unit when assignment is filtered out', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+    db.seed({
+      projects: [{ id: 100, name: 'P' }],
+      bibles: [{ id: 4, language_id: 1, name: 'B', abbreviation: 'B' }],
+      books: [{ id: 12, code: 'GEN', eng_display_name: 'Genesis' }],
+    });
+
+    await insertChapterAssignmentSyncData([
+      validAssignment({ chapterAssignmentId: 10, bibleId: 999 }),
+    ]);
+
+    expect(db.table('project_units')).toHaveLength(0);
+    expect(db.table('chapter_assignments')).toHaveLength(0);
+  });
+
   it('inserts assignment when FK parents exist', async () => {
     const db = createSyncTestDb();
     setDatabase(db as never);

--- a/src/db/repository.insertChapterAssignmentSyncData.test.ts
+++ b/src/db/repository.insertChapterAssignmentSyncData.test.ts
@@ -1,0 +1,373 @@
+import type { Transaction } from '@op-engineering/op-sqlite';
+import type { ChapterAssignment } from '../types/db/types';
+import {
+  filterAssignmentsWithValidParents,
+  insertChapterAssignmentSyncData,
+  resolveProjectUnitsForSync,
+  type ChapterAssignmentParentContext,
+} from './repository';
+import { setDatabase } from './db';
+import { createTableQueries } from './schema';
+
+type Row = Record<string, string | number | null>;
+
+type FakeTable = {
+  columns: Set<string>;
+  rows: Row[];
+  foreignKeys: Map<string, string>;
+};
+
+function parseCreateTable(sql: string, tables: Map<string, FakeTable>): void {
+  const match = sql.match(
+    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(([\s\S]*)\)/i,
+  );
+  if (!match) return;
+  const [, name, body] = match;
+  if (tables.has(name) && /IF\s+NOT\s+EXISTS/i.test(sql)) return;
+
+  const columns = new Set<string>();
+  const foreignKeys = new Map<string, string>();
+  for (const part of body.split(',')) {
+    const trimmed = part.trim();
+    const col = trimmed.split(/\s+/)[0];
+    if (
+      col &&
+      !/^(PRIMARY|UNIQUE|FOREIGN|CONSTRAINT|CHECK)$/i.test(col) &&
+      col !== ')'
+    ) {
+      const clean = col.replace(/[^a-zA-Z0-9_]/g, '');
+      columns.add(clean);
+      const fk = trimmed.match(/REFERENCES\s+(\w+)\s*\(/i);
+      if (fk) foreignKeys.set(clean, fk[1]);
+    }
+  }
+  tables.set(name, { columns, rows: [], foreignKeys });
+}
+
+function assertForeignKeys(
+  tableName: string,
+  row: Row,
+  tables: Map<string, FakeTable>,
+): void {
+  const table = tables.get(tableName);
+  if (!table) return;
+
+  for (const [column, refTable] of table.foreignKeys) {
+    const value = row[column];
+    if (value === null || value === undefined) continue;
+    const ref = tables.get(refTable);
+    if (!ref || !ref.rows.some(r => r.id === value)) {
+      throw new Error(
+        `FOREIGN KEY constraint failed: ${tableName}.${column} → ${refTable}(${value})`,
+      );
+    }
+  }
+}
+
+function createSyncTestDb() {
+  const tables = new Map<string, FakeTable>();
+
+  for (const sql of createTableQueries) {
+    if (/^CREATE\s+TABLE/i.test(sql.trim())) {
+      parseCreateTable(sql, tables);
+    }
+  }
+
+  const upsertById = (tableName: string, row: Row, idCol = 'id') => {
+    const table = tables.get(tableName);
+    if (!table) throw new Error(`no such table: ${tableName}`);
+    assertForeignKeys(tableName, row, tables);
+    const id = row[idCol];
+    const index = table.rows.findIndex(r => r[idCol] === id);
+    if (index >= 0) {
+      table.rows[index] = { ...table.rows[index], ...row };
+    } else {
+      table.rows.push(row);
+    }
+  };
+
+  const executor = {
+    execute: async (query: string, params: unknown[] = []) => {
+      const sql = query.replace(/\s+/g, ' ').trim();
+
+      if (/^SELECT id FROM users WHERE id IN/i.test(sql)) {
+        const users = tables.get('users')?.rows ?? [];
+        const allowed = new Set(params.map(Number));
+        return {
+          rows: users.filter(r => allowed.has(Number(r.id))),
+          rowsAffected: 0,
+        };
+      }
+
+      if (/^SELECT id FROM projects$/i.test(sql)) {
+        return { rows: tables.get('projects')?.rows ?? [], rowsAffected: 0 };
+      }
+
+      if (/^SELECT id FROM bibles$/i.test(sql)) {
+        return { rows: tables.get('bibles')?.rows ?? [], rowsAffected: 0 };
+      }
+
+      if (/^SELECT id FROM books$/i.test(sql)) {
+        return { rows: tables.get('books')?.rows ?? [], rowsAffected: 0 };
+      }
+
+      if (/^SELECT id, project_id FROM project_units$/i.test(sql)) {
+        return {
+          rows: tables.get('project_units')?.rows ?? [],
+          rowsAffected: 0,
+        };
+      }
+
+      if (/^INSERT OR IGNORE INTO project_units/i.test(sql)) {
+        const [id, projectId, status] = params;
+        const table = tables.get('project_units')!;
+        if (!table.rows.some(r => r.id === id)) {
+          const row = {
+            id: id as number,
+            project_id: projectId as number,
+            status: status as string,
+          };
+          assertForeignKeys('project_units', row, tables);
+          table.rows.push(row);
+        }
+        return { rows: [], rowsAffected: 1 };
+      }
+
+      if (/^UPDATE project_units SET project_id/i.test(sql)) {
+        const [projectId, id] = params;
+        const table = tables.get('project_units')!;
+        const row = table.rows.find(r => r.id === id);
+        if (row) {
+          row.project_id = projectId as number;
+          assertForeignKeys('project_units', row, tables);
+        }
+        return { rows: [], rowsAffected: 1 };
+      }
+
+      if (/^INSERT INTO chapter_assignments/i.test(sql)) {
+        const row: Row = {
+          id: params[0] as number,
+          project_unit_id: params[1] as number,
+          bible_id: params[2] as number,
+          book_id: params[3] as number,
+          chapter_number: params[4] as number,
+          assigned_user_id: params[5] as number | null,
+          peer_checker_id: params[6] as number | null,
+          status: params[7] as string,
+          submitted_time: params[8] as string | null,
+          updated_at: params[9] as string,
+          total_verses: params[10] as number,
+          completed_verses: params[11] as number,
+        };
+        upsertById('chapter_assignments', row);
+        return { rows: [], rowsAffected: 1 };
+      }
+
+      throw new Error(`Unhandled SQL in sync test db: ${sql}`);
+    },
+  };
+
+  const db = {
+    execute: executor.execute,
+    transaction: async (fn: (tx: Transaction) => Promise<void>) => {
+      await fn(executor as unknown as Transaction);
+    },
+    seed(row: {
+      projects?: Row[];
+      bibles?: Row[];
+      books?: Row[];
+      project_units?: Row[];
+      users?: Row[];
+    }) {
+      for (const [table, rows] of Object.entries(row)) {
+        const t = tables.get(table);
+        if (t) t.rows.push(...rows);
+      }
+    },
+    table(name: string) {
+      return tables.get(name)?.rows ?? [];
+    },
+  };
+
+  return db;
+}
+
+const baseContext = (): ChapterAssignmentParentContext => ({
+  knownProjectIds: new Set([100]),
+  knownBibleIds: new Set([4]),
+  knownBookIds: new Set([12]),
+  knownProjectUnitIds: new Set([10]),
+  projectUnitToProjectId: new Map([[10, 100]]),
+});
+
+const validAssignment = (
+  overrides: Partial<ChapterAssignment> = {},
+): ChapterAssignment => ({
+  chapterAssignmentId: 1,
+  projectUnitId: 10,
+  projectId: 100,
+  bibleId: 4,
+  bookId: 12,
+  chapterNumber: 1,
+  ...overrides,
+});
+
+describe('resolveProjectUnitsForSync', () => {
+  it('includes units when projectId exists locally', () => {
+    const units = resolveProjectUnitsForSync(
+      [validAssignment()],
+      baseContext().knownProjectIds,
+      baseContext().projectUnitToProjectId,
+    );
+    expect(units.get(10)).toEqual({ id: 10, projectId: 100 });
+  });
+
+  it('resolves projectId from existing project_units when payload omits it', () => {
+    const units = resolveProjectUnitsForSync(
+      [validAssignment({ projectId: 0 })],
+      baseContext().knownProjectIds,
+      baseContext().projectUnitToProjectId,
+    );
+    expect(units.get(10)).toEqual({ id: 10, projectId: 100 });
+  });
+
+  it('skips units when project is not local', () => {
+    const units = resolveProjectUnitsForSync(
+      [validAssignment({ projectId: 999 })],
+      baseContext().knownProjectIds,
+      new Map(),
+    );
+    expect(units.size).toBe(0);
+  });
+});
+
+describe('filterAssignmentsWithValidParents', () => {
+  it('keeps assignments with resolvable parents', () => {
+    const ctx = baseContext();
+    const units = resolveProjectUnitsForSync(
+      [validAssignment()],
+      ctx.knownProjectIds,
+      ctx.projectUnitToProjectId,
+    );
+    const filtered = filterAssignmentsWithValidParents(
+      [validAssignment()],
+      ctx,
+      units,
+    );
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('drops assignments referencing missing bible_id', () => {
+    const ctx = baseContext();
+    const units = resolveProjectUnitsForSync(
+      [validAssignment({ bibleId: 999 })],
+      ctx.knownProjectIds,
+      ctx.projectUnitToProjectId,
+    );
+    const filtered = filterAssignmentsWithValidParents(
+      [validAssignment({ bibleId: 999 })],
+      ctx,
+      units,
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('drops assignments when project unit cannot be resolved', () => {
+    const ctx = baseContext();
+    const filtered = filterAssignmentsWithValidParents(
+      [validAssignment({ projectUnitId: 99, projectId: 999 })],
+      ctx,
+      new Map(),
+    );
+    expect(filtered).toHaveLength(0);
+  });
+});
+
+describe('insertChapterAssignmentSyncData', () => {
+  it('does not throw on empty assignments array', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+
+    await expect(insertChapterAssignmentSyncData([])).resolves.toBeUndefined();
+
+    expect(db.table('chapter_assignments')).toHaveLength(0);
+    expect(db.table('project_units')).toHaveLength(0);
+  });
+
+  it('does not throw when assignment references missing bible_id', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+    db.seed({
+      projects: [{ id: 100, name: 'P' }],
+      bibles: [{ id: 4, language_id: 1, name: 'B', abbreviation: 'B' }],
+      books: [{ id: 12, code: 'GEN', eng_display_name: 'Genesis' }],
+      project_units: [{ id: 10, project_id: 100, status: 'not_started' }],
+    });
+
+    await expect(
+      insertChapterAssignmentSyncData([
+        validAssignment({ chapterAssignmentId: 5, bibleId: 999 }),
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(db.table('chapter_assignments')).toHaveLength(0);
+  });
+
+  it('does not throw when assignment references missing book_id', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+    db.seed({
+      projects: [{ id: 100, name: 'P' }],
+      bibles: [{ id: 4, language_id: 1, name: 'B', abbreviation: 'B' }],
+      books: [{ id: 12, code: 'GEN', eng_display_name: 'Genesis' }],
+      project_units: [{ id: 10, project_id: 100, status: 'not_started' }],
+    });
+
+    await expect(
+      insertChapterAssignmentSyncData([
+        validAssignment({ chapterAssignmentId: 6, bookId: 999 }),
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(db.table('chapter_assignments')).toHaveLength(0);
+  });
+
+  it('inserts assignment when FK parents exist', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+    db.seed({
+      projects: [{ id: 100, name: 'P' }],
+      bibles: [{ id: 4, language_id: 1, name: 'B', abbreviation: 'B' }],
+      books: [{ id: 12, code: 'GEN', eng_display_name: 'Genesis' }],
+      project_units: [{ id: 10, project_id: 100, status: 'not_started' }],
+      users: [{ id: 1, email: 'u@example.com' }],
+    });
+
+    await insertChapterAssignmentSyncData([
+      validAssignment({
+        chapterAssignmentId: 5,
+        assignedUserId: 999,
+      }),
+    ]);
+
+    expect(db.table('chapter_assignments')).toHaveLength(1);
+    expect(db.table('chapter_assignments')[0].assigned_user_id).toBeNull();
+  });
+
+  it('inserts assignment and upserts missing project unit from payload', async () => {
+    const db = createSyncTestDb();
+    setDatabase(db as never);
+    db.seed({
+      projects: [{ id: 100, name: 'P' }],
+      bibles: [{ id: 4, language_id: 1, name: 'B', abbreviation: 'B' }],
+      books: [{ id: 12, code: 'GEN', eng_display_name: 'Genesis' }],
+    });
+
+    await insertChapterAssignmentSyncData([
+      validAssignment({ chapterAssignmentId: 7 }),
+    ]);
+
+    expect(db.table('project_units')).toHaveLength(1);
+    expect(db.table('chapter_assignments')).toHaveLength(1);
+  });
+});

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -111,6 +111,30 @@ export type ChapterAssignmentParentContext = {
   projectUnitToProjectId: ReadonlyMap<number, number>;
 };
 
+export type ChapterAssignmentSkipReason =
+  | 'missing_chapter_assignment_id'
+  | 'missing_project_unit'
+  | 'missing_bible'
+  | 'missing_book';
+
+export type SkippedChapterAssignment = {
+  chapterAssignmentId: number;
+  reason: ChapterAssignmentSkipReason;
+};
+
+const SKIP_LOG_ID_LIMIT = 20;
+const SKIP_LOG_SAMPLE_LIMIT = 5;
+
+function countSkipReasons(
+  skipped: SkippedChapterAssignment[],
+): Partial<Record<ChapterAssignmentSkipReason, number>> {
+  const counts: Partial<Record<ChapterAssignmentSkipReason, number>> = {};
+  for (const { reason } of skipped) {
+    counts[reason] = (counts[reason] ?? 0) + 1;
+  }
+  return counts;
+}
+
 function collectIdsFromRows(rows: unknown[], key = 'id'): Set<number> {
   const ids = new Set<number>();
   for (const row of rows) {
@@ -179,39 +203,80 @@ export function resolveProjectUnitsForSync(
   return unitsMap;
 }
 
+/** Split assignments by resolvable FK parents (#234). */
+export function partitionAssignmentsWithValidParents(
+  assignments: DBTypes.ChapterAssignment[],
+  parentContext: ChapterAssignmentParentContext,
+  unitsToUpsert: ReadonlyMap<number, { id: number; projectId: number }>,
+): {
+  valid: DBTypes.ChapterAssignment[];
+  skipped: SkippedChapterAssignment[];
+} {
+  const validProjectUnitIds = new Set([
+    ...parentContext.knownProjectUnitIds,
+    ...unitsToUpsert.keys(),
+  ]);
+
+  const valid: DBTypes.ChapterAssignment[] = [];
+  const skipped: SkippedChapterAssignment[] = [];
+
+  for (const assignment of assignments) {
+    if (!assignment?.chapterAssignmentId) {
+      skipped.push({
+        chapterAssignmentId: 0,
+        reason: 'missing_chapter_assignment_id',
+      });
+      continue;
+    }
+
+    const chapterAssignmentId = assignment.chapterAssignmentId;
+    if (
+      !assignment.projectUnitId ||
+      !validProjectUnitIds.has(assignment.projectUnitId)
+    ) {
+      skipped.push({
+        chapterAssignmentId,
+        reason: 'missing_project_unit',
+      });
+      continue;
+    }
+    if (
+      !assignment.bibleId ||
+      !parentContext.knownBibleIds.has(assignment.bibleId)
+    ) {
+      skipped.push({
+        chapterAssignmentId,
+        reason: 'missing_bible',
+      });
+      continue;
+    }
+    if (
+      !assignment.bookId ||
+      !parentContext.knownBookIds.has(assignment.bookId)
+    ) {
+      skipped.push({
+        chapterAssignmentId,
+        reason: 'missing_book',
+      });
+      continue;
+    }
+    valid.push(assignment);
+  }
+
+  return { valid, skipped };
+}
+
 /** Keep only assignments whose FK parents exist or will be upserted (#234). */
 export function filterAssignmentsWithValidParents(
   assignments: DBTypes.ChapterAssignment[],
   parentContext: ChapterAssignmentParentContext,
   unitsToUpsert: ReadonlyMap<number, { id: number; projectId: number }>,
 ): DBTypes.ChapterAssignment[] {
-  const validProjectUnitIds = new Set([
-    ...parentContext.knownProjectUnitIds,
-    ...unitsToUpsert.keys(),
-  ]);
-
-  return assignments.filter(assignment => {
-    if (!assignment?.chapterAssignmentId) return false;
-    if (
-      !assignment.projectUnitId ||
-      !validProjectUnitIds.has(assignment.projectUnitId)
-    ) {
-      return false;
-    }
-    if (
-      !assignment.bibleId ||
-      !parentContext.knownBibleIds.has(assignment.bibleId)
-    ) {
-      return false;
-    }
-    if (
-      !assignment.bookId ||
-      !parentContext.knownBookIds.has(assignment.bookId)
-    ) {
-      return false;
-    }
-    return true;
-  });
+  return partitionAssignmentsWithValidParents(
+    assignments,
+    parentContext,
+    unitsToUpsert,
+  ).valid;
 }
 
 function collectAssigneeIds(
@@ -451,17 +516,18 @@ export async function insertChapterAssignmentSyncData(
       parentContext.knownProjectIds,
       parentContext.projectUnitToProjectId,
     );
-    const validAssignments = filterAssignmentsWithValidParents(
-      assignments,
-      parentContext,
-      unitsMapForFilter,
-    );
+    const { valid: validAssignments, skipped } =
+      partitionAssignmentsWithValidParents(
+        assignments,
+        parentContext,
+        unitsMapForFilter,
+      );
     const unitsMap = resolveProjectUnitsForSync(
       validAssignments,
       parentContext.knownProjectIds,
       parentContext.projectUnitToProjectId,
     );
-    const skippedCount = assignments.length - validAssignments.length;
+    const skippedCount = skipped.length;
 
     log.info('insertChapterAssignmentSyncData', {
       assignmentsCount: assignments.length,
@@ -482,6 +548,11 @@ export async function insertChapterAssignmentSyncData(
     if (skippedCount > 0) {
       log.info('Skipping chapter assignments with missing FK parents', {
         skippedCount,
+        skippedIds: skipped
+          .slice(0, SKIP_LOG_ID_LIMIT)
+          .map(entry => entry.chapterAssignmentId),
+        skipReasons: countSkipReasons(skipped),
+        skippedSample: skipped.slice(0, SKIP_LOG_SAMPLE_LIMIT),
         knownProjects: parentContext.knownProjectIds.size,
         knownBibles: parentContext.knownBibleIds.size,
         knownBooks: parentContext.knownBookIds.size,

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -103,6 +103,119 @@ async function loadKnownUserIds(
   return known;
 }
 
+export type ChapterAssignmentParentContext = {
+  knownProjectIds: ReadonlySet<number>;
+  knownBibleIds: ReadonlySet<number>;
+  knownBookIds: ReadonlySet<number>;
+  knownProjectUnitIds: ReadonlySet<number>;
+  projectUnitToProjectId: ReadonlyMap<number, number>;
+};
+
+function collectIdsFromRows(rows: unknown[], key = 'id'): Set<number> {
+  const ids = new Set<number>();
+  for (const row of rows) {
+    const id = Number((row as Record<string, number>)[key]);
+    if (Number.isFinite(id) && id > 0) ids.add(id);
+  }
+  return ids;
+}
+
+async function loadChapterAssignmentParentContext(
+  tx: Transaction,
+): Promise<ChapterAssignmentParentContext> {
+  const [projects, bibles, books, units] = await Promise.all([
+    tx.execute('SELECT id FROM projects'),
+    tx.execute('SELECT id FROM bibles'),
+    tx.execute('SELECT id FROM books'),
+    tx.execute('SELECT id, project_id FROM project_units'),
+  ]);
+
+  const knownProjectUnitIds = new Set<number>();
+  const projectUnitToProjectId = new Map<number, number>();
+  for (const row of units.rows) {
+    const id = Number((row as { id: number }).id);
+    const projectId = Number((row as { project_id: number }).project_id);
+    if (!Number.isFinite(id) || id <= 0) continue;
+    knownProjectUnitIds.add(id);
+    if (Number.isFinite(projectId) && projectId > 0) {
+      projectUnitToProjectId.set(id, projectId);
+    }
+  }
+
+  return {
+    knownProjectIds: collectIdsFromRows(projects.rows),
+    knownBibleIds: collectIdsFromRows(bibles.rows),
+    knownBookIds: collectIdsFromRows(books.rows),
+    knownProjectUnitIds,
+    projectUnitToProjectId,
+  };
+}
+
+/** Resolve project_units to upsert before chapter assignment inserts (#234). */
+export function resolveProjectUnitsForSync(
+  assignments: DBTypes.ChapterAssignment[],
+  knownProjectIds: ReadonlySet<number>,
+  projectUnitToProjectId: ReadonlyMap<number, number>,
+): Map<number, { id: number; projectId: number }> {
+  const unitsMap = new Map<number, { id: number; projectId: number }>();
+
+  for (const assignment of assignments) {
+    if (!assignment.projectUnitId) continue;
+    if (unitsMap.has(assignment.projectUnitId)) continue;
+
+    const resolvedProjectId =
+      assignment.projectId && knownProjectIds.has(assignment.projectId)
+        ? assignment.projectId
+        : projectUnitToProjectId.get(assignment.projectUnitId);
+
+    if (!resolvedProjectId || !knownProjectIds.has(resolvedProjectId)) {
+      continue;
+    }
+
+    unitsMap.set(assignment.projectUnitId, {
+      id: assignment.projectUnitId,
+      projectId: resolvedProjectId,
+    });
+  }
+
+  return unitsMap;
+}
+
+/** Keep only assignments whose FK parents exist or will be upserted (#234). */
+export function filterAssignmentsWithValidParents(
+  assignments: DBTypes.ChapterAssignment[],
+  parentContext: ChapterAssignmentParentContext,
+  unitsToUpsert: ReadonlyMap<number, { id: number; projectId: number }>,
+): DBTypes.ChapterAssignment[] {
+  const validProjectUnitIds = new Set([
+    ...parentContext.knownProjectUnitIds,
+    ...unitsToUpsert.keys(),
+  ]);
+
+  return assignments.filter(assignment => {
+    if (!assignment?.chapterAssignmentId) return false;
+    if (
+      !assignment.projectUnitId ||
+      !validProjectUnitIds.has(assignment.projectUnitId)
+    ) {
+      return false;
+    }
+    if (
+      !assignment.bibleId ||
+      !parentContext.knownBibleIds.has(assignment.bibleId)
+    ) {
+      return false;
+    }
+    if (
+      !assignment.bookId ||
+      !parentContext.knownBookIds.has(assignment.bookId)
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
 function collectAssigneeIds(
   assignments: DBTypes.ChapterAssignment[],
 ): number[] {
@@ -330,17 +443,31 @@ export async function insertChapterAssignmentSyncData(
   assignments: DBTypes.ChapterAssignment[],
 ) {
   const db = getDatabase();
-  const unitsMap = getUniqueProjectUnits(assignments);
   const assigneeIds = collectAssigneeIds(assignments);
-
-  log.info('insertChapterAssignmentSyncData', {
-    assignmentsCount: assignments.length,
-    unitsMapSize: unitsMap.size,
-    distinctAssignees: assigneeIds.length,
-  });
 
   await db.transaction(async (tx: Transaction) => {
     const knownUserIds = await loadKnownUserIds(tx, assigneeIds);
+    const parentContext = await loadChapterAssignmentParentContext(tx);
+    const unitsMap = resolveProjectUnitsForSync(
+      assignments,
+      parentContext.knownProjectIds,
+      parentContext.projectUnitToProjectId,
+    );
+    const validAssignments = filterAssignmentsWithValidParents(
+      assignments,
+      parentContext,
+      unitsMap,
+    );
+    const skippedCount = assignments.length - validAssignments.length;
+
+    log.info('insertChapterAssignmentSyncData', {
+      assignmentsCount: assignments.length,
+      insertCount: validAssignments.length,
+      skippedCount,
+      unitsMapSize: unitsMap.size,
+      distinctAssignees: assigneeIds.length,
+    });
+
     const orphanedAssignees = assigneeIds.filter(id => !knownUserIds.has(id));
     if (orphanedAssignees.length > 0) {
       log.info('Nulling assigned_user_id for users not in local users table', {
@@ -349,10 +476,19 @@ export async function insertChapterAssignmentSyncData(
       });
     }
 
+    if (skippedCount > 0) {
+      log.info('Skipping chapter assignments with missing FK parents', {
+        skippedCount,
+        knownProjects: parentContext.knownProjectIds.size,
+        knownBibles: parentContext.knownBibleIds.size,
+        knownBooks: parentContext.knownBookIds.size,
+      });
+    }
+
     for (const unit of unitsMap.values()) {
       await insertProjectUnitTx(tx, unit);
     }
-    for (const assignment of assignments) {
+    for (const assignment of validAssignments) {
       await insertChapterAssignmentTx(tx, assignment, knownUserIds);
     }
   });

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -123,12 +123,10 @@ function collectIdsFromRows(rows: unknown[], key = 'id'): Set<number> {
 async function loadChapterAssignmentParentContext(
   tx: Transaction,
 ): Promise<ChapterAssignmentParentContext> {
-  const [projects, bibles, books, units] = await Promise.all([
-    tx.execute('SELECT id FROM projects'),
-    tx.execute('SELECT id FROM bibles'),
-    tx.execute('SELECT id FROM books'),
-    tx.execute('SELECT id, project_id FROM project_units'),
-  ]);
+  const projects = await tx.execute('SELECT id FROM projects');
+  const bibles = await tx.execute('SELECT id FROM bibles');
+  const books = await tx.execute('SELECT id FROM books');
+  const units = await tx.execute('SELECT id, project_id FROM project_units');
 
   const knownProjectUnitIds = new Set<number>();
   const projectUnitToProjectId = new Map<number, number>();
@@ -448,7 +446,7 @@ export async function insertChapterAssignmentSyncData(
   await db.transaction(async (tx: Transaction) => {
     const knownUserIds = await loadKnownUserIds(tx, assigneeIds);
     const parentContext = await loadChapterAssignmentParentContext(tx);
-    const unitsMap = resolveProjectUnitsForSync(
+    const unitsMapForFilter = resolveProjectUnitsForSync(
       assignments,
       parentContext.knownProjectIds,
       parentContext.projectUnitToProjectId,
@@ -456,7 +454,12 @@ export async function insertChapterAssignmentSyncData(
     const validAssignments = filterAssignmentsWithValidParents(
       assignments,
       parentContext,
-      unitsMap,
+      unitsMapForFilter,
+    );
+    const unitsMap = resolveProjectUnitsForSync(
+      validAssignments,
+      parentContext.knownProjectIds,
+      parentContext.projectUnitToProjectId,
     );
     const skippedCount = assignments.length - validAssignments.length;
 

--- a/src/services/mapChapterAssignment.test.ts
+++ b/src/services/mapChapterAssignment.test.ts
@@ -68,4 +68,18 @@ describe('mapApiChapterAssignment', () => {
     expect(mapped.assignedUserId).toBe(241);
     expect(mapped.peerCheckerId).toBe(99);
   });
+
+  it('maps snake_case project_id when camelCase is absent', () => {
+    const mapped = mapApiChapterAssignment({
+      chapterAssignmentId: 13,
+      projectUnitId: 2,
+      bibleId: 4,
+      bookId: 12,
+      chapterNumber: 1,
+      status: 'not_started',
+      project_id: 42,
+    } as unknown as Parameters<typeof mapApiChapterAssignment>[0]);
+
+    expect(mapped.projectId).toBe(42);
+  });
 });

--- a/src/services/mapChapterAssignment.test.ts
+++ b/src/services/mapChapterAssignment.test.ts
@@ -82,4 +82,17 @@ describe('mapApiChapterAssignment', () => {
 
     expect(mapped.projectId).toBe(42);
   });
+
+  it('defaults projectId to 0 when camelCase and snake_case are absent', () => {
+    const mapped = mapApiChapterAssignment({
+      chapterAssignmentId: 14,
+      projectUnitId: 2,
+      bibleId: 4,
+      bookId: 12,
+      chapterNumber: 1,
+      status: 'not_started',
+    } as unknown as Parameters<typeof mapApiChapterAssignment>[0]);
+
+    expect(mapped.projectId).toBe(0);
+  });
 });

--- a/src/services/mapChapterAssignment.ts
+++ b/src/services/mapChapterAssignment.ts
@@ -19,7 +19,8 @@ export function mapApiChapterAssignment(
   return {
     chapterAssignmentId: api.chapterAssignmentId,
     projectUnitId: api.projectUnitId,
-    projectId: api.projectId,
+    projectId:
+      api.projectId ?? (api as { project_id?: number }).project_id ?? 0,
     bibleId: api.bibleId,
     bookId: api.bookId,
     chapterNumber: api.chapterNumber,


### PR DESCRIPTION
### TLDR

Post-login sync could fail with `FOREIGN KEY constraint failed` when inserting chapter assignments whose parent rows (`project_unit_id`, `bible_id`, `book_id`) were not yet present locally — observed for PMs with active projects but no personal chapter work. This PR validates FK parents inside `insertChapterAssignmentSyncData`, skips orphan rows with structured logging, and maps snake_case `project_id` from the API. PM post-login sync completes without blocking on orphan payloads.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Refs #234` — do **not** use `Closes` / `Fixes` / `Resolves`)
- [x] How to verify steps completed or valid waiver noted below
- [x] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [x] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Refs #234

**Root cause:** `insertChapterAssignmentSyncData` upserted project units and inserted all mapped assignments without checking whether `project_unit_id`, `bible_id`, or `book_id` existed locally. Orphan API rows caused SQLite FK violations during user/project chapter sync.

**Solution:** Load local parent IDs in the same transaction, resolve units to upsert only when the project exists locally, filter assignments to those with resolvable parents, then insert. Orphan assignee nulling (#99 precedent) unchanged. `mapApiChapterAssignment` now falls back to snake_case `project_id` when camelCase is absent.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/db/repository.ts`** — `loadChapterAssignmentParentContext`, `resolveProjectUnitsForSync`, `filterAssignmentsWithValidParents`; hardened `insertChapterAssignmentSyncData` with skip logging (`skippedCount`, `insertCount`)
- **`src/db/repository.insertChapterAssignmentSyncData.test.ts`** — fake SQLite harness with FK enforcement; orphan paths (`bible_id`, `book_id`, empty array), happy path, project unit upsert, orphan assignee nulling
- **`src/services/mapChapterAssignment.ts`** — `projectId` fallback from `project_id`
- **`src/services/mapChapterAssignment.test.ts`** — snake_case `project_id` mapping test

#### Testing

- `npm run format:check` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test -- --ci` — pass (735 tests; includes 11 in `repository.insertChapterAssignmentSyncData.test.ts`)

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Fresh install / clear local DB on Android dev client; sign in to dev cloud as a PM with active projects and empty My Work
3. Confirm post-login sync completes — no `[App] Post-login sync failed`, no `FOREIGN KEY constraint failed` in Metro
4. Optional: filter Metro for `insertChapterAssignmentSyncData` — expect `skippedCount` when orphan rows are filtered (may be `0` when API data is consistent)

**Expected:** Sync succeeds; My Work can be empty; Projects tab loads; no FK errors during chapter assignment sync.

**Manual QA performed:** Android dev client, fresh DB, `jonathanseehagen@buildmidwestern.com` (userId 245), 2026-08-12 — sync completed, My Work count 0, 3 projects / 208 chapter assignments synced, no FK errors.

### Follow-ups

- None blocking merge.
- **Repro account:** Issue #234 repro steps say “sign in as a PM on dev cloud” but do not name a specific account. Local docs suggest `pm@fluent.local` ([local-development-workflow.md](docs/guides/local-development-workflow.md)); login with that account on dev cloud **did not work** during QA. Follow up with issue author [@mattrace-gloo](https://github.com/mattrace-gloo) (reported from [#230](https://github.com/eten-tech-foundation/fluent-mobile/pull/230) review) to confirm which PM account/credentials reproduce the original FK failure, if reviewers want an exact pre-fix repro on device.
- Manual QA used equivalent session: `jonathanseehagen@buildmidwestern.com` — sync OK, My Work empty, no FK errors (see How to verify above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chapter-assignment synchronization by validating required parent records before insertion.
  * Skipped invalid assignments with missing projects, Bibles, books, or chapters.
  * Added support for resolving and creating missing project units during synchronization.
  * Improved handling of project identifiers returned in snake_case API responses.

* **Tests**
  * Added comprehensive coverage for synchronization validation, missing references, empty input, nullable users, and project-unit creation.
  * Added coverage for mapping snake_case project identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->