### PR TITLE
[#189]: Add Translation Notes section to Resources tab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,16 @@
 # Local emulator (host machine localhost:9999)
 EXPO_PUBLIC_API_BASE_URL=http://10.0.2.2:9999
 
-# Aquifer public content API. Add the real key to your local .env / EAS env,
-# not to this example file.
+# Aquifer content API
+# - Base URL may be public (EXPO_PUBLIC_ is fine).
+# - API key: set `AQUIFER_API_KEY` in Expo → Project → Environment variables
+#   (development / preview / production). Prefer Sensitive visibility.
+#   Do NOT use EXPO_PUBLIC_AQUIFER_API_KEY.
+# - Local: copy into .env, or `eas env:pull --environment development`
+#   (Secret visibility cannot be pulled locally — use Sensitive or a local .env).
+# - app.config.ts bakes the key into extra; runtime reads via expo-constants.
 EXPO_PUBLIC_AQUIFER_API_BASE_URL=https://api.aquifer.bible
-EXPO_PUBLIC_AQUIFER_API_KEY=
+AQUIFER_API_KEY=
 
 # EAS preview builds use https://dev.api.fluent.bible (see eas.json profile "preview").
 # dev.app.fluent.bible is the web app — not used by this mobile client.

--- a/app.config.ts
+++ b/app.config.ts
@@ -50,6 +50,14 @@ const config: ExpoConfig = {
     eas: {
       projectId: EAS_PROJECT_ID,
     },
+    // EAS project env var `AQUIFER_API_KEY` (expo.dev → Environment variables).
+    // Linked via eas.json `environment` per profile. Not EXPO_PUBLIC_ — baked into
+    // extra at config resolve / EAS Build, then read via expo-constants.
+    aquiferApiKey: process.env.AQUIFER_API_KEY?.trim() ?? '',
+    aquiferApiBaseUrl: (
+      process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL?.trim() ||
+      'https://api.aquifer.bible'
+    ).replace(/\/+$/, ''),
   },
   plugins: [
     [

--- a/eas.json
+++ b/eas.json
@@ -13,6 +13,7 @@
       "extends": "base",
       "developmentClient": true,
       "distribution": "internal",
+      "environment": "development",
       "env": {
         "EAS_USE_CACHE": "1"
       },
@@ -23,6 +24,7 @@
     "preview": {
       "extends": "base",
       "distribution": "internal",
+      "environment": "preview",
       "env": {
         "EAS_USE_CACHE": "1",
         "EXPO_PUBLIC_API_BASE_URL": "https://dev.api.fluent.bible"
@@ -34,6 +36,7 @@
     "nightly": {
       "extends": "base",
       "distribution": "internal",
+      "environment": "preview",
       "env": {
         "EAS_USE_CACHE": "1",
         "EXPO_PUBLIC_API_BASE_URL": "https://dev.api.fluent.bible"
@@ -44,6 +47,7 @@
     },
     "production": {
       "extends": "base",
+      "environment": "production",
       "env": {
         "EAS_RESTORE_CACHE": "0",
         "EAS_SAVE_CACHE": "1"

--- a/jest.env.cjs
+++ b/jest.env.cjs
@@ -1,1 +1,2 @@
 process.env.EXPO_PUBLIC_API_BASE_URL ??= 'http://localhost:9999';
+process.env.AQUIFER_API_KEY ??= 'test-aquifer-key';

--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -5,6 +5,18 @@ const config = getDefaultConfig(__dirname);
 config.transformer = {
   ...config.transformer,
   babelTransformerPath: require.resolve('react-native-svg-transformer/expo'),
+  // Required for react-native-worklets / Reanimated 4 on Expo.
+  // Default inlineRequires:false breaks Worklets init (installUnpackers
+  // reads __initData.code of undefined → redbox at startup).
+  // Also reduces eager require of Resources section bodies (helps avoid
+  // stale HMR "unknown module" crashes on named exports).
+  // See https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting
+  getTransformOptions: async () => ({
+    transform: {
+      experimentalImportSupport: true,
+      inlineRequires: true,
+    },
+  }),
 };
 
 config.resolver = {
@@ -15,8 +27,8 @@ config.resolver = {
     ...(Array.isArray(config.resolver.blockList)
       ? config.resolver.blockList
       : config.resolver.blockList
-        ? [config.resolver.blockList]
-        : []),
+      ? [config.resolver.blockList]
+      : []),
     /\/__tests__\//,
     /\.test\.[jt]sx?$/,
   ],

--- a/src/app/screens/DraftingScreen.tsx
+++ b/src/app/screens/DraftingScreen.tsx
@@ -253,7 +253,12 @@ export default function DraftingScreen() {
               ]}
               pointerEvents={activeTab === 'resources' ? 'auto' : 'none'}
             >
-              <ResourcesTab chapterId={chapterId} chapterName={chapterName} />
+              <ResourcesTab
+                chapterId={chapterId}
+                chapterName={chapterName}
+                bookCode={chapterData.bookCode ?? ''}
+                chapterNumber={chapterData.chapterNumber}
+              />
             </View>
             <View
               style={[

--- a/src/app/tabs/ResourcesTab.test.tsx
+++ b/src/app/tabs/ResourcesTab.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { Button, View } from 'react-native';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
 import { ResourcesTab } from './ResourcesTab';
 import {
   DraftingProvider,
@@ -9,6 +15,23 @@ import {
 import { RESOURCES_EMPTY_MESSAGE } from '../../constants/messages';
 import { clearResourcesTabUiState } from '../../utils/resourcesTabUiState';
 import { VerseData } from '../../types/db/types';
+import {
+  loadTranslationNotesForUnit,
+  setTranslationNotesLoadFailureForTests,
+} from '../../services/translationNotes';
+import { getMockTranslationNotes } from '../../mocks/resources/translationNotesMock';
+
+jest.mock('../../services/translationNotes', () => {
+  const actual = jest.requireActual('../../services/translationNotes');
+  return {
+    ...actual,
+    loadTranslationNotesForUnit: jest.fn(),
+  };
+});
+
+const mockLoad = loadTranslationNotesForUnit as jest.MockedFunction<
+  typeof loadTranslationNotesForUnit
+>;
 
 const verses: VerseData[] = [1, 2, 3].map(verseNumber => ({
   bibleId: 1,
@@ -50,7 +73,12 @@ function renderResources(initialVerse: number) {
   return render(
     <DraftingProvider verses={verses} initialVerse={initialVerse}>
       <VerseSwitcher />
-      <ResourcesTab chapterId={99} chapterName="Mark 14" />
+      <ResourcesTab
+        chapterId={99}
+        chapterName="Mark 14"
+        bookCode="MRK"
+        chapterNumber={14}
+      />
     </DraftingProvider>,
   );
 }
@@ -58,55 +86,131 @@ function renderResources(initialVerse: number) {
 describe('ResourcesTab', () => {
   beforeEach(() => {
     clearResourcesTabUiState();
+    setTranslationNotesLoadFailureForTests(false);
+    mockLoad.mockImplementation(async ({ verseNumber }) =>
+      getMockTranslationNotes(99, verseNumber),
+    );
   });
 
-  it('shows the empty message when the unit has no resources', () => {
+  afterEach(() => {
+    mockLoad.mockReset();
+  });
+
+  it('shows the empty message when the unit has no resources', async () => {
+    mockLoad.mockResolvedValue([]);
     renderResources(3);
-    expect(screen.getByText(RESOURCES_EMPTY_MESSAGE)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText(RESOURCES_EMPTY_MESSAGE)).toBeTruthy();
+    });
     expect(screen.queryByText('Translation Notes')).toBeNull();
   });
 
-  it('shows section stubs when the unit has resources', () => {
+  it('shows live Translation Notes even when mock shell is empty', async () => {
+    mockLoad.mockResolvedValue(getMockTranslationNotes(99, 1));
+    renderResources(3);
+
+    await waitFor(() => {
+      expect(screen.getByText('Translation Notes')).toBeTruthy();
+    });
+    expect(screen.queryByText(RESOURCES_EMPTY_MESSAGE)).toBeNull();
+    expect(screen.queryByText('Translation Questions')).toBeNull();
+  });
+
+  it('shows Translation Notes at the top when items exist', async () => {
     renderResources(2);
     expect(screen.getByText('Mark 14:2')).toBeTruthy();
     expect(screen.getByText('Translation Notes')).toBeTruthy();
     expect(screen.getByText('Translation Questions')).toBeTruthy();
     expect(screen.getByText('Images & Maps')).toBeTruthy();
     expect(screen.queryByText(RESOURCES_EMPTY_MESSAGE)).toBeNull();
+
+    fireEvent.press(
+      screen.getByTestId('resources-section-translationNotes-toggle'),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
+    });
+    expect(screen.getByText('connecting word')).toBeTruthy();
   });
 
-  it('updates immediately when the selected verse changes', () => {
+  it('hides Translation Notes when Aquifer returns no notes', async () => {
+    mockLoad.mockResolvedValue([]);
+    renderResources(1);
+
+    await waitFor(() => {
+      expect(screen.getByText(RESOURCES_EMPTY_MESSAGE)).toBeTruthy();
+    });
+    expect(
+      screen.queryByTestId('resources-section-translationNotes'),
+    ).toBeNull();
+  });
+
+  it('updates when the selected verse changes', async () => {
     renderResources(2);
     expect(screen.getByText('Translation Notes')).toBeTruthy();
 
     fireEvent.press(screen.getByTestId('select-verse-3'));
-    expect(screen.getByText(RESOURCES_EMPTY_MESSAGE)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText(RESOURCES_EMPTY_MESSAGE)).toBeTruthy();
+    });
     expect(screen.queryByText('Translation Notes')).toBeNull();
 
     fireEvent.press(screen.getByTestId('select-verse-1'));
-    expect(screen.getByText('Mark 14:1')).toBeTruthy();
-    expect(screen.getByText('Translation Notes')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Mark 14:1')).toBeTruthy();
+      expect(screen.getByText('Translation Notes')).toBeTruthy();
+    });
     expect(screen.queryByText('Translation Questions')).toBeNull();
   });
 
-  it('restores open accordion state when returning to a unit', () => {
+  it('restores open accordion state when returning to a unit', async () => {
     renderResources(2);
 
     fireEvent.press(
       screen.getByTestId('resources-section-translationNotes-toggle'),
     );
-    expect(
-      screen.getByText('Content for this section will appear here.'),
-    ).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
+    });
 
     fireEvent.press(screen.getByTestId('select-verse-1'));
-    expect(
-      screen.queryByText('Content for this section will appear here.'),
-    ).toBeNull();
+    await waitFor(() => {
+      expect(screen.getByText('Mark 14:1')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('translation-notes-list')).toBeNull();
 
     fireEvent.press(screen.getByTestId('select-verse-2'));
-    expect(
-      screen.getByText('Content for this section will appear here.'),
-    ).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
+    });
+  });
+
+  it('keeps Questions and Images visible when Notes load fails', async () => {
+    mockLoad.mockRejectedValue(new Error('boom'));
+    renderResources(2);
+
+    expect(screen.getByText('Translation Notes')).toBeTruthy();
+    expect(screen.getByText('Translation Questions')).toBeTruthy();
+    expect(screen.getByText('Images & Maps')).toBeTruthy();
+
+    fireEvent.press(
+      screen.getByTestId('resources-section-translationNotes-toggle'),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-error')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Translation Questions')).toBeTruthy();
+    expect(screen.getByText('Images & Maps')).toBeTruthy();
+
+    mockLoad.mockResolvedValue(getMockTranslationNotes(99, 2));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('translation-notes-retry'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
+    });
   });
 });

--- a/src/app/tabs/ResourcesTab.tsx
+++ b/src/app/tabs/ResourcesTab.tsx
@@ -26,7 +26,7 @@ import { RESOURCES_EMPTY_MESSAGE } from '../../constants/messages';
 import { useTranslationNotesForUnit } from '../../hooks/useTranslationNotesForUnit';
 import { ResourceSectionId } from '../../types/resources/types';
 import { getMockResourcesForUnit } from './resources/mockResourceData';
-import { TranslationNotesSection } from './resources/TranslationNotesSection';
+import { TranslationNotesSectionHost } from './resources/TranslationNotesSectionHost';
 import {
   getResourcesTabUiState,
   setResourcesTabUiState,
@@ -90,10 +90,12 @@ export function ResourcesTab({
 
   // Live Aquifer TN (#189): show while loading/error, or when notes exist.
   // Do not gate on #188 mock emptiness alone — verse % 3 === 0 still loads Aquifer.
+  // Guard notesState so a stale HMR/partial hook result cannot crash on `.status`.
   const showTranslationNotes =
-    notesState.status === 'loading' ||
-    notesState.status === 'error' ||
-    (notesState.status === 'ready' && notesState.notes.length > 0);
+    notesState !== undefined &&
+    (notesState.status === 'loading' ||
+      notesState.status === 'error' ||
+      (notesState.status === 'ready' && notesState.notes.length > 0));
 
   const [openAccordionIds, setOpenAccordionIds] = useState<Set<string>>(
     () => getResourcesTabUiState(chapterId, selectedVerse).openAccordionIds,
@@ -194,7 +196,7 @@ export function ResourcesTab({
               testID={`resources-section-${id}`}
             >
               {id === 'translationNotes' ? (
-                <TranslationNotesSection
+                <TranslationNotesSectionHost
                   state={notesState}
                   retry={retryNotes}
                   sectionExpanded={expanded}

--- a/src/app/tabs/ResourcesTab.tsx
+++ b/src/app/tabs/ResourcesTab.tsx
@@ -23,11 +23,10 @@ import { useDraftingContext } from '../context/DraftingContext';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { ResourceSectionAccordion } from '../../components/ui/ResourceSectionAccordion';
 import { RESOURCES_EMPTY_MESSAGE } from '../../constants/messages';
+import { useTranslationNotesForUnit } from '../../hooks/useTranslationNotesForUnit';
 import { ResourceSectionId } from '../../types/resources/types';
-import {
-  getMockResourcesForUnit,
-  unitHasAnyResources,
-} from './resources/mockResourceData';
+import { getMockResourcesForUnit } from './resources/mockResourceData';
+import { TranslationNotesSection } from './resources/TranslationNotesSection';
 import {
   getResourcesTabUiState,
   setResourcesTabUiState,
@@ -37,6 +36,9 @@ import { theme } from '../../theme';
 type ResourcesTabProps = {
   chapterId: number;
   chapterName: string;
+  /** USFM book code for Aquifer resource lookup (e.g. MRK). */
+  bookCode: string;
+  chapterNumber: number;
 };
 
 const SECTION_META: {
@@ -62,10 +64,15 @@ const SECTION_META: {
 ];
 
 /**
- * Resources tab host (#188): unit-synced shell, empty state, accordion stubs.
- * Section bodies (#189–#191) mount into these slots later.
+ * Resources tab host (#188): unit-synced shell, empty state, accordion slots.
+ * Translation Notes body: #189 (live Aquifer). Questions / Images stubs until #190 / #191.
  */
-export function ResourcesTab({ chapterId, chapterName }: ResourcesTabProps) {
+export function ResourcesTab({
+  chapterId,
+  chapterName,
+  bookCode,
+  chapterNumber,
+}: ResourcesTabProps) {
   const { selectedVerse } = useDraftingContext();
   const scrollRef = useRef<ScrollView>(null);
   const scrollOffsetRef = useRef(0);
@@ -74,14 +81,25 @@ export function ResourcesTab({ chapterId, chapterName }: ResourcesTabProps) {
     () => getMockResourcesForUnit(chapterId, selectedVerse, chapterName),
     [chapterId, selectedVerse, chapterName],
   );
-  const hasContent = unitHasAnyResources(resources);
+
+  const { state: notesState, retry: retryNotes } = useTranslationNotesForUnit({
+    bookCode,
+    chapterNumber,
+    verseNumber: selectedVerse,
+  });
+
+  // Live Aquifer TN (#189): show while loading/error, or when notes exist.
+  // Do not gate on #188 mock emptiness alone — verse % 3 === 0 still loads Aquifer.
+  const showTranslationNotes =
+    notesState.status === 'loading' ||
+    notesState.status === 'error' ||
+    (notesState.status === 'ready' && notesState.notes.length > 0);
 
   const [openAccordionIds, setOpenAccordionIds] = useState<Set<string>>(
     () => getResourcesTabUiState(chapterId, selectedVerse).openAccordionIds,
   );
   const openIdsRef = useRef(openAccordionIds);
 
-  // Restore scroll + accordion state when the active unit changes.
   useEffect(() => {
     const saved = getResourcesTabUiState(chapterId, selectedVerse);
     openIdsRef.current = saved.openAccordionIds;
@@ -127,17 +145,21 @@ export function ResourcesTab({ chapterId, chapterName }: ResourcesTabProps) {
     [persistUiState],
   );
 
-  if (!hasContent) {
+  const visibleSections = SECTION_META.filter(section => {
+    if (section.id === 'translationNotes') {
+      return showTranslationNotes;
+    }
+    // TQ / Images stay on the #188 mock shell until #190 / #191.
+    return resources.sections.includes(section.id);
+  });
+
+  if (visibleSections.length === 0) {
     return (
       <View style={styles.emptyHost} testID="resources-tab">
         <EmptyState message={RESOURCES_EMPTY_MESSAGE} />
       </View>
     );
   }
-
-  const visibleSections = SECTION_META.filter(section =>
-    resources.sections.includes(section.id),
-  );
 
   return (
     <ScrollView
@@ -160,20 +182,34 @@ export function ResourcesTab({ chapterId, chapterName }: ResourcesTabProps) {
       </View>
 
       <View style={styles.sections}>
-        {visibleSections.map(({ id, label, Icon }) => (
-          <ResourceSectionAccordion
-            key={`${selectedVerse}-${id}`}
-            label={label}
-            Icon={Icon}
-            expanded={openAccordionIds.has(id)}
-            onToggle={() => handleToggle(id)}
-            testID={`resources-section-${id}`}
-          >
-            <Text style={styles.stubBody}>
-              Content for this section will appear here.
-            </Text>
-          </ResourceSectionAccordion>
-        ))}
+        {visibleSections.map(({ id, label, Icon }) => {
+          const expanded = openAccordionIds.has(id);
+          return (
+            <ResourceSectionAccordion
+              key={`${chapterId}-${selectedVerse}-${id}`}
+              label={label}
+              Icon={Icon}
+              expanded={expanded}
+              onToggle={() => handleToggle(id)}
+              testID={`resources-section-${id}`}
+            >
+              {id === 'translationNotes' ? (
+                <TranslationNotesSection
+                  state={notesState}
+                  retry={retryNotes}
+                  sectionExpanded={expanded}
+                  bookCode={bookCode}
+                  chapterNumber={chapterNumber}
+                  verseNumber={selectedVerse}
+                />
+              ) : (
+                <Text style={styles.stubBody}>
+                  Content for this section will appear here.
+                </Text>
+              )}
+            </ResourceSectionAccordion>
+          );
+        })}
       </View>
     </ScrollView>
   );

--- a/src/app/tabs/resources/TranslationNoteAccordion.tsx
+++ b/src/app/tabs/resources/TranslationNoteAccordion.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  LayoutAnimation,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  UIManager,
+  View,
+} from 'react-native';
+import { ChevronDown, ChevronUp } from 'lucide-react-native';
+import { TRANSLATION_NOTE_EMPTY_BODY } from '../../../constants/messages';
+import { theme, iconSizes, listIconStrokeWidth } from '../../../theme';
+
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental?.(true);
+}
+
+type TranslationNoteAccordionProps = {
+  title: string;
+  body: string;
+  expanded: boolean;
+  onToggle: () => void;
+  testID?: string;
+};
+
+/**
+ * Nested TN accordion — body hidden until expanded (#189).
+ */
+export function TranslationNoteAccordion({
+  title,
+  body,
+  expanded,
+  onToggle,
+  testID,
+}: TranslationNoteAccordionProps) {
+  const noteBody = body.trim() ? body : TRANSLATION_NOTE_EMPTY_BODY;
+
+  return (
+    <View style={styles.card} testID={testID}>
+      <TouchableOpacity
+        style={styles.header}
+        onPress={() => {
+          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+          onToggle();
+        }}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        accessibilityLabel={title}
+        testID={testID ? `${testID}-toggle` : undefined}
+      >
+        <Text style={styles.title}>{title}</Text>
+        {expanded ? (
+          <ChevronUp
+            size={iconSizes.chevron}
+            color={theme.colors.mutedForeground}
+            strokeWidth={listIconStrokeWidth}
+          />
+        ) : (
+          <ChevronDown
+            size={iconSizes.chevron}
+            color={theme.colors.mutedForeground}
+            strokeWidth={listIconStrokeWidth}
+          />
+        )}
+      </TouchableOpacity>
+      {expanded ? (
+        <View
+          style={styles.body}
+          testID={testID ? `${testID}-body` : undefined}
+        >
+          <Text style={styles.bodyText}>{noteBody}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.colors.background,
+    borderRadius: theme.radius.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.border,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.md,
+    minHeight: 44,
+  },
+  title: {
+    flex: 1,
+    fontSize: theme.typography.sizes.sm,
+    fontWeight: theme.typography.weights.medium,
+    color: theme.colors.foreground,
+    lineHeight: theme.typography.lineHeights.normal,
+  },
+  body: {
+    paddingHorizontal: theme.spacing.md,
+    paddingBottom: theme.spacing.md,
+  },
+  bodyText: {
+    fontSize: theme.typography.sizes.sm,
+    color: theme.colors.mutedForeground,
+    lineHeight: theme.typography.lineHeights.normal,
+  },
+});

--- a/src/app/tabs/resources/TranslationNotesSection.test.tsx
+++ b/src/app/tabs/resources/TranslationNotesSection.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import { TranslationNotesSection } from './TranslationNotesSection';
+import { TRANSLATION_NOTES_LOAD_ERROR } from '../../../constants/messages';
+import {
+  loadTranslationNotesForUnit,
+  setTranslationNotesLoadFailureForTests,
+} from '../../../services/translationNotes';
+import { getMockTranslationNotes } from '../../../mocks/resources/translationNotesMock';
+import { useTranslationNotesForUnit } from '../../../hooks/useTranslationNotesForUnit';
+
+jest.mock('../../../services/translationNotes', () => {
+  const actual = jest.requireActual('../../../services/translationNotes');
+  return {
+    ...actual,
+    loadTranslationNotesForUnit: jest.fn(),
+  };
+});
+
+const mockLoad = loadTranslationNotesForUnit as jest.MockedFunction<
+  typeof loadTranslationNotesForUnit
+>;
+
+function SectionHarness({
+  verseNumber,
+  sectionExpanded = true,
+}: {
+  verseNumber: number;
+  sectionExpanded?: boolean;
+}) {
+  const { state, retry } = useTranslationNotesForUnit({
+    bookCode: 'MRK',
+    chapterNumber: 14,
+    verseNumber,
+  });
+  return (
+    <TranslationNotesSection
+      state={state}
+      retry={retry}
+      sectionExpanded={sectionExpanded}
+      bookCode="MRK"
+      chapterNumber={14}
+      verseNumber={verseNumber}
+    />
+  );
+}
+
+describe('TranslationNotesSection', () => {
+  beforeEach(() => {
+    mockLoad.mockImplementation(async ({ verseNumber }) =>
+      getMockTranslationNotes(99, verseNumber),
+    );
+  });
+
+  afterEach(() => {
+    setTranslationNotesLoadFailureForTests(false);
+    mockLoad.mockReset();
+  });
+
+  it('hides content when no notes are available', async () => {
+    render(<SectionHarness verseNumber={3} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('translation-notes-loading')).toBeNull();
+    });
+    expect(screen.queryByTestId('translation-notes-list')).toBeNull();
+    expect(screen.queryByTestId('translation-notes-error')).toBeNull();
+  });
+
+  it('keeps note bodies hidden until a nested accordion is expanded', async () => {
+    render(<SectionHarness verseNumber={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
+    });
+
+    expect(screen.getByText('connecting word')).toBeTruthy();
+    expect(
+      screen.queryByText(
+        'This phrase connects the current verse to the previous one.',
+      ),
+    ).toBeNull();
+
+    fireEvent.press(screen.getByTestId('translation-note-tn-99-1-1-toggle'));
+
+    expect(
+      screen.getByText(
+        'This phrase connects the current verse to the previous one.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('shows section-scoped error and recovers on Retry', async () => {
+    mockLoad.mockRejectedValueOnce(new Error('boom'));
+    mockLoad.mockResolvedValueOnce(getMockTranslationNotes(99, 1));
+
+    render(<SectionHarness verseNumber={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-error')).toBeTruthy();
+    });
+    expect(screen.getByText(TRANSLATION_NOTES_LOAD_ERROR)).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('translation-notes-retry'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
+    });
+  });
+});

--- a/src/app/tabs/resources/TranslationNotesSection.test.tsx
+++ b/src/app/tabs/resources/TranslationNotesSection.test.tsx
@@ -115,4 +115,19 @@ describe('TranslationNotesSection', () => {
       expect(screen.getByTestId('translation-notes-list')).toBeTruthy();
     });
   });
+
+  it('treats a missing load state as loading instead of crashing', () => {
+    render(
+      <TranslationNotesSection
+        state={undefined}
+        retry={() => undefined}
+        sectionExpanded
+        bookCode="MRK"
+        chapterNumber={14}
+        verseNumber={1}
+      />,
+    );
+
+    expect(screen.getByTestId('translation-notes-loading')).toBeTruthy();
+  });
 });

--- a/src/app/tabs/resources/TranslationNotesSection.tsx
+++ b/src/app/tabs/resources/TranslationNotesSection.tsx
@@ -12,7 +12,7 @@ import { TRANSLATION_NOTES_LOAD_ERROR } from '../../../constants/messages';
 import { theme } from '../../../theme';
 
 type TranslationNotesSectionProps = {
-  state: TranslationNotesLoadState;
+  state: TranslationNotesLoadState | undefined;
   retry: () => void;
   /** Reset nested open state when the parent section collapses or unit changes. */
   sectionExpanded: boolean;
@@ -57,7 +57,7 @@ export function TranslationNotesSection({
     });
   }, []);
 
-  if (state.status === 'loading') {
+  if (!state || state.status === 'loading') {
     return (
       <View style={styles.centered} testID="translation-notes-loading">
         <ActivityIndicator color={theme.colors.primary} />
@@ -81,7 +81,7 @@ export function TranslationNotesSection({
     );
   }
 
-  if (state.notes.length === 0) {
+  if (state.status !== 'ready' || state.notes.length === 0) {
     return null;
   }
 

--- a/src/app/tabs/resources/TranslationNotesSection.tsx
+++ b/src/app/tabs/resources/TranslationNotesSection.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { TranslationNoteAccordion } from './TranslationNoteAccordion';
+import type { TranslationNotesLoadState } from '../../../hooks/useTranslationNotesForUnit';
+import { TRANSLATION_NOTES_LOAD_ERROR } from '../../../constants/messages';
+import { theme } from '../../../theme';
+
+type TranslationNotesSectionProps = {
+  state: TranslationNotesLoadState;
+  retry: () => void;
+  /** Reset nested open state when the parent section collapses or unit changes. */
+  sectionExpanded: boolean;
+  bookCode: string;
+  chapterNumber: number;
+  verseNumber: number;
+};
+
+/**
+ * Translation Notes body for the Resources tab (#189).
+ * Nested note accordions; section-scoped error + Retry.
+ */
+export function TranslationNotesSection({
+  state,
+  retry,
+  sectionExpanded,
+  bookCode,
+  chapterNumber,
+  verseNumber,
+}: TranslationNotesSectionProps) {
+  const [openNoteIds, setOpenNoteIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setOpenNoteIds(new Set());
+  }, [bookCode, chapterNumber, verseNumber]);
+
+  useEffect(() => {
+    if (!sectionExpanded) {
+      setOpenNoteIds(new Set());
+    }
+  }, [sectionExpanded]);
+
+  const handleToggle = useCallback((noteId: string) => {
+    setOpenNoteIds(prev => {
+      const next = new Set(prev);
+      if (next.has(noteId)) {
+        next.delete(noteId);
+      } else {
+        next.add(noteId);
+      }
+      return next;
+    });
+  }, []);
+
+  if (state.status === 'loading') {
+    return (
+      <View style={styles.centered} testID="translation-notes-loading">
+        <ActivityIndicator color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <View style={styles.centered} testID="translation-notes-error">
+        <Text style={styles.errorMessage}>{TRANSLATION_NOTES_LOAD_ERROR}</Text>
+        <TouchableOpacity
+          onPress={() => void retry()}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading Translation Notes"
+          testID="translation-notes-retry"
+        >
+          <Text style={styles.retryLink}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (state.notes.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.list} testID="translation-notes-list">
+      {state.notes.map(note => (
+        <TranslationNoteAccordion
+          key={note.id}
+          title={note.title}
+          body={note.body}
+          expanded={openNoteIds.has(note.id)}
+          onToggle={() => handleToggle(note.id)}
+          testID={`translation-note-${note.id}`}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    gap: theme.spacing.sm,
+  },
+  centered: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing.sm,
+    paddingVertical: theme.spacing.md,
+  },
+  errorMessage: {
+    fontSize: theme.typography.sizes.sm,
+    color: theme.colors.foreground,
+    textAlign: 'center',
+  },
+  retryLink: {
+    fontSize: theme.typography.sizes.sm,
+    color: theme.colors.primary,
+    fontWeight: theme.typography.weights.medium,
+  },
+});

--- a/src/app/tabs/resources/TranslationNotesSectionHost.tsx
+++ b/src/app/tabs/resources/TranslationNotesSectionHost.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { TranslationNotesLoadState } from '../../../hooks/useTranslationNotesForUnit';
+
+type TranslationNotesSectionHostProps = {
+  state: TranslationNotesLoadState | undefined;
+  retry: () => void;
+  sectionExpanded: boolean;
+  bookCode: string;
+  chapterNumber: number;
+  verseNumber: number;
+};
+
+/**
+ * Lazily require the TN body so a Metro HMR / module-graph glitch in
+ * `TranslationNotesSection` cannot make ResourcesTab crash on
+ * `TranslationNotesSection` of undefined (same pattern as ImagesMapsSectionHost).
+ */
+export function TranslationNotesSectionHost(
+  props: TranslationNotesSectionHostProps,
+) {
+  const { TranslationNotesSection } =
+    require('./TranslationNotesSection') as typeof import('./TranslationNotesSection');
+  return <TranslationNotesSection {...props} />;
+}

--- a/src/app/tabs/resources/mockResourceData.test.ts
+++ b/src/app/tabs/resources/mockResourceData.test.ts
@@ -15,7 +15,7 @@ describe('getMockResourcesForUnit', () => {
     const resources = getMockResourcesForUnit(1, 1, 'Mark 14');
     expect(resources.sections).toEqual(['translationNotes']);
     expect(unitHasAnyResources(resources)).toBe(true);
-    expect(resources.passageTitle).toBeTruthy();
+    expect(resources.passageTitle).toBeUndefined();
   });
 
   it('returns all three sections for verses with remainder 2', () => {

--- a/src/app/tabs/resources/mockResourceData.ts
+++ b/src/app/tabs/resources/mockResourceData.ts
@@ -10,15 +10,15 @@ const ALL_SECTIONS: ResourceSectionId[] = [
 ];
 
 /**
- * Deterministic mock resources for a drafting unit.
+ * Deterministic mock shell for Resources tab stubs (#188 / #190 / #191).
  *
  * Pattern (by verse number):
- * - `% 3 === 0` → empty (tab-wide empty state)
- * - `% 3 === 1` → Translation Notes only
- * - `% 3 === 2` → all three section stubs
+ * - `% 3 === 0` → no stub sections (TN may still appear from live Aquifer #189)
+ * - `% 3 === 1` → Translation Notes slot only (live Aquifer fills body)
+ * - `% 3 === 2` → all three section stubs (TQ / Images until #190 / #191)
  *
- * Sync / no loading gate — replace with local queries when #189+ / #192 land.
- * Do not call FluentAPI from this module (API has no resource content endpoints).
+ * Translation Notes visibility is driven by Aquifer load state in ResourcesTab,
+ * not by this mock alone.
  */
 export function getMockResourcesForUnit(
   _chapterId: number,
@@ -37,14 +37,12 @@ export function getMockResourcesForUnit(
   if (pattern === 1) {
     return {
       referenceLabel: `${chapterName}:${verseNumber}`,
-      passageTitle: 'Sample notes for this verse',
       sections: ['translationNotes'],
     };
   }
 
   return {
     referenceLabel: `${chapterName}:${verseNumber}`,
-    passageTitle: 'Sample passage resources',
     sections: [...ALL_SECTIONS],
   };
 }

--- a/src/config/aquiferApi.test.ts
+++ b/src/config/aquiferApi.test.ts
@@ -1,0 +1,81 @@
+type AquiferExtra = {
+  aquiferApiKey?: string;
+  aquiferApiBaseUrl?: string;
+};
+
+const constantsState: {
+  expoConfig: { extra: AquiferExtra } | null;
+  manifest: { extra?: AquiferExtra } | null;
+} = {
+  expoConfig: { extra: {} },
+  manifest: null,
+};
+
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    get expoConfig() {
+      return constantsState.expoConfig;
+    },
+    set expoConfig(value: { extra: AquiferExtra } | null) {
+      constantsState.expoConfig = value;
+    },
+    get manifest() {
+      return constantsState.manifest;
+    },
+    set manifest(value: { extra?: AquiferExtra } | null) {
+      constantsState.manifest = value;
+    },
+  },
+}));
+
+import { getAquiferApiBaseUrl, getAquiferApiKey } from './aquiferApi';
+
+describe('aquiferApi config', () => {
+  const originalKey = process.env.AQUIFER_API_KEY;
+  const originalBase = process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL;
+
+  beforeEach(() => {
+    constantsState.expoConfig = { extra: {} };
+    constantsState.manifest = null;
+    delete process.env.AQUIFER_API_KEY;
+    delete process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL;
+  });
+
+  afterAll(() => {
+    process.env.AQUIFER_API_KEY = originalKey;
+    process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL = originalBase;
+  });
+
+  it('reads AQUIFER_API_KEY from expo-constants extra', () => {
+    constantsState.expoConfig = { extra: { aquiferApiKey: 'from-extra' } };
+    expect(getAquiferApiKey()).toBe('from-extra');
+  });
+
+  it('falls back to process.env.AQUIFER_API_KEY', () => {
+    process.env.AQUIFER_API_KEY = 'from-env';
+    expect(getAquiferApiKey()).toBe('from-env');
+  });
+
+  it('throws when the Aquifer key is missing', () => {
+    expect(() => getAquiferApiKey()).toThrow(/AQUIFER_API_KEY is required/);
+  });
+
+  it('prefers extra base URL then env then default', () => {
+    expect(getAquiferApiBaseUrl()).toBe('https://api.aquifer.bible');
+
+    process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL = 'https://env.aquifer.test/';
+    expect(getAquiferApiBaseUrl()).toBe('https://env.aquifer.test');
+
+    constantsState.expoConfig = {
+      extra: { aquiferApiBaseUrl: 'https://extra.aquifer.test/' },
+    };
+    expect(getAquiferApiBaseUrl()).toBe('https://extra.aquifer.test');
+  });
+
+  it('reads extra from legacy Constants.manifest when expoConfig is absent', () => {
+    constantsState.expoConfig = null;
+    constantsState.manifest = { extra: { aquiferApiKey: 'from-manifest' } };
+    expect(getAquiferApiKey()).toBe('from-manifest');
+  });
+});

--- a/src/config/aquiferApi.ts
+++ b/src/config/aquiferApi.ts
@@ -1,17 +1,56 @@
+import Constants from 'expo-constants';
+
 const DEFAULT_AQUIFER_API_BASE_URL = 'https://api.aquifer.bible';
 
-export function getAquiferApiBaseUrl(): string {
-  return (
-    process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL?.trim() ||
-    DEFAULT_AQUIFER_API_BASE_URL
-  ).replace(/\/+$/, '');
+type AquiferConfigExtra = {
+  aquiferApiKey?: string;
+  aquiferApiBaseUrl?: string;
+};
+
+/**
+ * Resolve `extra` from the active Expo config.
+ * Prefer `expoConfig` (modern); fall back to classic `manifest.extra`.
+ */
+function getAquiferExtra(): AquiferConfigExtra {
+  const fromExpoConfig = Constants.expoConfig?.extra;
+  if (fromExpoConfig && typeof fromExpoConfig === 'object') {
+    return fromExpoConfig as AquiferConfigExtra;
+  }
+
+  const legacyManifest = Constants.manifest as
+    | { extra?: AquiferConfigExtra }
+    | null
+    | undefined;
+  if (legacyManifest?.extra && typeof legacyManifest.extra === 'object') {
+    return legacyManifest.extra;
+  }
+
+  return {};
 }
 
+export function getAquiferApiBaseUrl(): string {
+  const fromExtra = getAquiferExtra().aquiferApiBaseUrl?.trim();
+  const fromEnv = process.env.EXPO_PUBLIC_AQUIFER_API_BASE_URL?.trim();
+  return (fromExtra || fromEnv || DEFAULT_AQUIFER_API_BASE_URL).replace(
+    /\/+$/,
+    '',
+  );
+}
+
+/**
+ * Aquifer API key from EAS/Expo env `AQUIFER_API_KEY` (not EXPO_PUBLIC_).
+ *
+ * Flow: Expo dashboard / `.env` → `process.env.AQUIFER_API_KEY` when
+ * `app.config.ts` resolves → `extra.aquiferApiKey` → expo-constants here.
+ */
 export function getAquiferApiKey(): string {
-  const key = process.env.EXPO_PUBLIC_AQUIFER_API_KEY?.trim();
+  const fromExtra = getAquiferExtra().aquiferApiKey?.trim();
+  // Jest / Node scripts may set the var directly without going through extra.
+  const fromEnv = process.env.AQUIFER_API_KEY?.trim();
+  const key = fromExtra || fromEnv;
   if (!key) {
     throw new Error(
-      'EXPO_PUBLIC_AQUIFER_API_KEY is required for Aquifer resource downloads.',
+      'AQUIFER_API_KEY is required for Aquifer resource downloads. Set it as an EAS environment variable (or locally in .env — see .env.example).',
     );
   }
   return key;

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -9,6 +9,10 @@ export const PROJECT_CHAPTERS_EMPTY_MESSAGE =
 
 export const RESOURCES_EMPTY_MESSAGE = 'No resources available for this verse';
 
+export const TRANSLATION_NOTES_LOAD_ERROR = 'Unable to load Translation Notes.';
+
+export const TRANSLATION_NOTE_EMPTY_BODY = 'No note text available.';
+
 export const LOGOUT_UNSYNCED_TITLE = 'Unsynced work on device';
 export const LOGOUT_UNSYNCED_MESSAGE =
   'You have recordings that have not been uploaded. Log out anyway?';

--- a/src/hooks/useTranslationNotesForUnit.test.ts
+++ b/src/hooks/useTranslationNotesForUnit.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useTranslationNotesForUnit } from './useTranslationNotesForUnit';
+import {
+  loadTranslationNotesForUnit,
+  setTranslationNotesLoadFailureForTests,
+} from '../services/translationNotes';
+import { TRANSLATION_NOTES_LOAD_ERROR } from '../constants/messages';
+import { getMockTranslationNotes } from '../mocks/resources/translationNotesMock';
+
+jest.mock('../services/translationNotes', () => {
+  const actual = jest.requireActual('../services/translationNotes');
+  return {
+    ...actual,
+    loadTranslationNotesForUnit: jest.fn(),
+  };
+});
+
+const mockLoad = loadTranslationNotesForUnit as jest.MockedFunction<
+  typeof loadTranslationNotesForUnit
+>;
+
+describe('useTranslationNotesForUnit', () => {
+  afterEach(() => {
+    setTranslationNotesLoadFailureForTests(false);
+    mockLoad.mockReset();
+  });
+
+  it('loads notes for units that have TN content', async () => {
+    mockLoad.mockResolvedValue(getMockTranslationNotes(10, 1));
+
+    const { result } = renderHook(() =>
+      useTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 1,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('ready');
+    });
+
+    if (result.current.state.status !== 'ready') {
+      throw new Error('expected ready state');
+    }
+    expect(result.current.state.notes.length).toBeGreaterThan(0);
+    expect(mockLoad).toHaveBeenCalledWith({
+      bookCode: 'MRK',
+      chapterNumber: 14,
+      verseNumber: 1,
+      languageCode: undefined,
+    });
+  });
+
+  it('exposes an error state that retry can clear', async () => {
+    mockLoad.mockRejectedValueOnce(new Error('boom'));
+    mockLoad.mockResolvedValueOnce(getMockTranslationNotes(10, 1));
+
+    const { result } = renderHook(() =>
+      useTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 1,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('error');
+    });
+
+    if (result.current.state.status !== 'error') {
+      throw new Error('expected error state');
+    }
+    expect(result.current.state.message).toBe(TRANSLATION_NOTES_LOAD_ERROR);
+
+    await act(async () => {
+      await result.current.retry();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('ready');
+    });
+  });
+});

--- a/src/hooks/useTranslationNotesForUnit.ts
+++ b/src/hooks/useTranslationNotesForUnit.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { TRANSLATION_NOTES_LOAD_ERROR } from '../constants/messages';
+import {
+  loadTranslationNotesForUnit,
+  type LoadTranslationNotesParams,
+} from '../services/translationNotes';
+import { TranslationNoteItem } from '../types/resources/translationNotes';
+import { logger } from '../utils/logger';
+
+const log = logger.create('useTranslationNotesForUnit');
+
+export type TranslationNotesLoadState =
+  | { status: 'loading' }
+  | { status: 'ready'; notes: TranslationNoteItem[] }
+  | { status: 'error'; message: string };
+
+type TrackedLoadState = {
+  bookCode: string;
+  chapterNumber: number;
+  verseNumber: number;
+  value: TranslationNotesLoadState;
+};
+
+export type UseTranslationNotesForUnitParams = LoadTranslationNotesParams;
+
+/**
+ * Section-scoped TN loader (#189). Failures stay local — do not block TQ / Images.
+ * Ignores stale responses when the active unit changes mid-load.
+ * Loads real Aquifer uW TN (interim until fluent-api#273).
+ */
+export function useTranslationNotesForUnit(
+  params: UseTranslationNotesForUnitParams,
+) {
+  const { bookCode, chapterNumber, verseNumber, languageCode } = params;
+
+  const [tracked, setTracked] = useState<TrackedLoadState>({
+    bookCode,
+    chapterNumber,
+    verseNumber,
+    value: { status: 'loading' },
+  });
+  const requestIdRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setTracked({
+      bookCode,
+      chapterNumber,
+      verseNumber,
+      value: { status: 'loading' },
+    });
+    try {
+      const notes = await loadTranslationNotesForUnit({
+        bookCode,
+        chapterNumber,
+        verseNumber,
+        languageCode,
+      });
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setTracked({
+        bookCode,
+        chapterNumber,
+        verseNumber,
+        value: { status: 'ready', notes },
+      });
+    } catch (error) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      log.warn('Translation Notes load failed', {
+        bookCode,
+        chapterNumber,
+        verseNumber,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      setTracked({
+        bookCode,
+        chapterNumber,
+        verseNumber,
+        value: {
+          status: 'error',
+          message: TRANSLATION_NOTES_LOAD_ERROR,
+        },
+      });
+    }
+  }, [bookCode, chapterNumber, verseNumber, languageCode]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [load]);
+
+  const state: TranslationNotesLoadState =
+    tracked.bookCode === bookCode &&
+    tracked.chapterNumber === chapterNumber &&
+    tracked.verseNumber === verseNumber
+      ? tracked.value
+      : { status: 'loading' };
+
+  return {
+    state,
+    retry: load,
+  };
+}

--- a/src/mocks/resources/translationNotesMock.ts
+++ b/src/mocks/resources/translationNotesMock.ts
@@ -1,0 +1,30 @@
+/**
+ * Deterministic TN fixtures for unit tests (#189).
+ * Production loads Aquifer via `services/translationNotes`.
+ */
+import { TranslationNoteItem } from '../../types/resources/translationNotes';
+
+/**
+ * Aligns with `getMockResourcesForUnit`: notes when verse % 3 === 1 or 2.
+ */
+export function getMockTranslationNotes(
+  chapterId: number,
+  verseNumber: number,
+): TranslationNoteItem[] {
+  if (verseNumber % 3 === 0) {
+    return [];
+  }
+
+  return [
+    {
+      id: `tn-${chapterId}-${verseNumber}-1`,
+      title: 'connecting word',
+      body: 'This phrase connects the current verse to the previous one.',
+    },
+    {
+      id: `tn-${chapterId}-${verseNumber}-2`,
+      title: 'Important name',
+      body: 'Translate this name consistently with earlier uses in the book.',
+    },
+  ];
+}

--- a/src/services/aquiferApi.test.ts
+++ b/src/services/aquiferApi.test.ts
@@ -37,7 +37,6 @@ describe('AquiferAPI', () => {
       expect.objectContaining({
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
           'api-key': 'key-123',
         },
         signal: expect.any(AbortSignal),

--- a/src/services/aquiferApi.test.ts
+++ b/src/services/aquiferApi.test.ts
@@ -94,4 +94,36 @@ describe('AquiferAPI', () => {
     expect(url).toContain('BookCode=GEN');
     expect(url).toContain('shouldReturnAudioData=true');
   });
+
+  it('throws ApiError instead of crashing when fetch resolves undefined', async () => {
+    fetchMock.mockResolvedValue(undefined);
+
+    await expect(AquiferAPI.getLanguages()).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 0,
+      message: expect.stringMatching(/no response/i),
+    });
+  });
+
+  it('throws ApiError with HTTP status when Aquifer returns an error response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ message: 'Invalid api-key' }),
+    });
+
+    await expect(
+      AquiferAPI.searchResources({
+        bookCode: 'MRK',
+        startChapter: 1,
+        endChapter: 1,
+        languageCode: 'eng',
+        resourceCollectionCode: 'UWTranslationNotes',
+      }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 401,
+      message: 'Invalid api-key',
+    });
+  });
 });

--- a/src/services/aquiferApi.ts
+++ b/src/services/aquiferApi.ts
@@ -11,8 +11,9 @@ import type {
 import { createApiError, createNetworkApiError } from './apiError';
 
 function aquiferHeaders(): Record<string, string> {
+  // Match fluent-web: api-key only. Aquifer rejects some GETs when
+  // Content-Type: application/json is set (HTTP 400 "One or more errors occurred!").
   return {
-    'Content-Type': 'application/json',
     'api-key': getAquiferApiKey(),
   };
 }

--- a/src/services/aquiferApi.ts
+++ b/src/services/aquiferApi.ts
@@ -49,6 +49,14 @@ async function aquiferRequest<T>(endpoint: string): Promise<T> {
       signal: controller.signal,
     });
 
+    // Some RN/network failure modes resolve fetch without a Response.
+    // Guard before reading `.ok` / `.status` so callers get ApiError, not a crash.
+    if (response === undefined || response === null) {
+      throw createNetworkApiError(
+        new Error('Aquifer request returned no response'),
+      );
+    }
+
     if (!response.ok) {
       throw createApiError(response.status, await response.text());
     }

--- a/src/services/translationNotes.test.ts
+++ b/src/services/translationNotes.test.ts
@@ -1,0 +1,169 @@
+import type { AquiferResourceDetails } from '../types/api/aquifer';
+import {
+  loadTranslationNotesForUnit,
+  parseAquiferTranslationNotes,
+  setTranslationNotesLoadFailureForTests,
+} from './translationNotes';
+import { AquiferAPI } from './aquiferApi';
+
+jest.mock('./aquiferApi', () => ({
+  AquiferAPI: {
+    searchResources: jest.fn(),
+    getResourceDetails: jest.fn(),
+  },
+}));
+
+const searchResources = AquiferAPI.searchResources as jest.MockedFunction<
+  typeof AquiferAPI.searchResources
+>;
+const getResourceDetails = AquiferAPI.getResourceDetails as jest.MockedFunction<
+  typeof AquiferAPI.getResourceDetails
+>;
+
+const sampleDetails: AquiferResourceDetails = {
+  id: 12345,
+  referenceId: 1,
+  name: 'Mark 14:2',
+  localizedName: 'Mark 14:2',
+  content: [
+    {
+      tiptap: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'connecting word' }],
+          },
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'This phrase connects the current verse to the previous one.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+  grouping: {
+    type: 'Guide',
+    name: 'Translation Notes',
+    mediaType: 'Text',
+  },
+  language: {
+    id: 1,
+    code: 'eng',
+    displayName: 'English',
+    scriptDirection: 'LTR',
+  },
+};
+
+describe('parseAquiferTranslationNotes', () => {
+  it('maps TipTap content to note title/body', () => {
+    expect(parseAquiferTranslationNotes(sampleDetails)).toEqual([
+      {
+        id: 'tn-aquifer-12345-0',
+        title: 'Mark 14:2',
+        body: 'connecting word\nThis phrase connects the current verse to the previous one.',
+      },
+    ]);
+  });
+});
+
+describe('loadTranslationNotesForUnit', () => {
+  afterEach(() => {
+    setTranslationNotesLoadFailureForTests(false);
+    searchResources.mockReset();
+    getResourceDetails.mockReset();
+  });
+
+  it('returns [] when bookCode is missing', async () => {
+    await expect(
+      loadTranslationNotesForUnit({
+        bookCode: '  ',
+        chapterNumber: 14,
+        verseNumber: 1,
+      }),
+    ).resolves.toEqual([]);
+    expect(searchResources).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when Aquifer has no TN for the unit', async () => {
+    searchResources.mockResolvedValue({
+      totalItemCount: 0,
+      returnedItemCount: 0,
+      offset: 0,
+      items: [],
+    });
+
+    await expect(
+      loadTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 1,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('searches Aquifer and parses resource details', async () => {
+    searchResources.mockResolvedValue({
+      totalItemCount: 1,
+      returnedItemCount: 1,
+      offset: 0,
+      items: [
+        {
+          id: 12345,
+          name: 'Mark 14:2',
+          localizedName: 'Mark 14:2',
+          mediaType: 'Text',
+          languageCode: 'eng',
+          grouping: {
+            type: 'Guide',
+            name: 'Translation Notes',
+            collectionTitle: 'Translation Notes',
+            collectionCode: 'UWTranslationNotes',
+          },
+        },
+      ],
+    });
+    getResourceDetails.mockResolvedValue(sampleDetails);
+
+    await expect(
+      loadTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 2,
+      }),
+    ).resolves.toEqual([
+      {
+        id: 'tn-aquifer-12345-0',
+        title: 'Mark 14:2',
+        body: 'connecting word\nThis phrase connects the current verse to the previous one.',
+      },
+    ]);
+
+    expect(searchResources).toHaveBeenCalledWith({
+      bookCode: 'MRK',
+      startChapter: 14,
+      endChapter: 14,
+      startVerse: 2,
+      endVerse: 2,
+      languageCode: 'eng',
+      resourceCollectionCode: 'UWTranslationNotes',
+      limit: 50,
+    });
+  });
+
+  it('throws when failure injection is enabled', async () => {
+    setTranslationNotesLoadFailureForTests(true);
+    await expect(
+      loadTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 2,
+      }),
+    ).rejects.toThrow(/Failed to load Translation Notes/);
+  });
+});

--- a/src/services/translationNotes.test.ts
+++ b/src/services/translationNotes.test.ts
@@ -5,6 +5,7 @@ import {
   setTranslationNotesLoadFailureForTests,
 } from './translationNotes';
 import { AquiferAPI } from './aquiferApi';
+import { ApiError } from './apiError';
 
 jest.mock('./aquiferApi', () => ({
   AquiferAPI: {
@@ -105,6 +106,37 @@ describe('loadTranslationNotesForUnit', () => {
         verseNumber: 1,
       }),
     ).resolves.toEqual([]);
+  });
+
+  it('returns [] when Aquifer search payload omits items', async () => {
+    searchResources.mockResolvedValue({} as never);
+
+    await expect(
+      loadTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 1,
+      }),
+    ).resolves.toEqual([]);
+    expect(getResourceDetails).not.toHaveBeenCalled();
+  });
+
+  it('propagates Aquifer ApiError so the section can show retry', async () => {
+    searchResources.mockRejectedValue(
+      new ApiError(0, 'Aquifer request returned no response'),
+    );
+
+    await expect(
+      loadTranslationNotesForUnit({
+        bookCode: 'MRK',
+        chapterNumber: 14,
+        verseNumber: 2,
+      }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 0,
+      message: expect.stringMatching(/no response/i),
+    });
   });
 
   it('searches Aquifer and parses resource details', async () => {

--- a/src/services/translationNotes.ts
+++ b/src/services/translationNotes.ts
@@ -110,12 +110,15 @@ export async function loadTranslationNotesForUnit(
     limit: 50,
   });
 
-  if (!search.items.length) {
+  // Aquifer can return 200 with an empty/`{}` body (parsed as `{}`) or omit
+  // `items` on unexpected payloads — treat as no notes, not a crash.
+  const items = Array.isArray(search?.items) ? search.items : [];
+  if (items.length === 0) {
     return [];
   }
 
   const detailsList = await Promise.all(
-    search.items.map(item => AquiferAPI.getResourceDetails(item.id)),
+    items.map(item => AquiferAPI.getResourceDetails(item.id)),
   );
 
   return detailsList.flatMap(parseAquiferTranslationNotes);

--- a/src/services/translationNotes.ts
+++ b/src/services/translationNotes.ts
@@ -1,0 +1,122 @@
+import type { AquiferResourceDetails } from '../types/api/aquifer';
+import type { TranslationNoteItem } from '../types/resources/translationNotes';
+import { tipTapToPlainText } from '../utils/aquiferTipTapText';
+import { AQUIFER_RESOURCE_COLLECTIONS } from './prepareOfflineResourceManifest';
+import { AquiferAPI } from './aquiferApi';
+
+const DEFAULT_TN_LANGUAGE_CODE = 'eng';
+
+export type LoadTranslationNotesParams = {
+  bookCode: string;
+  chapterNumber: number;
+  verseNumber: number;
+  /** Aquifer language for uW TN (defaults to English source). */
+  languageCode?: string;
+};
+
+type TipTapContentItem = {
+  tiptap?: unknown;
+};
+
+/** Test-only failure injection for section-scoped error/retry. */
+let loadShouldFailForTests = false;
+
+export function setTranslationNotesLoadFailureForTests(
+  shouldFail: boolean,
+): void {
+  loadShouldFailForTests = shouldFail;
+}
+
+function isContentItemArray(value: unknown): value is TipTapContentItem[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Parse one Aquifer TN resource detail into note items.
+ * Each TipTap content block becomes a nested note; title falls back to the
+ * resource localized name when a block has no leading heading text.
+ */
+export function parseAquiferTranslationNotes(
+  details: AquiferResourceDetails,
+): TranslationNoteItem[] {
+  if (!isContentItemArray(details.content)) {
+    return [];
+  }
+
+  const resourceTitle = (details.localizedName || details.name || '').trim();
+  const contentItems = details.content;
+  const notes: TranslationNoteItem[] = [];
+
+  contentItems.forEach((item, index) => {
+    const body = tipTapToPlainText(item.tiptap).trim();
+    if (!body) {
+      return;
+    }
+
+    const firstLine =
+      body
+        .split('\n')
+        .find(line => line.trim())
+        ?.trim() ?? '';
+    const useResourceTitle = contentItems.length === 1 && resourceTitle;
+    const title = useResourceTitle
+      ? resourceTitle
+      : firstLine.length > 0 && firstLine.length <= 120
+      ? firstLine
+      : resourceTitle || `Note ${index + 1}`;
+
+    const noteBody =
+      !useResourceTitle && title === firstLine && body.startsWith(firstLine)
+        ? body.slice(firstLine.length).trim()
+        : body;
+
+    notes.push({
+      id: `tn-aquifer-${details.id}-${index}`,
+      title,
+      body: noteBody || body,
+    });
+  });
+
+  return notes;
+}
+
+/**
+ * Load uW Translation Notes for a drafting unit from Aquifer.
+ * Interim until fluent-api#273 proxies these payloads.
+ */
+export async function loadTranslationNotesForUnit(
+  params: LoadTranslationNotesParams,
+): Promise<TranslationNoteItem[]> {
+  if (loadShouldFailForTests) {
+    throw new Error('Failed to load Translation Notes');
+  }
+
+  const bookCode = params.bookCode.trim();
+  // Missing bookCode (e.g. chapter row without USFM code) → hide section, not error.
+  if (!bookCode) {
+    return [];
+  }
+
+  const languageCode = params.languageCode?.trim() || DEFAULT_TN_LANGUAGE_CODE;
+
+  const search = await AquiferAPI.searchResources({
+    bookCode,
+    startChapter: params.chapterNumber,
+    endChapter: params.chapterNumber,
+    startVerse: params.verseNumber,
+    endVerse: params.verseNumber,
+    languageCode,
+    resourceCollectionCode: AQUIFER_RESOURCE_COLLECTIONS.translationNotes,
+    limit: 50,
+  });
+
+  if (!search.items.length) {
+    return [];
+  }
+
+  const detailsList = await Promise.all(
+    search.items.map(item => AquiferAPI.getResourceDetails(item.id)),
+  );
+
+  return detailsList.flatMap(parseAquiferTranslationNotes);
+}

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,5 +1,7 @@
 declare namespace NodeJS {
   interface ProcessEnv {
     EXPO_PUBLIC_API_BASE_URL: string;
+    EXPO_PUBLIC_AQUIFER_API_BASE_URL?: string;
+    AQUIFER_API_KEY?: string;
   }
 }

--- a/src/types/resources/translationNotes.ts
+++ b/src/types/resources/translationNotes.ts
@@ -1,0 +1,8 @@
+/** Aquifer Translation Note item for the Resources tab (#189). */
+export interface TranslationNoteItem {
+  id: string;
+  /** Accordion title (resource / note name). */
+  title: string;
+  /** Plain-text body with paragraphs/lists flattened for mobile. */
+  body: string;
+}

--- a/src/utils/aquiferTipTapText.test.ts
+++ b/src/utils/aquiferTipTapText.test.ts
@@ -1,0 +1,69 @@
+import { tipTapToPlainText } from './aquiferTipTapText';
+
+describe('tipTapToPlainText', () => {
+  it('flattens a TQ-style doc into question and answer lines', () => {
+    const text = tipTapToPlainText({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [{ type: 'bold' }],
+              text: 'Why did they wait?',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'They feared a riot.' }],
+        },
+      ],
+    });
+
+    expect(text).toBe('Why did they wait?\nThey feared a riot.');
+  });
+
+  it('preserves bullet list items as separate lines', () => {
+    const text = tipTapToPlainText({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Key points:' }],
+        },
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'First item' }],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Second item' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(text).toBe('Key points:\n• First item\n• Second item');
+  });
+
+  it('returns empty string for unknown shapes', () => {
+    expect(tipTapToPlainText(null)).toBe('');
+    expect(tipTapToPlainText('plain')).toBe('');
+  });
+});

--- a/src/utils/aquiferTipTapText.ts
+++ b/src/utils/aquiferTipTapText.ts
@@ -1,0 +1,48 @@
+type TipTapLike = {
+  type?: string;
+  text?: string;
+  content?: TipTapLike[];
+};
+
+function isTipTapLike(value: unknown): value is TipTapLike {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Flatten Aquifer TipTap JSON to plain text for mobile Resources accordions.
+ * Paragraphs and list items become newlines; bullets are preserved as `• `.
+ */
+export function tipTapToPlainText(node: unknown): string {
+  if (!isTipTapLike(node)) {
+    return '';
+  }
+
+  if (typeof node.text === 'string') {
+    return node.text;
+  }
+
+  if (!Array.isArray(node.content) || node.content.length === 0) {
+    return '';
+  }
+
+  const parts = node.content.map(child => tipTapToPlainText(child));
+  if (node.type === 'doc') {
+    return parts.filter(Boolean).join('\n').trim();
+  }
+  if (node.type === 'paragraph' || node.type === 'heading') {
+    return parts.join('').trim();
+  }
+  if (node.type === 'bulletList' || node.type === 'orderedList') {
+    return parts.filter(Boolean).join('\n');
+  }
+  if (node.type === 'listItem') {
+    const text = parts
+      .join('\n')
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .join(' ');
+    return text ? `• ${text}` : '';
+  }
+  return parts.join('');
+}


### PR DESCRIPTION
### TLDR

Adds the Translation Notes section on the Resources tab for the active drafting unit, loading live uW notes from Aquifer (`UWTranslationNotes`) instead of a stub body. Nested note accordions preserve paragraph/list formatting from TipTap, hide the section when empty, and keep load failures scoped to Notes so Questions and Images still render. Aquifer API key follows the `#303`/`#304` pattern via `app.config.ts` `extra.aquiferApiKey` + EAS `environment` (not `EXPO_PUBLIC_`).

### Reviewer checklist

- [ ] GitHub issue linked in Details (`Refs #NNN` — do **not** use `Closes` / `Fixes` / `Resolves`)
- [ ] How to verify steps completed or valid waiver noted below
- [ ] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`)
- [ ] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Refs #189

Implements the first live Resources content section: section accordion (collapsed by default) with book-open icon, nested per-note accordions, hide-when-empty, and section-scoped error + Retry. TQ / Images remain on the #188 mock shell until #190 / #191. Offline cache remains #192.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- `src/app/tabs/ResourcesTab.tsx` — wire live TN visibility from Aquifer load state (not mock emptiness alone); mount `TranslationNotesSection`
- `src/app/tabs/resources/TranslationNotesSection.tsx` / `TranslationNoteAccordion.tsx` — section + nested note UI, error/retry
- `src/hooks/useTranslationNotesForUnit.ts` — unit-keyed loader with stale-response ignore
- `src/services/translationNotes.ts` — Aquifer search + detail parse for `UWTranslationNotes`
- `src/utils/aquiferTipTapText.ts` — TipTap → plain text with paragraph/list preservation
- `src/config/aquiferApi.ts` / `app.config.ts` / `eas.json` / `.env.example` — bake `AQUIFER_API_KEY` into `extra.aquiferApiKey` per profile `environment`
- `src/app/screens/DraftingScreen.tsx` — pass `bookCode` / `chapterNumber` into Resources tab

#### Testing

- `npm run format:check` — pass
- `npm run lint` — pass (existing repo warnings only)
- `npm run typecheck` — pass
- `npm test -- --ci` — pass (118 suites / 763 tests; 1 skipped live API)
- `code-reviewer` — APPROVE (prior Should-fix items fixed)

### How to verify

1. `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci`
2. Ensure `AQUIFER_API_KEY` is set locally (`.env`) or via `eas env:pull --environment development`.
3. On Android (dev client): open a drafting chapter → Resources tab → expand Translation Notes for a verse that has uW TN; expand a nested note and confirm paragraphs/lists read correctly.
4. Force a Notes load failure (invalid key or airplane mode mid-fetch) and confirm Retry is section-scoped while Questions / Images stubs still show when the mock shell includes them.
5. Switch to a verse with no TN and confirm the Translation Notes section is hidden (empty host when no other sections either).

**Expected:** Live Aquifer TN for the active unit; empty hide; isolated error/retry; no draft-blocking of sibling sections.

**Human Android device QA:** Required for network Aquifer fetch + accordion UX / TipTap formatting on device — unit tests alone are not enough. Leave the device-QA checklist box unchecked until a human records results on this PR.

### Follow-ups

- [ ] #190 / #191 — Translation Questions / Images & Maps live content
- [ ] #192 — offline resource cache for TN (and siblings)
- [ ] fluent-api#273 — proxy Aquifer TN (interim direct Aquifer client remains until then)
