### PR TITLE
[#273]Refresh Assignment and Stage State on Chapter List Open

### DIFF
--- a/src/hooks/useMyWorkChapters.ts
+++ b/src/hooks/useMyWorkChapters.ts
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { getMyWorkChapters } from '../db/queries';
 import { MyWorkChapter } from '../types/db/types';
 import { parseUserId } from '../utils/parseUserId';
+import { getActiveUserId } from '../services/storage';
+import { refreshChapterMetadataIfOnline } from '../services/sync';
 import { logger } from '../utils/logger';
 
 const log = logger.create('useMyWorkChapters');
@@ -10,6 +13,7 @@ export function useMyWorkChapters(refreshKey = 0) {
   const [chapters, setChapters] = useState<MyWorkChapter[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const hasFocusedBefore = useRef(false);
 
   const loadChapters = useCallback(async () => {
     const userId = parseUserId();
@@ -30,6 +34,28 @@ export function useMyWorkChapters(refreshKey = 0) {
     setLoading(true);
     loadChapters().finally(() => setLoading(false));
   }, [loadChapters, refreshKey]);
+
+  // #273: on re-focus (not initial mount — that's covered by the effect
+  // above, and immediately post-login data is already fresh from the login
+  // sync), pull latest assignment/stage metadata in the background and
+  // re-read the cache. Uses getActiveUserId (not parseUserId) — the two can
+  // drift on shared/multi-account devices, and calling the API with a
+  // userId that doesn't match the live bearer token 403s (see #291).
+  useFocusEffect(
+    useCallback(() => {
+      if (!hasFocusedBefore.current) {
+        hasFocusedBefore.current = true;
+        return;
+      }
+
+      const activeUserId = getActiveUserId();
+      if (!activeUserId) return;
+
+      refreshChapterMetadataIfOnline(Number(activeUserId)).then(() => {
+        void loadChapters();
+      });
+    }, [loadChapters]),
+  );
 
   const refresh = useCallback(async () => {
     setRefreshing(true);

--- a/src/hooks/useProjectChapters.ts
+++ b/src/hooks/useProjectChapters.ts
@@ -1,7 +1,10 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { getProjectChapters } from '../db/queries';
 import { ProjectChapter } from '../types/db/types';
 import { parseUserId } from '../utils/parseUserId';
+import { getActiveUserId } from '../services/storage';
+import { refreshChapterMetadataIfOnline } from '../services/sync';
 import { logger } from '../utils/logger';
 
 const log = logger.create('useProjectChapters');
@@ -11,6 +14,7 @@ export function useProjectChapters(projectId: number) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<unknown>(null);
+  const hasFocusedBefore = useRef(false);
 
   const loadChapters = useCallback(async () => {
     try {
@@ -34,6 +38,28 @@ export function useProjectChapters(projectId: number) {
     setLoading(true);
     loadChapters();
   }, [loadChapters]);
+
+  // #273: on re-focus (not initial mount — that's covered by the effect
+  // above, and immediately post-login data is already fresh from the login
+  // sync), pull latest assignment/stage metadata in the background and
+  // re-read the cache. Uses getActiveUserId (not parseUserId) — the two can
+  // drift on shared/multi-account devices, and calling the API with a
+  // userId that doesn't match the live bearer token 403s (see #291).
+  useFocusEffect(
+    useCallback(() => {
+      if (!hasFocusedBefore.current) {
+        hasFocusedBefore.current = true;
+        return;
+      }
+
+      const activeUserId = getActiveUserId();
+      if (!activeUserId) return;
+
+      refreshChapterMetadataIfOnline(Number(activeUserId)).then(() => {
+        void loadChapters();
+      });
+    }, [loadChapters]),
+  );
 
   const refresh = useCallback(async () => {
     setRefreshing(true);

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from '../utils/logger';
 import { getDatabase } from '../db/db';
 import { ApiBook, ApiVerse } from '../types/api/types';
+import { getConnectivitySnapshot } from './connectivity';
 import { unwrapApiListResponse } from '../types/api/responses';
 import {
   setUserSync,
@@ -695,4 +696,32 @@ export async function syncAllData(isIncremental = false, email?: string) {
 export async function switchUser(userId: string): Promise<void> {
   log.info('Switching to user', { userId });
   emitSyncComplete();
+}
+
+const lastMetadataRefreshAt = new Map<number, number>();
+const METADATA_REFRESH_COOLDOWN_MS = 60_000;
+
+export async function refreshChapterMetadataIfOnline(
+  userId: number,
+): Promise<void> {
+  const last = lastMetadataRefreshAt.get(userId);
+  if (last && Date.now() - last < METADATA_REFRESH_COOLDOWN_MS) {
+    return;
+  }
+
+  const { isOnline } = await getConnectivitySnapshot();
+  if (!isOnline) return;
+
+  lastMetadataRefreshAt.set(userId, Date.now());
+
+  try {
+    const userIdStr = String(userId);
+    const cursor = getUserLastSyncedAt(userIdStr) || undefined;
+    await syncChapterAssignmentsForUser(userId, cursor);
+  } catch (error) {
+    log.warn('Chapter metadata refresh failed (non-blocking)', {
+      userId,
+      error: getErrorMessage(error),
+    });
+  }
 }


### PR DESCRIPTION
### TLDR

Adds a lightweight, non-blocking metadata refresh to My Work and View Project — on screen re-focus (not initial mount), the app quietly pulls latest chapter assignment/stage data in the background while showing cached data immediately, so ownership and stage changes made elsewhere show up without a full manual sync. Includes a per-user cooldown to prevent request storms from rapid tab-switching, discovered during testing.

### Reviewer checklist

- [x] GitHub issue linked in Details (`Refs #NNN` — do **not** use `Closes` / `Fixes` / `Resolves`)
- [x] How to verify steps completed or valid waiver noted below
- [ ] Acceptance criteria met, **or** unmet AC waived **in the issue** with linked follow-up (see `AGENTS.md`) — see waiver below
- [x] Scope limited to this issue — no adjacent tickets implemented/stubbed without approval
- [ ] Android device tested when required (native / mic / camera / filesystem / permissions) — do **not** check unless verified on a device

### Details

Refs #273

Chapter list screens previously only refreshed assignment/stage metadata on login or a full repair sync, so a chapter claimed or advanced elsewhere could show stale on My Work / View Project until the next full sync. This adds a targeted background pull, reusing the existing `syncChapterAssignmentsForUser` path rather than duplicating fetch logic.

**Type of change:**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Maintenance / refactor

#### Technical changes

- **`src/services/sync.ts`** — new `refreshChapterMetadataIfOnline(userId)`: gated by a per-user, in-memory 60s cooldown and an online check (`getConnectivitySnapshot`), calls existing `syncChapterAssignmentsForUser` without emitting sync-UI events (no spinner)
- **`src/hooks/useMyWorkChapters.ts`**, **`src/hooks/useProjectChapters.ts`** — added `useFocusEffect`; skips the first focus (covered by existing mount effect, and immediately post-login data is already fresh); uses `getActiveUserId()` rather than `parseUserId()` for the refresh call — see note below

#### Testing

Manual device testing only so far (see open items). `npm run format:check && npm run lint && npm run typecheck && npm test -- --ci` not yet re-run against final state.

### How to verify

1. Sign in, land on My Work (first tab) — confirm no extra network calls fire immediately (first-focus skip).
2. Switch to View Project and back to My Work a few times in quick succession — confirm only one background pull fires, not one per switch (cooldown).
3. While one device/account has a chapter assigned, reassign it (or its stage) from another session — return to My Work / View Project on the original device and confirm the row updates without a manual sync.
4. Airplane mode: switch tabs — confirm no network requests fire, cached data still renders.

**Expected:** Rows reflect current assignment/stage after a normal re-focus while online; nothing changes or errors while offline.

### Follow-ups

Nill